### PR TITLE
Feat: Apple 소셜 로그인 OAuth 2.0 구현

### DIFF
--- a/STORIX-Api/build.gradle
+++ b/STORIX-Api/build.gradle
@@ -9,6 +9,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation "software.amazon.awssdk:s3"
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.7.0'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -30,7 +30,6 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthUseCase authUseCase;
-    private final LoginUseCase loginUseCase;
     private final LogoutUseCase logoutUseCase;
     private final OAuthLoginUseCase oauthLoginUseCase;
     private final AuthorizationUseCase authorizationUseCase;
@@ -54,6 +53,15 @@ public class AuthController {
     ) {
         OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forNaver(code, state);
         return oauthLoginUseCase.readerOAuthLogin(req, OAuthProvider.NAVER);
+    }
+
+    @Operation(summary = "애플 로그인", description = "애플로 로그인 하는 api 입니다.  \n회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
+    @GetMapping("/oauth/apple/login")
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> appleLogin(
+            @RequestParam("code") String code
+    ) {
+        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forApple(code);
+        return oauthLoginUseCase.readerOAuthLogin(req, OAuthProvider.APPLE);
     }
 
     @Operation(summary = "독자 계정 회원가입", description = "유저 정보를 최종적으로 등록하는 api 입니다.  \n온보딩 토큰을 보내주세요.")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/AppleClientSecretHelper.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/AppleClientSecretHelper.java
@@ -1,0 +1,56 @@
+package com.storix.api.domain.user.helper;
+
+import com.storix.common.property.OAuthProperties;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import com.storix.domain.domains.user.exception.oauth.ApplePrivateKeyException;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AppleClientSecretHelper {
+
+    private final OAuthProperties oauthProperties;
+
+    // Apple client_secret JWT 생성 (ES256 서명)
+    public String generateClientSecret() {
+        var apple = oauthProperties.getApple();
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+                .setHeaderParam("kid", apple.getKeyId())
+                .setHeaderParam("alg", "ES256")
+                .setIssuer(apple.getTeamId())
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plusSeconds(15 * 60))) // 15분
+                .setAudience("https://appleid.apple.com")
+                .setSubject(apple.getClientId())
+                .signWith(getPrivateKey(apple.getPrivateKey()), SignatureAlgorithm.ES256)
+                .compact();
+    }
+
+    private PrivateKey getPrivateKey(String privateKeyString) {
+        try {
+            String key = privateKeyString
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replaceAll("\\s", "");
+
+            byte[] keyBytes = Base64.getDecoder().decode(key);
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return keyFactory.generatePrivate(keySpec);
+        } catch (Exception e) {
+            throw ApplePrivateKeyException.EXCEPTION;
+        }
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/OAuthHelper.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/OAuthHelper.java
@@ -2,6 +2,7 @@ package com.storix.api.domain.user.helper;
 
 import com.storix.domain.domains.user.adaptor.JwtOIDCProvider;
 import com.storix.common.property.OAuthProperties;
+import com.storix.infrastructure.external.oauth.client.AppleOAuthClient;
 import com.storix.infrastructure.external.oauth.client.KakaoInfoClient;
 import com.storix.infrastructure.external.oauth.client.KakaoOAuthClient;
 import com.storix.infrastructure.external.oauth.client.NaverInfoClient;
@@ -33,6 +34,10 @@ public class OAuthHelper {
     // 네이버
     private final NaverOAuthClient naverOauthClient;
     private final NaverInfoClient naverInfoClient;
+
+    // 애플
+    private final AppleOAuthClient appleOauthClient;
+    private final AppleClientSecretHelper appleClientSecretHelper;
 
     // 카카오: 인가 코드로 토큰 발급 요청 -> accessToken, idToken
     public KakaoTokenResponse getKakaoOAuthToken(String code, String redirectUri) {
@@ -85,12 +90,24 @@ public class OAuthHelper {
         // 네이버는 토큰 캐싱 및 주기적 갱신 필요
     }
 
+    // 애플: 인가 코드로 토큰 발급 요청 -> accessToken, idToken (네이티브 전용)
+    public AppleTokenResponse getAppleOAuthToken(String code) {
+        var apple = oauthProperties.getApple();
+        String clientSecret = appleClientSecretHelper.generateClientSecret();
+        return appleOauthClient.appleAuth(
+                "authorization_code",
+                apple.getClientId(),
+                clientSecret,
+                code
+        );
+    }
 
     // OIDC 스펙: OIDC 공개키 목록 조회
     public OIDCPublicKeysResponse getOIDCPublicKeys(OAuthProvider provider) {
         return switch (provider) {
             case KAKAO -> kakaoOauthClient.getKakaoOIDCOpenKeys();
             case NAVER -> naverOauthClient.getNaverOIDCOpenKeys();
+            case APPLE -> appleOauthClient.getAppleOIDCOpenKeys();
             case SLACK -> throw UnsupportedOAuthProviderException.EXCEPTION;
         };
     }
@@ -101,6 +118,7 @@ public class OAuthHelper {
         switch (provider) {
             case KAKAO -> cache = oidcCacheManager.getCache("KakaoOIDC");
             case NAVER -> cache = oidcCacheManager.getCache("NaverOIDC");
+            case APPLE -> cache = oidcCacheManager.getCache("AppleOIDC");
             default -> cache = null;
         }
 
@@ -117,6 +135,10 @@ public class OAuthHelper {
              case NAVER ->  {
                 var naver = oauthProperties.getNaver();
                 return new OIDCConfigDTO(naver.getBaseUri(), naver.getClientId());
+             }
+             case APPLE -> {
+                var apple = oauthProperties.getApple();
+                return new OIDCConfigDTO(apple.getBaseUri(), apple.getClientId());
              }
             default -> {
                 return null;
@@ -150,6 +172,7 @@ public class OAuthHelper {
                     .oid(idToken) // 네이버인 경우, 일시적으로 idToken 값에 oid 값 반환
                     .build();
         }
+        // KAKAO, APPLE: OIDC idToken에서 sub 클레임 추출
         OIDCDecodePayload oidcDecodePayload = getOIDCDecodePayload(idToken, provider);
         return OAuthInfo.builder()
                 .provider(provider)

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -45,6 +45,11 @@ public class AuthUseCase {
                 if (naverUser.id() == null) throw FeignClientServerErrorException.EXCEPTION;
                 yield authService.validNaverSignup(naverUser.id());
             }
+            case APPLE -> {
+                AppleTokenResponse appleToken = oauthHelper.getAppleOAuthToken(req.authCode());
+                OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(appleToken.idToken(), OAuthProvider.APPLE);
+                yield authService.validAppleSignup(oauthInfo.getOid(), appleToken.idToken());
+            }
             case SLACK -> throw UnsupportedOAuthProviderException.EXCEPTION;
         };
     }

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -79,6 +79,7 @@ public enum ErrorCode {
     AOE_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "APPLE_AOE_INVALID_REQUEST", "Apple 요청이 잘못되었습니다."),
     AOE_INVALID_CLIENT(HttpStatus.BAD_REQUEST, "APPLE_AOE_INVALID_CLIENT", "Apple 클라이언트 인증에 실패했습니다."),
     AOE_INVALID_GRANT(HttpStatus.BAD_REQUEST, "APPLE_AOE_INVALID_GRANT", "Apple 인가 코드가 유효하지 않거나 만료되었습니다."),
+    AOE_PRIVATE_KEY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE_AOE_PRIVATE_KEY_ERROR", "Apple private key 파싱에 실패했습니다."),
 
     // X OAuth error
     XOE_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "X_XOE_INVALID_REQUEST", "X 요청이 잘못되었습니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/property/AppleProperties.java
+++ b/STORIX-Common/src/main/java/com/storix/common/property/AppleProperties.java
@@ -1,0 +1,22 @@
+package com.storix.common.property;
+
+import lombok.Getter;
+
+@Getter
+public class AppleProperties {
+
+    private final String baseUri;
+    private final String clientId;
+    private final String teamId;
+    private final String keyId;
+    private final String privateKey;
+
+    public AppleProperties(String baseUri, String clientId, String teamId, String keyId, String privateKey) {
+        this.baseUri = baseUri;
+        this.clientId = clientId;
+        this.teamId = teamId;
+        this.keyId = keyId;
+        this.privateKey = privateKey;
+    }
+
+}

--- a/STORIX-Common/src/main/java/com/storix/common/property/OAuthProperties.java
+++ b/STORIX-Common/src/main/java/com/storix/common/property/OAuthProperties.java
@@ -9,10 +9,12 @@ public class OAuthProperties {
 
     private final KakaoProperties kakao;
     private final NaverProperties naver;
+    private final AppleProperties apple;
 
-    public OAuthProperties(KakaoProperties kakao, NaverProperties naver) {
+    public OAuthProperties(KakaoProperties kakao, NaverProperties naver, AppleProperties apple) {
         this.kakao = kakao;
         this.naver = naver;
+        this.apple = apple;
     }
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OAuthProvider.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OAuthProvider.java
@@ -1,5 +1,5 @@
 package com.storix.domain.domains.user.domain;
 
 public enum OAuthProvider {
-    KAKAO, NAVER, SLACK
+    KAKAO, NAVER, APPLE, SLACK
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/AppleTokenResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/AppleTokenResponse.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AppleTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("id_token") String idToken,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("expires_in") Long expiresIn
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OAuthAuthorizationRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OAuthAuthorizationRequest.java
@@ -16,4 +16,8 @@ public record OAuthAuthorizationRequest(
     ) {
         return new OAuthAuthorizationRequest(authCode, null, state);
     }
+
+    public static OAuthAuthorizationRequest forApple(String authCode) {
+        return new OAuthAuthorizationRequest(authCode, null, null);
+    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/exception/oauth/ApplePrivateKeyException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/exception/oauth/ApplePrivateKeyException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.user.exception.oauth;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class ApplePrivateKeyException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new ApplePrivateKeyException();
+
+    private ApplePrivateKeyException() { super(ErrorCode.AOE_PRIVATE_KEY_ERROR); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -42,6 +42,13 @@ public class AuthService {
         return new ValidAuthDTO(isRegistered, naverUserId);
     }
 
+    // - 애플
+    @Transactional(readOnly = true)
+    public ValidAuthDTO validAppleSignup(String appleUserId, String idToken) {
+        boolean isRegistered = userAdaptor.isUserPresentWithProviderAndOid(OAuthProvider.APPLE, appleUserId);
+        return new ValidAuthDTO(isRegistered, idToken);
+    }
+
     // 독자 회원 가입 (소셜 로그인)
     @Transactional
     public AuthUserDetails signUpReaderUser(ReaderSignupRequest cmd, String jti) {

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/FeignClientConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/FeignClientConfig.java
@@ -1,5 +1,6 @@
 package com.storix.infrastructure.config;
 
+import com.storix.infrastructure.external.oauth.client.AppleOAuthClient;
 import com.storix.infrastructure.external.oauth.client.KakaoInfoClient;
 import com.storix.infrastructure.external.oauth.client.KakaoOAuthClient;
 import com.storix.infrastructure.external.oauth.client.NaverInfoClient;
@@ -15,7 +16,8 @@ import org.springframework.context.annotation.Configuration;
         KakaoInfoClient.class,
         KakaoOAuthClient.class,
         NaverInfoClient.class,
-        NaverOAuthClient.class
+        NaverOAuthClient.class,
+        AppleOAuthClient.class
 })
 public class FeignClientConfig {
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/client/AppleOAuthClient.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/client/AppleOAuthClient.java
@@ -1,0 +1,32 @@
+package com.storix.infrastructure.external.oauth.client;
+
+import com.storix.domain.domains.user.dto.AppleTokenResponse;
+import com.storix.domain.domains.user.dto.OIDCPublicKeysResponse;
+import com.storix.infrastructure.external.oauth.config.AppleOauthConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "AppleOAuthClient",
+        url = "https://appleid.apple.com",
+        configuration = AppleOauthConfig.class
+)
+public interface AppleOAuthClient {
+
+    // 인가 코드로 토큰 발급 요청 (네이티브: redirect_uri 불필요)
+    @PostMapping("/auth/token")
+    AppleTokenResponse appleAuth(
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("code") String code
+    );
+
+    // OIDC 공개키 목록 조회 (id_token 서명 검증용)
+    @Cacheable(cacheNames = "AppleOIDC", cacheManager = "oidcCacheManager")
+    @GetMapping("/auth/keys")
+    OIDCPublicKeysResponse getAppleOIDCOpenKeys();
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/config/AppleOauthConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/config/AppleOauthConfig.java
@@ -1,0 +1,15 @@
+package com.storix.infrastructure.external.oauth.config;
+
+import com.storix.infrastructure.external.oauth.exception.decoder.AppleOauthErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppleOauthConfig {
+
+    @Bean
+    public ErrorDecoder appleOauthErrorDecoder() {
+        return new AppleOauthErrorDecoder();
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/exception/decoder/AppleOauthErrorDecoder.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/exception/decoder/AppleOauthErrorDecoder.java
@@ -1,0 +1,21 @@
+package com.storix.infrastructure.external.oauth.exception.decoder;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+import com.storix.infrastructure.external.oauth.exception.dto.AppleOauthErrorResponse;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class AppleOauthErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        AppleOauthErrorResponse body = AppleOauthErrorResponse.from(response);
+
+        return switch (body.error()) {
+            case "invalid_client" -> new STORIXCodeException(ErrorCode.AOE_INVALID_CLIENT);
+            case "invalid_grant" -> new STORIXCodeException(ErrorCode.AOE_INVALID_GRANT);
+            default -> new STORIXCodeException(ErrorCode.AOE_INVALID_REQUEST);
+        };
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/exception/dto/AppleOauthErrorResponse.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/exception/dto/AppleOauthErrorResponse.java
@@ -1,0 +1,22 @@
+package com.storix.infrastructure.external.oauth.exception.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.storix.domain.domains.user.exception.oauth.UnHandleException;
+
+import java.io.IOException;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AppleOauthErrorResponse(
+        String error,
+        String errorDescription
+) {
+    public static AppleOauthErrorResponse from(feign.Response response) {
+        try (var is = response.body().asInputStream()) {
+            return new ObjectMapper().readValue(is, AppleOauthErrorResponse.class);
+        } catch (IOException e) {
+            throw UnHandleException.EXCEPTION;
+        }
+    }
+}


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용

### 1. Apple OAuth 2.0 소셜 로그인 구현 (Capacitor 네이티브 전용)

**[Apple 로그인 도입 사유]**
App Store 심사 가이드라인(4.8)에 따라, 앱에서 제3자 소셜 로그인(카카오, 네이버)을 제공하는 경우 Sign in with Apple도 반드시 제공해야 합니다. Capacitor 웹뷰 앱으로 배포 예정이므로, iOS 네이티브 Sign in with Apple 플로우에 맞춰 구현하였습니다.

**[Apple OAuth 특이점]**
Apple은 카카오/네이버와 달리 `client_secret`이 정적 문자열이 아닌, 서버에서 ES256으로 서명한 JWT를 매번 생성해야 합니다. 이를 위해 `AppleClientSecretHelper`를 도입하였으며, Team ID, Key ID, Private Key(.p8)를 환경변수로 관리합니다.

**[구현 내역]**
- `AppleClientSecretHelper` — ES256 JWT `client_secret` 동적 생성 (만료: 15분)
- `AppleOAuthClient` — Feign 클라이언트 (Apple 토큰 교환 `POST /auth/token` + JWKS 공개키 조회 `GET /auth/keys`)
- `AppleTokenResponse` — Apple 토큰 응답 DTO (`access_token`, `id_token`)
- `AppleProperties` — Apple OAuth 설정값 (`baseUri`, `clientId`, `teamId`, `keyId`, `privateKey`)

### 2. 기존 OAuth 인증 플로우에 APPLE 케이스 통합

**[통합 방식]**
기존 카카오/네이버 로그인과 동일한 `OAuthLoginUseCase` → `AuthUseCase` → `AuthService` 플로우를 따르도록 구성하였습니다. Apple은 OIDC를 지원하므로, 카카오와 동일하게 `id_token`의 `sub` 클레임에서 유저 고유 ID를 추출합니다.

- `OAuthProvider` — `APPLE` enum 추가
- `OAuthHelper` — Apple 토큰 발급, OIDC 공개키/캐시/설정 조회에 APPLE 케이스 추가
- `AuthUseCase.checkAvailableRegister()` — APPLE 케이스 추가
- `AuthService.validAppleSignup()` — Apple 유저 등록 여부 검증 메서드
- `OAuthAuthorizationRequest.forApple()` — 팩토리 메서드 (네이티브 전용이므로 `redirectUri` 없음)
- `FeignClientConfig` — `AppleOAuthClient` 빈 등록

### 3. Apple 전용 에러 핸들링

- `AppleOauthErrorDecoder` — Apple API 에러 응답을 `invalid_client`, `invalid_grant` 등으로 분기 처리
- `AppleOauthErrorResponse` — Apple 에러 응답 DTO
- `ApplePrivateKeyException` — Private Key 파싱 실패 시 커스텀 예외 (`AOE_PRIVATE_KEY_ERROR`)

### 4. API 엔드포인트

```
GET /api/v1/auth/oauth/apple/login?code={authorization_code}
```
- SecurityConfig에서 `/api/v1/auth/oauth/**`가 이미 `permitAll()`이므로 별도 수정 불필요
- 기존 유저: `isRegistered=true` + `accessToken` 반환
- 신규 유저: `isRegistered=false` + `onboardingToken` 반환 → 회원가입 플로우


## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [ ] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #9 

## 🖇️ 기타
- 환경변수 (배포 시 추가 필요)
```
APPLE_AUTH_CLIENT, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY
```

- 기존 카카오/네이버 OAuth 구현 패턴과 동일하게 작성
- `build.gradle (Api)`에 jjwt 의존성을 추가 (Domain/Infrastructure는 `implementation` 스코프라 Api 모듈로 전이되지 않아 별도 추가)