### PR TITLE
Refactor: Works Platform 필드 연관관계 설정

### DIFF
--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/dto/ExplorationWorksResponseDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/dto/ExplorationWorksResponseDto.java
@@ -2,6 +2,7 @@ package com.storix.domain.domains.preference.dto;
 
 import com.storix.domain.domains.hashtag.domain.Hashtag;
 import com.storix.domain.domains.works.domain.Works;
+import com.storix.domain.domains.works.domain.WorksPlatform;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +19,7 @@ public class ExplorationWorksResponseDto {
     private String thumbnailUrl;
     private String artistName;
 
-    private String platform;
+    private List<String> platforms;
     private String genre;
     private String description;
     private List<String> hashtags;
@@ -29,7 +30,9 @@ public class ExplorationWorksResponseDto {
                 .worksName(works.getWorksName())
                 .thumbnailUrl(works.getThumbnailUrl())
                 .artistName(works.getArtistName())
-                .platform(works.getPlatform() != null ? works.getPlatform().toString() : null)
+                .platforms(works.getPlatforms() != null ? works.getPlatforms().stream()
+                        .map(wp -> wp.getPlatform().getDbValue())
+                        .toList() : List.of())
                 .genre(works.getGenre() != null ? works.getGenre().getDbValue() : null)
                 .description(works.getDescription())
                 .hashtags(works.getHashtags() != null ? works.getHashtags().stream()

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/domain/Works.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/domain/Works.java
@@ -27,9 +27,8 @@ public class Works {
     @Column(name = "user_id")
     private Long userId = null;
 
-    // 작품 플랫폼
-    @Column(nullable = false)
-    private Platform platform;
+    @OneToMany(mappedBy = "works", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<WorksPlatform> platforms = new HashSet<>();
 
     // 작품명
     @Column(name = "works_name", nullable = false)
@@ -86,13 +85,12 @@ public class Works {
     private Boolean isOnboarding;
 
     @Builder
-    private Works(Platform platform, String worksName,
+    private Works(String worksName,
                   String artistName, String author, String illustrator,
                   String originalAuthor, AgeClassification ageClassification,
                   String description, Genre genre, String thumbnailUrl,
                   WorksType worksType) {
 
-        this.platform = platform;
         this.worksName = worksName;
         this.artistName = artistName;
         this.author = author;
@@ -105,13 +103,19 @@ public class Works {
         this.worksType = worksType;
         this.reviewsCount = 0;
         this.avgRating = 0.0;
+        this.platforms = new HashSet<>();
         this.hashtags = new HashSet<>();
     }
 
-    /**
-     * 해시태그 조회 (read-only)
-     * */
+    public void addPlatform(Platform platform) {
+        this.platforms.add(new WorksPlatform(this, platform));
+    }
+
     public Set<Hashtag> getHashtags() {
         return Set.copyOf(hashtags);
+    }
+
+    public Set<WorksPlatform> getPlatforms() {
+        return Set.copyOf(platforms);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/domain/WorksPlatform.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/domain/WorksPlatform.java
@@ -1,0 +1,30 @@
+package com.storix.domain.domains.works.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "works_platform",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"works_id", "platform"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WorksPlatform {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "works_id", nullable = false)
+    private Works works;
+
+    @Column(nullable = false)
+    private Platform platform;
+
+    public WorksPlatform(Works works, Platform platform) {
+        this.works = works;
+        this.platform = platform;
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/dto/WorksDetailResponseDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/dto/WorksDetailResponseDto.java
@@ -2,6 +2,8 @@ package com.storix.domain.domains.works.dto;
 
 import com.storix.domain.domains.hashtag.domain.Hashtag;
 import com.storix.domain.domains.works.domain.Works;
+import com.storix.domain.domains.works.domain.WorksPlatform;
+import com.storix.domain.domains.works.domain.Platform;
 import lombok.Builder;
 
 import java.math.BigDecimal;
@@ -18,7 +20,7 @@ public record WorksDetailResponseDto(
         String illustrator,
         String originalAuthor,
         String genre,
-        String platform,
+        List<String> platforms,
         String ageClassification,
         Double avgRating,
         Long reviewCount,
@@ -35,7 +37,9 @@ public record WorksDetailResponseDto(
                 .illustrator(works.getIllustrator())
                 .originalAuthor(works.getOriginalAuthor())
                 .genre(works.getGenre().getDbValue())
-                .platform(works.getPlatform().getDbValue())
+                .platforms(works.getPlatforms().stream()
+                        .map(wp -> wp.getPlatform().getDbValue())
+                        .toList())
                 .ageClassification(works.getAgeClassification().getDbValue())
                 .avgRating(works.getAvgRating() != null ? roundAvgRating(works.getAvgRating()) : 0.0)
                 .reviewCount(reviewCount)


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
[변경 전]
Works Platform 필드: 단일 필드
-> 동일 작품이 여러 플랫폼에 등록되어 있는 경우, 크롤링 작업이 플랫폼 마다 분기별로 실행되었을 때 추가할 방법이 없었습니다.

[변경 후]
WorksPlatform 엔티티를 추가하고,
Works : WorksPlatform = 1 : N 연관관계를 맺었습니다.
또한 작품 플랫폼 정보를 조회하는 관련 로직에서 List 형으로 받을 수 있도록 변경하였습니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #14 

## 🖇️ 기타