### PR TITLE
Refactor: [웹/네이티브 지원] RefreshToken 분기 처리

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.storix.api.domain.user.controller.dto.AuthorizationResponse;
 import com.storix.api.domain.user.controller.dto.KakaoNativeLoginRequest;
 import com.storix.api.domain.user.controller.dto.NaverNativeLoginRequest;
 import com.storix.api.domain.user.controller.dto.ReaderSocialLoginResponse;
+import com.storix.api.domain.user.controller.dto.RefreshTokenRequest;
 import com.storix.api.domain.user.usecase.*;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.domain.domains.user.adaptor.OnboardingUserDetails;
@@ -117,13 +118,18 @@ public class AuthController {
                 .body(authUseCase.checkAvailableNickname(nickName));
     }
 
-    @Operation(summary = "토큰 재발급", description = "액세스 토큰을 리프레쉬 토큰 쿠키와 함께 재발급하는 api 입니다.   \n액세스 토큰 만료 시 호출해주세요.")
+    @Operation(summary = "토큰 재발급", description = "액세스 토큰을 재발급하는 api 입니다. 액세스 토큰 만료 시 호출해주세요.  \n" +
+            "- Web   : 요청에 Cookie 붙여서 호출 -> 응답 body로 accessToken, Set-Cookie로 refreshToken 재발급  \n" +
+            "- Native: RequestBody에 refreshToken 담아 전송 -> 응답 body로 access/refreshToken 재발급")
     @PostMapping("/tokens/refresh")
     public ResponseEntity<CustomResponse<AuthorizationResponse>> reissueAccessToken(
             @Parameter(hidden = true)
-            @CookieValue(value = "refreshToken", required = false) String refreshToken
+            @CookieValue(value = "refreshToken", required = false) String cookieRefreshToken,
+
+            @RequestBody(required = false) RefreshTokenRequest body
     ) {
-        return authorizationUseCase.getTokenRefresh(refreshToken);
+        String bodyRefreshToken = (body != null) ? body.refreshToken() : null;
+        return authorizationUseCase.getTokenRefresh(cookieRefreshToken, bodyRefreshToken);
     }
 
     @Operation(summary = "로그아웃", description = "로그아웃용 api 입니다.   \n액세스 토큰을 보내주세요.")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/AuthorizationResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/AuthorizationResponse.java
@@ -1,6 +1,17 @@
 package com.storix.api.domain.user.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record AuthorizationResponse(
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {
+    public static AuthorizationResponse webRefresh(String accessToken) {
+        return new AuthorizationResponse(accessToken, null);
+    }
+
+    public static AuthorizationResponse nativeRefresh(String accessToken, String refreshToken) {
+        return new AuthorizationResponse(accessToken, refreshToken);
+    }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderLoginResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderLoginResponse.java
@@ -1,6 +1,17 @@
 package com.storix.api.domain.user.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ReaderLoginResponse(
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {
+    public static ReaderLoginResponse webLogin(String accessToken) {
+        return new ReaderLoginResponse(accessToken, null);
+    }
+
+    public static ReaderLoginResponse nativeLogin(String accessToken, String refreshToken) {
+        return new ReaderLoginResponse(accessToken, refreshToken);
+    }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -66,7 +66,7 @@ public class AuthUseCase {
     public ResponseEntity<CustomResponse<AuthorizationResponse>> readerSignup(ReaderSignupRequest req, String jti) {
         AuthUserDetails userDetails = authService.signUpReaderUser(req, jti);
         LoginWithTokenResponse tokenResponse = tokenGenerateHelper.generateLoginWithToken(userDetails);
-        AuthorizationResponse result = new AuthorizationResponse(tokenResponse.accessToken());
+        AuthorizationResponse result = AuthorizationResponse.webRefresh(tokenResponse.accessToken());
 
         return ResponseEntity.ok()
                 .headers(cookieHelper.getTokenCookie(tokenResponse.refreshToken()))

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthorizationUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthorizationUseCase.java
@@ -19,15 +19,28 @@ public class AuthorizationUseCase {
 
     private final CookieHelper cookieHelper;
 
-    public ResponseEntity<CustomResponse<AuthorizationResponse>> getTokenRefresh(String refreshToken) {
+    // 토큰 재발급
+    public ResponseEntity<CustomResponse<AuthorizationResponse>> getTokenRefresh(
+            String cookieRefreshToken, String bodyRefreshToken
+    ) {
+        boolean useBodyToken = cookieRefreshToken == null || cookieRefreshToken.isBlank();
+        String refreshToken = useBodyToken ? bodyRefreshToken : cookieRefreshToken;
 
         if (refreshToken == null || refreshToken.isBlank()) throw RefreshTokenNotExistException.EXCEPTION;
 
         LoginWithTokenResponse tokenResponse = tokenGenerateHelper.reissueTokens(refreshToken);
-        AuthorizationResponse result = new AuthorizationResponse(tokenResponse.accessToken());
 
+        // Native: body로 access/refresh 둘 다 반환
+        if (useBodyToken) {
+            return ResponseEntity.ok()
+                    .body(CustomResponse.onSuccess(SuccessCode.AUTH_REISSUE_ACCESSTOKEN_SUCCESS,
+                            AuthorizationResponse.nativeRefresh(tokenResponse.accessToken(), tokenResponse.refreshToken())));
+        }
+
+        // Web: accessToken만 body, refreshToken은 Set-Cookie 로 재발급
         return ResponseEntity.ok()
                 .headers(cookieHelper.getTokenCookie(tokenResponse.refreshToken()))
-                .body(CustomResponse.onSuccess(SuccessCode.AUTH_REISSUE_ACCESSTOKEN_SUCCESS, result));
+                .body(CustomResponse.onSuccess(SuccessCode.AUTH_REISSUE_ACCESSTOKEN_SUCCESS,
+                        AuthorizationResponse.webRefresh(tokenResponse.accessToken())));
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/DeveloperAuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/DeveloperAuthUseCase.java
@@ -57,7 +57,7 @@ public class DeveloperAuthUseCase {
     public ResponseEntity<CustomResponse<AuthorizationResponse>> developerLogin(DeveloperLoginRequest req) {
         AuthUserDetails userDetails = developerAuthService.loginDeveloper(req.pendingId());
         LoginWithTokenResponse tokenResponse = tokenGenerateHelper.generateLoginWithToken(userDetails);
-        AuthorizationResponse result = new AuthorizationResponse(tokenResponse.accessToken());
+        AuthorizationResponse result = AuthorizationResponse.webRefresh(tokenResponse.accessToken());
 
         return ResponseEntity.ok()
                 .headers(cookieHelper.getTokenCookie(tokenResponse.refreshToken()))

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LoginUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LoginUseCase.java
@@ -40,14 +40,22 @@ public class LoginUseCase {
         AuthUserDetails userDetails = readerLoginService.execute(oauthInfo);
         LoginWithTokenResponse loginToken = tokenGenerateHelper.generateLoginWithToken(userDetails);
 
-        ReaderLoginResponse readerLoginResponse = new ReaderLoginResponse(
-                loginToken.accessToken()
-        );
+        // Native: body로 access/refresh 둘 다 반환
+        if (isNative) {
+            return ResponseEntity.ok()
+                    .body(CustomResponse.onSuccess(SuccessCode.OAUTH_LOGIN_SUCCESS,
+                            new ReaderSocialLoginResponse(true,
+                                    ReaderLoginResponse.nativeLogin(loginToken.accessToken(), loginToken.refreshToken()),
+                                    null)));
+        }
 
+        // Web: accessToken만 body, refreshToken은 Set-Cookie
         return ResponseEntity.ok()
                 .headers(cookieHelper.getTokenCookie(loginToken.refreshToken()))
                 .body(CustomResponse.onSuccess(SuccessCode.OAUTH_LOGIN_SUCCESS,
-                        new ReaderSocialLoginResponse(true, readerLoginResponse, null)));
+                        new ReaderSocialLoginResponse(true,
+                                ReaderLoginResponse.webLogin(loginToken.accessToken()),
+                                null)));
     }
 
     // 회원가입하지 않은 경우 로그인

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/repository/ReaderBoardRankingRepositoryImpl.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/repository/ReaderBoardRankingRepositoryImpl.java
@@ -22,7 +22,7 @@ public class ReaderBoardRankingRepositoryImpl implements ReaderBoardRankingRepos
             UPDATE reader_board
             SET popularity_score = (like_count * 4 + reply_count * 3)
             WHERE created_at >= ?
-                AND (popularity_score IS NULL OR popularity_score <> (like_count*3 + reply_count*4))
+                AND (popularity_score IS NULL OR popularity_score <> (like_count * 4 + reply_count * 3))
         """;
 
         return jdbcTemplate.update(sql, threshold);


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. [웹/네이티브 지원] RefreshToken 분기 처리
- 네이티브 환경에서 RefreshToken 관련 요청 시, request/response body에서 RefreshToken을 담아 보내거나 꺼내서 확인할 수 있도록 분기 처리하였습니다.

### 2. 피드 인기도 점수 계산 비교식 수정
- 인기도 점수 계산 비교식 3:4 -> 4:3 수정

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]

## 🖇️ 기타