### PR TITLE
Refactor: 피드 답댓글 원뎁스 제한 및 답댓글 조회 변경

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/feed/controller/FeedController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/feed/controller/FeedController.java
@@ -121,20 +121,7 @@ public class FeedController {
                 .body(feedReactionUseCase.writeReaderBoardReply(authUserDetails.getUserId(), boardId, req));
     }
 
-    @Operation(summary = "[관심 작품] 답댓글 조회", description = "댓글의 답댓글 목록을 조회하는 api 입니다. '답글 N개 보기' UI에서 호출합니다.")
-    @GetMapping("/reader/board/{boardId}/reply/{replyId}/children")
-    public ResponseEntity<CustomResponse<Slice<ReaderBoardReplyInfoWithProfile>>> getChildReplies(
-            @AuthenticationPrincipal AuthUserDetails authUserDetails,
-            @PathVariable @NotNull Long boardId,
-            @PathVariable @NotNull Long replyId,
-            @RequestParam(defaultValue = "0") @Min(0) int page
-    ) {
-        Pageable pageable = PageRequest.of(page, 10);
-        return ResponseEntity.ok()
-                .body(feedUseCase.getChildReplies(authUserDetails.getUserId(), replyId, pageable));
-    }
-
-    @Operation(summary = "[관심 작품] 답댓글 작성", description = "댓글에 대한 답댓글을 작성하는 api 입니다. depth 제한 없이 답댓글에 답댓글 작성이 가능합니다.")
+    @Operation(summary = "[관심 작품] 답댓글 작성", description = "댓글에 대한 답댓글을 작성하는 api 입니다. depth 1까지만 허용됩니다 (답댓글에 답댓글 불가).")
     @PostMapping("/reader/board/{boardId}/reply/{replyId}/reply")
     public ResponseEntity<CustomResponse<ReaderBoardReplyResponse>> writeReaderBoardChildReply(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,

--- a/STORIX-Api/src/main/java/com/storix/api/domain/feed/usecase/FeedUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/feed/usecase/FeedUseCase.java
@@ -46,11 +46,5 @@ public class FeedUseCase {
         return CustomResponse.onSuccess(SuccessCode.FEED_READER_BOARD_LOAD_SUCCESS, result);
     }
 
-    // 답댓글 조회
-    public CustomResponse<Slice<ReaderBoardReplyInfoWithProfile>> getChildReplies(Long userId, Long parentReplyId, Pageable pageable) {
-
-        Slice<ReaderBoardReplyInfoWithProfile> result = feedService.findChildReplies(userId, parentReplyId, pageable);
-        return CustomResponse.onSuccess(SuccessCode.FEED_READER_BOARD_CHILD_REPLY_LOAD_SUCCESS, result);
-    }
 
 }

--- a/STORIX-Api/src/test/java/com/storix/api/domain/feed/controller/FeedReplyE2ETest.java
+++ b/STORIX-Api/src/test/java/com/storix/api/domain/feed/controller/FeedReplyE2ETest.java
@@ -6,8 +6,11 @@ import com.storix.api.domain.feed.controller.dto.ReaderBoardReplyRequest;
 import com.storix.api.domain.feed.usecase.FeedKebabUseCase;
 import com.storix.api.domain.feed.usecase.FeedReactionUseCase;
 import com.storix.api.domain.feed.usecase.FeedUseCase;
+import com.storix.common.code.ErrorCode;
 import com.storix.common.code.SuccessCode;
+import com.storix.common.exception.STORIXCodeException;
 import com.storix.common.payload.CustomResponse;
+import com.storix.common.payload.ErrorResponse;
 import com.storix.domain.domains.feed.dto.LikeToggleResponse;
 import com.storix.domain.domains.feed.dto.ReaderBoardReplyInfoWithProfile;
 import com.storix.domain.domains.feed.dto.ReaderBoardReplyResponse;
@@ -22,15 +25,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -68,6 +66,7 @@ class FeedReplyE2ETest {
                         new PageableHandlerMethodArgumentResolver(),
                         new AuthUserDetailsArgumentResolver()
                 )
+                .setControllerAdvice(new TestExceptionHandler())
                 .build();
     }
 
@@ -103,28 +102,18 @@ class FeedReplyE2ETest {
         }
 
         @Test
-        @DisplayName("성공: 답댓글에 답댓글을 작성한다 (depth 제한 없음)")
-        void writeNestedChildReply_success() throws Exception {
+        @DisplayName("실패: 답댓글에 답댓글을 작성하면 에러가 발생한다 (depth 1 제한)")
+        void writeNestedChildReply_depthExceeded_fail() throws Exception {
             // given
-            Long nestedReplyId = 400L;
-            StandardReplyInfo replyInfo = new StandardReplyInfo(
-                    nestedReplyId, "대댓글의 대댓글", 0, 2, 0, CHILD_REPLY_ID, false
-            );
-            ReaderBoardReplyResponse response = new ReaderBoardReplyResponse(null, replyInfo);
-            CustomResponse<ReaderBoardReplyResponse> customResponse =
-                    CustomResponse.onSuccess(SuccessCode.FEED_READER_BOARD_REPLY_UPLOAD_SUCCESS, response);
-
             given(feedReactionUseCase.writeReaderBoardChildReply(eq(USER_ID), eq(BOARD_ID), eq(CHILD_REPLY_ID), any()))
-                    .willReturn(customResponse);
+                    .willThrow(new com.storix.common.exception.STORIXCodeException(
+                            com.storix.common.code.ErrorCode.REPLY_DEPTH_EXCEEDED));
 
             // when & then
             mockMvc.perform(post("/api/v1/feed/reader/board/{boardId}/reply/{replyId}/reply", BOARD_ID, CHILD_REPLY_ID)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(new ReaderBoardReplyRequest("대댓글의 대댓글"))))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.isSuccess").value(true))
-                    .andExpect(jsonPath("$.result.content.depth").value(2))
-                    .andExpect(jsonPath("$.result.content.parentReplyId").value(CHILD_REPLY_ID));
+                    .andExpect(status().isBadRequest());
         }
 
         @Test
@@ -144,33 +133,6 @@ class FeedReplyE2ETest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(new ReaderBoardReplyRequest(longComment))))
                     .andExpect(status().isBadRequest());
-        }
-    }
-
-    // ===== 답댓글 조회 =====
-
-    @Nested
-    @DisplayName("답댓글 조회 API")
-    class GetChildReplies {
-
-        @Test
-        @DisplayName("성공: 원댓글의 답댓글 목록을 조회한다")
-        void getChildReplies_success() throws Exception {
-            // given
-            Slice<ReaderBoardReplyInfoWithProfile> emptySlice =
-                    new SliceImpl<>(Collections.emptyList(), PageRequest.of(0, 10), false);
-            CustomResponse<Slice<ReaderBoardReplyInfoWithProfile>> customResponse =
-                    CustomResponse.onSuccess(SuccessCode.FEED_READER_BOARD_CHILD_REPLY_LOAD_SUCCESS, emptySlice);
-
-            given(feedUseCase.getChildReplies(eq(USER_ID), eq(REPLY_ID), any()))
-                    .willReturn(customResponse);
-
-            // when & then
-            mockMvc.perform(get("/api/v1/feed/reader/board/{boardId}/reply/{replyId}/children", BOARD_ID, REPLY_ID)
-                            .param("page", "0"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.isSuccess").value(true))
-                    .andExpect(jsonPath("$.result.content").isArray());
         }
     }
 
@@ -276,6 +238,19 @@ class FeedReplyE2ETest {
                             .content(objectMapper.writeValueAsString(new FeedReportRequest(99L))))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.isSuccess").value(true));
+        }
+    }
+
+    /**
+     * STORIXCodeException을 처리하는 테스트용 예외 핸들러
+     */
+    @org.springframework.web.bind.annotation.RestControllerAdvice
+    static class TestExceptionHandler {
+
+        @org.springframework.web.bind.annotation.ExceptionHandler(STORIXCodeException.class)
+        public org.springframework.http.ResponseEntity<ErrorResponse> handleSTORIXCodeException(STORIXCodeException ex) {
+            ErrorCode errorCode = ex.getErrorCode();
+            return org.springframework.http.ResponseEntity.status(errorCode.getHttpStatus()).body(new ErrorResponse(errorCode));
         }
     }
 

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -144,6 +144,7 @@ public enum ErrorCode {
     DUPLICATE_FEED_USER_REPORT(HttpStatus.BAD_REQUEST, "FEED_ERROR_001", "이미 신고가 완료된 게시물입니다."),
     DUPLICATE_FEED_REPLY_USER_REPORT(HttpStatus.BAD_REQUEST, "FEED_ERROR_002", "이미 신고가 완료된 댓글입니다."),
     BOARD_REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "REPLY_ERROR_001", "해당 게시글에 대한 댓글 정보를 찾을 수 없습니다."),
+    REPLY_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "REPLY_ERROR_002", "답댓글에는 답댓글을 작성할 수 없습니다."),
     SPOILER_SCRIPT_REQUIRED(HttpStatus.BAD_REQUEST, "SPOILER_ERROR_001", "스포일러 설정 시 스포일러 문구를 입력해주세요."),
 
     // Preference error

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/dto/ReaderBoardReplyInfoWithProfile.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/dto/ReaderBoardReplyInfoWithProfile.java
@@ -1,12 +1,23 @@
 package com.storix.domain.domains.feed.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.storix.domain.domains.user.dto.StandardProfileInfo;
+
+import java.util.List;
 
 public record ReaderBoardReplyInfoWithProfile(
         StandardProfileInfo profile,
-        StandardReplyInfoWithLike reply
+        StandardReplyInfoWithLike reply,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        List<ReaderBoardReplyInfoWithProfile> childReplies
 ) {
+    // 답댓글용 (childReplies 필드 자체를 제외)
     public static ReaderBoardReplyInfoWithProfile of(StandardProfileInfo profile, StandardReplyInfoWithLike reply) {
-        return new ReaderBoardReplyInfoWithProfile(profile, reply);
+        return new ReaderBoardReplyInfoWithProfile(profile, reply, null);
+    }
+
+    // 최상위 댓글용 (답댓글 리스트 포함)
+    public static ReaderBoardReplyInfoWithProfile of(StandardProfileInfo profile, StandardReplyInfoWithLike reply, List<ReaderBoardReplyInfoWithProfile> childReplies) {
+        return new ReaderBoardReplyInfoWithProfile(profile, reply, childReplies);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/dto/StandardReplyInfoWithLike.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/dto/StandardReplyInfoWithLike.java
@@ -1,5 +1,7 @@
 package com.storix.domain.domains.feed.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 public record StandardReplyInfoWithLike(
         Long replyId,
         Long userId,
@@ -9,7 +11,8 @@ public record StandardReplyInfoWithLike(
         int likeCount,
         boolean isLiked,
         int depth,
-        int childReplyCount,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Integer childReplyCount,
         Long parentReplyId,
         boolean deleted
 ) {
@@ -23,7 +26,7 @@ public record StandardReplyInfoWithLike(
                 reply.likeCount(),
                 isLiked,
                 reply.depth(),
-                reply.childReplyCount(),
+                reply.depth() >= 1 ? null : reply.childReplyCount(),
                 reply.parentReplyId(),
                 reply.deleted()
         );

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/exception/ReplyDepthExceededException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/exception/ReplyDepthExceededException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.feed.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class ReplyDepthExceededException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new ReplyDepthExceededException();
+
+    private ReplyDepthExceededException() { super(ErrorCode.REPLY_DEPTH_EXCEEDED); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/repository/ReaderBoardReplyRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/repository/ReaderBoardReplyRepository.java
@@ -43,8 +43,9 @@ public interface ReaderBoardReplyRepository extends JpaRepository<ReaderBoardRep
             "WHERE r.id = :id AND r.childReplyCount > 0")
     void decrementChildReplyCount(@Param("id") Long id);
 
-    // 피드 댓글 - 조회 (최상위 댓글만)
-    @Query("SELECT r FROM ReaderBoardReply r " +
+    // 피드 댓글 - 조회 (최상위 댓글 + 답댓글 fetch join)
+    @Query("SELECT DISTINCT r FROM ReaderBoardReply r " +
+            "LEFT JOIN FETCH r.childReplies c " +
             "WHERE r.board.id = :boardId AND r.parentReply IS NULL")
     Slice<ReaderBoardReply> findAllByBoard_Id(@Param("boardId") Long boardId, Pageable pageable);
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedReactionService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedReactionService.java
@@ -6,6 +6,7 @@ import com.storix.domain.domains.feed.dto.CreateFeedReplyCommand;
 import com.storix.domain.domains.feed.dto.LikeToggleResponse;
 import com.storix.domain.domains.feed.dto.ReaderBoardReplyResponse;
 import com.storix.domain.domains.feed.dto.StandardReplyInfo;
+import com.storix.domain.domains.feed.exception.ReplyDepthExceededException;
 import com.storix.domain.domains.plus.domain.ReaderBoard;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import com.storix.domain.domains.user.dto.StandardProfileInfo;
@@ -53,12 +54,16 @@ public class FeedReactionService {
         return ReaderBoardReplyResponse.of(profile, reply);
     }
 
-    // 답댓글 등록
+    // 답댓글 등록 (depth 1 제한: 답댓글에 대한 답댓글 불가)
     @Transactional
     public ReaderBoardReplyResponse uploadReaderBoardChildReply(Long userId, Long boardId, Long parentReplyId, String comment) {
 
         ReaderBoard readerBoard = readerFeedAdaptor.findReaderBoardById(boardId);
         ReaderBoardReply parentReply = readerFeedAdaptor.findReplyById(parentReplyId);
+
+        if (parentReply.getDepth() >= 1) {
+            throw ReplyDepthExceededException.EXCEPTION;
+        }
 
         CreateFeedReplyCommand cmd =
                 new CreateFeedReplyCommand(readerBoard, userId, comment, parentReply);

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedService.java
@@ -141,14 +141,6 @@ public class FeedService {
         return new BoardWrapperDto<>(board, comments);
     }
 
-    @Transactional(readOnly = true)
-    public Slice<ReaderBoardReplyInfoWithProfile> findChildReplies(Long userId, Long parentReplyId, Pageable pageable) {
-
-        Slice<ReaderBoardReply> childReplies =
-                readerFeedAdaptor.findAllByParentReplyId(parentReplyId, pageable);
-
-        return readerBoardHelper.mapRepliesWithProfileAndLike(userId, childReplies);
-    }
 
     @Transactional(readOnly = true)
     public List<SlicedReaderBoardWithProfileInfo> findTodayTrendingFeeds(Long userId) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReaderBoardHelper.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReaderBoardHelper.java
@@ -252,27 +252,32 @@ public class ReaderBoardHelper {
             return replies.map(r -> null);
         }
 
-        // 1) 댓글 작성자 userIds
-        List<Long> userIds = content.stream()
-                .map(ReaderBoardReply::getUserId)
-                .distinct()
-                .toList();
+        // 1) 부모 댓글 + 답댓글 작성자 userIds 전부 수집
+        List<Long> userIds = new ArrayList<>();
+        List<Long> allReplyIds = new ArrayList<>();
+
+        for (ReaderBoardReply reply : content) {
+            userIds.add(reply.getUserId());
+            allReplyIds.add(reply.getId());
+
+            for (ReaderBoardReply child : reply.getChildReplies()) {
+                userIds.add(child.getUserId());
+                allReplyIds.add(child.getId());
+            }
+        }
+
+        userIds = userIds.stream().distinct().toList();
 
         // 2) 프로필 조회
         Map<Long, StandardProfileInfo> profileMap =
                 userAdaptor.findStandardProfileInfoByUserIds(userIds);
 
-        // 3) 댓글 ids
-        List<Long> replyIds = content.stream()
-                .map(ReaderBoardReply::getId)
-                .toList();
-
-        // 4) 좋아요 여부 조회
+        // 3) 좋아요 여부 조회 (부모 + 답댓글 전부)
         Set<Long> likedReplyIds = (userId != null)
-                ? readerFeedAdaptor.findLikedReplyIds(userId, replyIds)
+                ? readerFeedAdaptor.findLikedReplyIds(userId, allReplyIds)
                 : Collections.emptySet();
 
-        // 5) 최종 매핑
+        // 4) 최종 매핑 (답댓글 embed)
         return replies.map(reply -> {
             StandardProfileInfo profile = profileMap.get(reply.getUserId());
             if (profile == null) return null;
@@ -280,9 +285,28 @@ public class ReaderBoardHelper {
             ReaderBoardReplyInfo replyInfo = ReaderBoardReplyInfo.from(reply);
             boolean isLiked = likedReplyIds.contains(reply.getId());
 
+            // 답댓글 매핑
+            List<ReaderBoardReplyInfoWithProfile> childRepliesDto = reply.getChildReplies().stream()
+                    .sorted(Comparator.comparing(ReaderBoardReply::getCreatedAt))
+                    .map(child -> {
+                        StandardProfileInfo childProfile = profileMap.get(child.getUserId());
+                        if (childProfile == null) return null;
+
+                        ReaderBoardReplyInfo childInfo = ReaderBoardReplyInfo.from(child);
+                        boolean childIsLiked = likedReplyIds.contains(child.getId());
+
+                        return ReaderBoardReplyInfoWithProfile.of(
+                                childProfile,
+                                StandardReplyInfoWithLike.of(childInfo, childIsLiked)
+                        );
+                    })
+                    .filter(Objects::nonNull)
+                    .toList();
+
             return ReaderBoardReplyInfoWithProfile.of(
                     profile,
-                    StandardReplyInfoWithLike.of(replyInfo, isLiked)
+                    StandardReplyInfoWithLike.of(replyInfo, isLiked),
+                    childRepliesDto
             );
         });
     }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 피드 답댓글 depth 1 제한
[기존]
답댓글에 대한 답댓글 작성이 depth 제한 없이 가능했음 (depth 0 → 1 → 2 → ...)

[변경 후]
답댓글은 최상위 댓글(depth 0)에만 작성 가능하도록 제한. 답댓글(depth >= 1)에 답댓글 작성 시 `ReplyDepthExceededException` (REPLY_ERROR_002) 발생
- `FeedReactionService.uploadReaderBoardChildReply()`에 depth 검증 추가
- `ReplyDepthExceededException` 커스텀 예외 신규 생성
- `ErrorCode.REPLY_DEPTH_EXCEEDED` 추가

### 2. 피드 상세 조회 시 답댓글 embed 방식으로 변경
[기존]
피드 상세 조회 시 최상위 댓글만 반환하고, 답댓글은 별도 API(`GET .../reply/{replyId}/children`)로 조회해야 했음

[변경 후]
피드 상세 조회 시 최상위 댓글 페이징(10개 단위) + 각 댓글의 답댓글을 `childReplies` 리스트에 embed하여 한 번에 반환
- `ReaderBoardReplyRepository.findAllByBoard_Id()`에 fetch join 적용 (`LEFT JOIN FETCH r.childReplies`)
- `ReaderBoardHelper.mapRepliesWithProfileAndLike()`에서 부모 댓글 + 답댓글의 프로필/좋아요를 배치 조회 후 embed
- `ReaderBoardReplyInfoWithProfile`에 `childReplies` 필드 추가

### 3. 답댓글 별도 조회 API 제거
답댓글이 피드 상세 조회에 포함되므로 별도 조회 API가 불필요
- `FeedController.getChildReplies()` 엔드포인트 제거
- `FeedUseCase.getChildReplies()` 메서드 제거
- `FeedService.findChildReplies()` 메서드 제거

### 4. 답댓글 응답 필드 최적화
답댓글(depth 1)에서 불필요한 필드를 JSON 응답에서 제외
- `childReplyCount`: 답댓글은 항상 0이므로 depth >= 1일 때 null 처리 → `@JsonInclude(NON_NULL)`로 제외
- `childReplies`: 답댓글에는 하위 답댓글이 없으므로 null 처리 → `@JsonInclude(NON_NULL)`로 제외

### 5. E2E 테스트 반영
- "답댓글에 답댓글 작성 성공" → "답댓글에 답댓글 작성 시 400 에러" 케이스로 변경
- 답댓글 별도 조회 테스트 제거
- `TestExceptionHandler` 추가 (standalone MockMvc에서 `STORIXCodeException` 처리)

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- Closes #10

## 🖇️ 기타
