### PR TITLE
Feat: 카카오&네이버 네이티브 소셜 로그인 지원 (+ 웹소켓 Capacitor CORS)

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.storix.api.domain.user.controller;
 
 import com.storix.api.domain.user.controller.dto.AuthorizationResponse;
+import com.storix.api.domain.user.controller.dto.KakaoNativeLoginRequest;
+import com.storix.api.domain.user.controller.dto.NaverNativeLoginRequest;
 import com.storix.api.domain.user.controller.dto.ReaderSocialLoginResponse;
 import com.storix.api.domain.user.usecase.*;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
@@ -45,7 +47,9 @@ public class AuthController {
         return oauthLoginUseCase.readerOAuthLogin(req, OAuthProvider.KAKAO);
     }
 
-    @Operation(summary = "네이버 로그인", description = "네이버로 로그인 하는 api 입니다.  \n회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
+    @Operation(summary = "네이버 로그인", description = "네이버로 로그인 하는 api 입니다.  \n" +
+            "회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n" +
+            "회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
     @GetMapping("/oauth/naver/login")
     public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> naverLogin(
             @RequestParam("code") String code,
@@ -55,13 +59,37 @@ public class AuthController {
         return oauthLoginUseCase.readerOAuthLogin(req, OAuthProvider.NAVER);
     }
 
-    @Operation(summary = "애플 로그인", description = "애플로 로그인 하는 api 입니다.  \n회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
+    @Operation(summary = "애플 로그인", description = "애플로 로그인 하는 api 입니다.  \n" +
+            "회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n" +
+            "회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
     @GetMapping("/oauth/apple/login")
     public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> appleLogin(
             @RequestParam("code") String code
     ) {
-        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forApple(code);
-        return oauthLoginUseCase.readerOAuthLogin(req, OAuthProvider.APPLE);
+        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forAppleNative(code);
+        return oauthLoginUseCase.readerOAuthNativeLogin(req, OAuthProvider.APPLE);
+    }
+
+    @Operation(summary = "카카오 네이티브 로그인", description = "iOS/Android 네이티브 SDK에서 받은 accessToken/idToken을 그대로 검증하여 로그인합니다.  \n" +
+            "회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n" +
+            "회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
+    @PostMapping("/oauth/kakao-native/login")
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> kakaoNativeLogin(
+            @Valid @RequestBody KakaoNativeLoginRequest body
+    ) {
+        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forKakaoNative(body.accessToken(), body.idToken());
+        return oauthLoginUseCase.readerOAuthNativeLogin(req, OAuthProvider.KAKAO);
+    }
+
+    @Operation(summary = "네이버 네이티브 로그인", description = "iOS/Android 네이티브 SDK에서 받은 accessToken을 그대로 검증하여 로그인합니다.  \n" +
+            "회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n" +
+            "회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
+    @PostMapping("/oauth/naver-native/login")
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> naverNativeLogin(
+            @Valid @RequestBody NaverNativeLoginRequest body
+    ) {
+        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forNaverNative(body.accessToken());
+        return oauthLoginUseCase.readerOAuthNativeLogin(req, OAuthProvider.NAVER);
     }
 
     @Operation(summary = "독자 계정 회원가입", description = "유저 정보를 최종적으로 등록하는 api 입니다.  \n온보딩 토큰을 보내주세요.")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/KakaoNativeLoginRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/KakaoNativeLoginRequest.java
@@ -1,0 +1,12 @@
+package com.storix.api.domain.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoNativeLoginRequest(
+        @NotBlank(message = "accessToken은 필수입니다.")
+        String accessToken,
+
+        @NotBlank(message = "idToken은 필수입니다.")
+        String idToken
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/NaverNativeLoginRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/NaverNativeLoginRequest.java
@@ -1,0 +1,9 @@
+package com.storix.api.domain.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record NaverNativeLoginRequest(
+        @NotBlank(message = "accessToken은 필수입니다.")
+        String accessToken
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -29,27 +29,35 @@ public class AuthUseCase {
     private final TokenGenerateHelper tokenGenerateHelper;
     private final CookieHelper cookieHelper;
 
-    // 독자 회원 가입 가능 여부
+    // 독자 회원 가입 가능 여부 (Web)
+    // - authCode로 토큰을 얻은 뒤 공통 검증
     public ValidAuthDTO checkAvailableRegister(OAuthAuthorizationRequest req, OAuthProvider provider) {
         return switch (provider) {
             case KAKAO -> {
                 KakaoTokenResponse kakaoToken = oauthHelper.getKakaoOAuthToken(req.authCode(), req.redirectUri());
-                KakaoUserResponse kakaoUser = oauthHelper.getKakaoInformation(kakaoToken.accessToken());
-                OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(kakaoToken.idToken(), OAuthProvider.KAKAO);
-                if (!oauthInfo.getOid().equals(kakaoUser.id())) throw UnknownUserException.EXCEPTION;
-                yield authService.validKakaoSignup(kakaoUser.id(), kakaoToken.idToken());
+                yield validateKakao(kakaoToken.accessToken(), kakaoToken.idToken());
             }
             case NAVER -> {
                 NaverTokenResponse naverToken = oauthHelper.getNaverOAuthToken(req.authCode(), req.state());
-                NaverUserResponse naverUser = oauthHelper.getNaverInformation(naverToken.accessToken());
-                if (naverUser.id() == null) throw FeignClientServerErrorException.EXCEPTION;
-                yield authService.validNaverSignup(naverUser.id());
+                yield validateNaver(naverToken.accessToken());
             }
+
+            case APPLE, SLACK -> throw UnsupportedOAuthProviderException.EXCEPTION;
+        };
+    }
+
+    // 독자 회원 가입 가능 여부 (Native)
+    // - Kakao/Naver: SDK가 내려준 accessToken(+idToken)으로 검증
+    // - Apple: SDK가 내려준 authorizationCode로 토큰을 얻은 뒤 공통 검증
+    public ValidAuthDTO checkAvailableRegisterNative(OAuthAuthorizationRequest req, OAuthProvider provider) {
+        return switch (provider) {
+            case KAKAO -> validateKakao(req.accessToken(), req.idToken());
+            case NAVER -> validateNaver(req.accessToken());
             case APPLE -> {
                 AppleTokenResponse appleToken = oauthHelper.getAppleOAuthToken(req.authCode());
-                OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(appleToken.idToken(), OAuthProvider.APPLE);
-                yield authService.validAppleSignup(oauthInfo.getOid(), appleToken.idToken());
+                yield validateApple(appleToken.idToken());
             }
+
             case SLACK -> throw UnsupportedOAuthProviderException.EXCEPTION;
         };
     }
@@ -69,6 +77,37 @@ public class AuthUseCase {
     public CustomResponse<Void> checkAvailableNickname(String nickName) {
         authService.validNickname(nickName);
         return CustomResponse.onSuccess(SuccessCode.AUTH_NICKNAME_SUCCESS);
+    }
+
+
+
+    // Kakao 공통 검증 로직
+    private ValidAuthDTO validateKakao(String accessToken, String idToken) {
+        // accessToken으로 사용자 정보 조회
+        KakaoUserResponse kakaoUser = oauthHelper.getKakaoInformation(accessToken);
+        // idToken으로 OIDC 검증
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, OAuthProvider.KAKAO);
+
+        // token 간 정보 일치 확인 후 회원가입 여부 반환
+        if (!oauthInfo.getOid().equals(kakaoUser.id())) throw UnknownUserException.EXCEPTION;
+        return authService.validKakaoSignup(kakaoUser.id(), idToken);
+    }
+
+    // Naver 공통 검증 로직
+    private ValidAuthDTO validateNaver(String accessToken) {
+        // accessToken으로 사용자 정보 조회
+        NaverUserResponse naverUser = oauthHelper.getNaverInformation(accessToken);
+
+        // token 간 정보 일치 확인 후 회원가입 여부 반환
+        if (naverUser.id() == null) throw FeignClientServerErrorException.EXCEPTION;
+        return authService.validNaverSignup(naverUser.id());
+    }
+
+    // Apple 공통 검증 로직
+    private ValidAuthDTO validateApple(String idToken) {
+        // idToken으로 OIDC 검증 및 회원가입 여부 반환
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, OAuthProvider.APPLE);
+        return authService.validAppleSignup(oauthInfo.getOid(), idToken);
     }
 
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/OAuthLoginUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/OAuthLoginUseCase.java
@@ -16,23 +16,31 @@ public class OAuthLoginUseCase {
     private final AuthUseCase authUseCase;
     private final LoginUseCase loginUseCase;
 
+    // Web: authCode로 accessToken(+idToken) 요청 및 검증
     public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerOAuthLogin(OAuthAuthorizationRequest req, OAuthProvider provider) {
         ValidAuthDTO valid = authUseCase.checkAvailableRegister(req, provider);
+        return dispatchLoginByRegistration(valid, provider);
+    }
 
-        /**
-         * (1) isRegistered = true (계정 정보 있음) -> 로그인 시키기
-         *     return 1)isRegistered 2)AccessToken 3)RefreshToken
-         * */
+    // Native: Kakao/Naver SDK에서 받은 accessToken(+idToken)을 그대로 검증
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerOAuthNativeLogin(OAuthAuthorizationRequest req, OAuthProvider provider) {
+        ValidAuthDTO valid = authUseCase.checkAvailableRegisterNative(req, provider);
+        return dispatchLoginByRegistration(valid, provider);
+    }
+
+    /**
+     * 회원 등록 여부에 따라 로그인 응답을 분기
+     *
+     * (1) isRegistered = true  -> 액세스 토큰 + 리프레쉬 토큰 쿠키 반환
+     * (2) isRegistered = false -> 온보딩 토큰 반환 (회원가입 필요)
+     */
+    private ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> dispatchLoginByRegistration(
+            ValidAuthDTO valid, OAuthProvider provider
+    ) {
         if (valid.isRegistered()) {
             return loginUseCase.readerLoginWithIdToken(valid.idToken(), provider);
         }
-        /**
-         * (2) isRegistered = false (계정 정보 없음) -> 회원가입에 필요한 유저 정보를 담은 온보딩 토큰 반환 (OAuthInfo)
-         *     return 1)isRegistered 2)OnboardingToken
-         * */
-        else {
-            return loginUseCase.readerPreLoginWithIdToken(valid.idToken(), provider);
-        }
+        return loginUseCase.readerPreLoginWithIdToken(valid.idToken(), provider);
     }
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OAuthAuthorizationRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OAuthAuthorizationRequest.java
@@ -2,22 +2,37 @@ package com.storix.domain.domains.user.dto;
 
 public record OAuthAuthorizationRequest(
         String authCode,
-        String redirectUri, // kakao
-        String state // naver
+        String redirectUri, // kakao (web)
+        String state,       // naver (web)
+        String accessToken, // native (kakao, naver)
+        String idToken      // native (kakao OIDC)
 ) {
+    // Web: Kakao Redirect Uri -> authCode
     public static OAuthAuthorizationRequest forKakao(
             String authCode, String redirectUri
     ) {
-        return new OAuthAuthorizationRequest(authCode, redirectUri, null);
+        return new OAuthAuthorizationRequest(authCode, redirectUri, null, null, null);
     }
 
+    // Web: Naver Redirect Uri -> authCode + state
     public static OAuthAuthorizationRequest forNaver(
             String authCode, String state
     ) {
-        return new OAuthAuthorizationRequest(authCode, null, state);
+        return new OAuthAuthorizationRequest(authCode, null, state, null, null);
     }
 
-    public static OAuthAuthorizationRequest forApple(String authCode) {
-        return new OAuthAuthorizationRequest(authCode, null, null);
+    // Native: Apple SDK -> authCode
+    public static OAuthAuthorizationRequest forAppleNative(String authCode) {
+        return new OAuthAuthorizationRequest(authCode, null, null, null, null);
+    }
+
+    // Native: Kakao SDK -> accessToken + idToken
+    public static OAuthAuthorizationRequest forKakaoNative(String accessToken, String idToken) {
+        return new OAuthAuthorizationRequest(null, null, null, accessToken, idToken);
+    }
+
+    // Native: Naver SDK -> accessToken
+    public static OAuthAuthorizationRequest forNaverNative(String accessToken) {
+        return new OAuthAuthorizationRequest(null, null, null, accessToken, null);
     }
 }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/WebSocketConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/WebSocketConfig.java
@@ -28,6 +28,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 "https://api.storix.kr",
                 "http://localhost:3000",
                 "http://localhost:5173",
+                "capacitor://localhost",
+                "https://localhost",
                 "https://storix-fe-git-develop-kim-yunseongs-projects.vercel.app",
                 "https://storix-fe-git-main-kim-yunseongs-projects.vercel.app"
         );


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 카카오/네이버 네이티브 소셜 로그인 지원
- 네이티브 SDK 소셜 로그인을 지원하도록, token을 전달받아서 검증하는 api를 추가하였습니다. (기존 웹 api 유지)
- token 검증 로직은 기존 웹 기반 소셜 로그인 로직을 재활용하였습니다.

### 2. 웹소켓 CORS 설정
- Capacitor로 정적 빌딩된 앱에서 채팅 기능을 사용할 수 있도록 CORS 설정을 추가하였습니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
## 🖇️ 기타