### PR TITLE
Feat: 작품홈 리뷰 정렬 및 응답 필드 개선

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/review/controller/ReviewController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/review/controller/ReviewController.java
@@ -50,7 +50,7 @@ public class ReviewController {
     public ResponseEntity<CustomResponse<Slice<SliceReviewInfoWithProfile>>> getOtherReview(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
             @PathVariable @NotNull Long worksId,
-            @RequestParam(defaultValue = "LATEST") ReviewSortType sort,
+            @RequestParam(defaultValue = "TRENDING") ReviewSortType sort,
             @RequestParam(defaultValue = "0") @Min(0) int page
     ) {
         Pageable pageable = PageRequest.of(page, 10, sort.getSortValue());

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/dto/SliceReviewInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/dto/SliceReviewInfo.java
@@ -8,6 +8,7 @@ public record SliceReviewInfo(
         boolean isSpoiler,
         String spoilerScript,
         String content,
-        Rating rating
+        Rating rating,
+        int likeCount
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/repository/ReviewRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/repository/ReviewRepository.java
@@ -39,13 +39,13 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // 작품 상세탭
     long countByWorksId(Long worksId);
 
-    @Query("SELECT new com.storix.domain.domains.plus.dto.SliceReviewInfo(r.libraryUserId, r.id, r.isSpoiler, r.spoilerScript, r.content, r.rating) " +
+    @Query("SELECT new com.storix.domain.domains.plus.dto.SliceReviewInfo(r.libraryUserId, r.id, r.isSpoiler, r.spoilerScript, r.content, r.rating, r.likeCount) " +
             "FROM Review r " +
             "WHERE r.libraryUserId = :userId AND r.worksId = :worksId")
     SliceReviewInfo findMySliceReviewInfo(@Param("userId") Long userId,
                                           @Param("worksId") Long worksId);
 
-    @Query("SELECT new com.storix.domain.domains.plus.dto.SliceReviewInfo(r.libraryUserId, r.id, r.isSpoiler, r.spoilerScript, r.content, r.rating) " +
+    @Query("SELECT new com.storix.domain.domains.plus.dto.SliceReviewInfo(r.libraryUserId, r.id, r.isSpoiler, r.spoilerScript, r.content, r.rating, r.likeCount) " +
             "FROM Review r " +
             "WHERE (:userId IS NULL OR r.libraryUserId <> :userId) AND r.worksId = :worksId")
     Slice<SliceReviewInfo> findOtherSliceReviewInfo(@Param("userId") Long userId,

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/review/domain/ReviewSortType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/review/domain/ReviewSortType.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Sort;
 @RequiredArgsConstructor
 public enum ReviewSortType {
 
-    LATEST("최신순", Sort.by(Sort.Direction.DESC, "id"));
+    TRENDING("좋아요순", Sort.by(Sort.Direction.DESC,"likeCount", "id"));
 
     private final String description;
     private final Sort sortValue;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/review/dto/StandardSliceReviewInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/review/dto/StandardSliceReviewInfo.java
@@ -10,7 +10,8 @@ public record StandardSliceReviewInfo(
         boolean isSpoiler,
         String spoilerScript,
         String content,
-        Rating rating
+        Rating rating,
+        int likeCount
 ) {
     public static StandardSliceReviewInfo from(SliceReviewInfo review) {
         return StandardSliceReviewInfo.builder()
@@ -19,6 +20,7 @@ public record StandardSliceReviewInfo(
                 .spoilerScript(review.spoilerScript())
                 .content(review.content())
                 .rating(review.rating())
+                .likeCount(review.likeCount())
                 .build();
     }
 }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 작품홈 리뷰 정렬 및 반환 필드 추가
- 리뷰 기본 정렬을 최신순(LATEST) → 좋아요순(TRENDING)으로 변경 (likeCount DESC, id DESC)
- SliceReviewInfo, StandardSliceReviewInfo에 rating, likeCount 응답 필드 추가
- ReviewRepository 쿼리에 r.rating, r.likeCount SELECT 추가

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #28

## 🖇️ 기타