### PR TITLE
Refactor: [프로필 - 선호 장르 통계] 유저 행동 로그 기반 도메인 이벤트 발행

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/preference/PreferenceController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/preference/PreferenceController.java
@@ -60,15 +60,4 @@ public class PreferenceController {
                 explorationUseCase.getExplorationResults(authUserDetails.getUserId()));
     }
 
-    // 마이페이지 누적 조회
-    @Operation(summary = "마이페이지 선호 장르 통계", description = "레이더 차트용 선호 장르별 점수를 조회합니다.")
-    @GetMapping("/stats")
-    public CustomResponse<List<GenreScoreInfo>> getStats(
-            @AuthenticationPrincipal AuthUserDetails authUserDetails
-    ) {
-        return CustomResponse.onSuccess(
-                SuccessCode.SUCCESS,
-                explorationUseCase.getCumulativeStats(authUserDetails.getUserId())
-        );
-    }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/preference/PreferenceController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/preference/PreferenceController.java
@@ -4,7 +4,6 @@ import com.storix.domain.domains.preference.application.ExplorationUseCase;
 import com.storix.domain.domains.preference.dto.ExplorationResultResponseDto;
 import com.storix.domain.domains.preference.dto.ExplorationSubmitRequestDto;
 import com.storix.domain.domains.preference.dto.ExplorationWorksResponseDto;
-import com.storix.domain.domains.preference.dto.GenreScoreInfo;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.common.payload.CustomResponse;
 import com.storix.common.code.SuccessCode;

--- a/STORIX-Api/src/main/java/com/storix/api/domain/profile/controller/ProfileController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/profile/controller/ProfileController.java
@@ -1,6 +1,7 @@
 package com.storix.api.domain.profile.controller;
 
 import com.storix.domain.domains.feed.dto.ReaderBoardReplyInfoWithProfile;
+import com.storix.domain.domains.preference.dto.GenreScoreInfo;
 import com.storix.domain.domains.profile.dto.*;
 import com.storix.api.domain.profile.usecase.ProfileActivityUseCase;
 import com.storix.api.domain.profile.usecase.ProfileFavoriteUseCase;
@@ -22,6 +23,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Validated
 @RestController
@@ -111,6 +114,16 @@ public class ProfileController {
     ) {
         return ResponseEntity.ok()
                 .body(profileFavoriteUseCase.getRatingDistribution(authUserDetails.getUserId()));
+    }
+
+    // 마이페이지 누적 조회
+    @Operation(summary = "[독자] 선호 장르 통계 조회", description = "선호 장르별 점수를 조회합니다.")
+    @GetMapping("/reader/stats")
+    public ResponseEntity<CustomResponse<List<GenreScoreInfo>>> getStats(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails
+    ) {
+        return ResponseEntity.ok()
+                .body(profileFavoriteUseCase.getGenreStats(authUserDetails.getUserId()));
     }
 
     // 선호 해시태그 조회

--- a/STORIX-Api/src/main/java/com/storix/api/domain/profile/usecase/ProfileFavoriteUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/profile/usecase/ProfileFavoriteUseCase.java
@@ -1,6 +1,8 @@
 package com.storix.api.domain.profile.usecase;
 
 import com.storix.common.annotation.UseCase;
+import com.storix.domain.domains.genrescore.service.GenreScoreQueryService;
+import com.storix.domain.domains.preference.dto.GenreScoreInfo;
 import com.storix.domain.domains.profile.dto.FavoriteWorksWithReviewInfo;
 import com.storix.domain.domains.profile.dto.FavoriteHashtagsResponse;
 import com.storix.domain.domains.profile.dto.ProfileFavoriteWorksWrapperDto;
@@ -12,11 +14,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
 @UseCase
 @RequiredArgsConstructor
 public class ProfileFavoriteUseCase {
 
     private final ProfileFavoriteService profileFavoriteService;
+    private final GenreScoreQueryService genreScoreQueryService;
 
     // 관심 작품 조회
     public CustomResponse<ProfileFavoriteWorksWrapperDto<FavoriteWorksWithReviewInfo>> getFavoriteWorksList(Long userId, Pageable pageable) {
@@ -44,5 +49,12 @@ public class ProfileFavoriteUseCase {
 
         FavoriteHashtagsResponse result = profileFavoriteService.findFavoriteHashtagsByUserId(userId);
         return CustomResponse.onSuccess(SuccessCode.PROFILE_FAVORITE_HASHTAGS_LOAD_SUCCESS, result);
+    }
+
+    // 선호 장르 통계 조회 (비율 정규화)
+    public CustomResponse<List<GenreScoreInfo>> getGenreStats(Long userId) {
+
+        List<GenreScoreInfo> result = genreScoreQueryService.getRatioNormalized(userId);
+        return CustomResponse.onSuccess(SuccessCode.PROFILE_GENRE_STATS_LOAD_SUCCESS, result);
     }
 }

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
@@ -1,0 +1,63 @@
+package com.storix.batch.scheduler;
+
+import com.storix.domain.domains.genrescore.service.GenreScoreAggregationService;
+import com.storix.domain.domains.genrescore.service.GenreScoreAggregationService.ChunkResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GenreScoreAggregationScheduler {
+
+    private static final int CHUNK_SIZE = GenreScoreAggregationService.DEFAULT_CHUNK_SIZE;
+    private static final long INTER_CHUNK_DELAY_MS = 100L;
+    private static final int MAX_ITERATIONS = 10_000;
+
+    private final GenreScoreAggregationService aggregationService;
+
+
+    // 매일 자정, 미처리 로그 청크 단위로 집계
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void run() {
+        long started = System.currentTimeMillis();
+        Set<Long> touchedUsers = new HashSet<>();
+        int totalLogs = 0;
+        int totalGroups = 0;
+        int iter = 0;
+
+        while (iter++ < MAX_ITERATIONS) {
+            ChunkResult result = aggregationService.processChunk(CHUNK_SIZE);
+            if (result.processedLogs() == 0) break;
+
+            totalLogs += result.processedLogs();
+            totalGroups += result.groups();
+            touchedUsers.addAll(result.users());
+
+            sleep(INTER_CHUNK_DELAY_MS);
+        }
+
+        if (iter >= MAX_ITERATIONS) {
+            log.warn(">>> [GenreScoreBatch] MAX_ITERATIONS({}) 도달 — 다음 실행 시 잔여분 처리", MAX_ITERATIONS);
+        }
+
+        int oldDeleted = aggregationService.cleanupOldProcessed();
+
+        log.info(">>> [GenreScoreBatch] processedLogs={}, groups={}, users={}, oldDeleted={}, iterations={}, took={}ms",
+                totalLogs, totalGroups, touchedUsers.size(), oldDeleted, iter - 1,
+                System.currentTimeMillis() - started);
+    }
+
+    private void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -45,6 +45,7 @@ public enum SuccessCode {
     PROFILE_MY_BOARDS_LIKE_LIST_LOAD_SUCCESS(HttpStatus.OK, "PROFILE_SUCCESS_010", "프로필 내 활동 좋아요 리스트 조회에 성공했습니다."),
     PROFILE_RATING_DISTRIBUTION_LOAD_SUCCESS(HttpStatus.OK, "PROFILE_SUCCESS_011", "프로필 리뷰 별점 분포 조회에 성공했습니다."),
     PROFILE_FAVORITE_HASHTAGS_LOAD_SUCCESS(HttpStatus.OK, "PROFILE_SUCCESS_012", "프로필 선호 해시태그 조회에 성공했습니다."),
+    PROFILE_GENRE_STATS_LOAD_SUCCESS(HttpStatus.OK, "PROFILE_SUCCESS_013", "프로필 선호 장르 통계 조회에 성공했습니다."),
 
     // Image success
     IMAGE_ISSUE_PRESIGNED_URL_SUCCESS(HttpStatus.OK, "IMAGE_SUCCESS_001", "이미지를 업로드할 Presigned Url 발급에 성공했습니다."),

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/favorite/service/FavoriteService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/favorite/service/FavoriteService.java
@@ -2,6 +2,8 @@ package com.storix.domain.domains.favorite.service;
 
 import com.storix.domain.domains.favorite.adaptor.FavoriteWorksAdaptor;
 import com.storix.domain.domains.favorite.exception.DuplicateFavoriteWorksRequestException;
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FavoriteService {
 
     private final FavoriteWorksAdaptor favoriteWorksAdaptor;
+    private final GenreScorePublisher genreScorePublisher;
 
     // [작품] 관심 작품 관련
     @Transactional(readOnly = true)
@@ -26,6 +29,7 @@ public class FavoriteService {
         }
 
         favoriteWorksAdaptor.saveSingleFavoriteWorks(userId, worksId);
+        genreScorePublisher.publish(userId, worksId, GenreScoreEventType.FAVORITE_WORKS_ADD);
     }
 
     @Transactional

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreRawScore.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreRawScore.java
@@ -1,0 +1,33 @@
+package com.storix.domain.domains.genrescore.domain;
+
+import com.storix.common.model.BaseTimeEntity;
+import com.storix.domain.domains.works.domain.Genre;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_genre_raw_score",
+        indexes = {
+                @Index(name = "idx_user", columnList = "user_id")
+        }
+)
+public class UserGenreRawScore extends BaseTimeEntity {
+
+    @EmbeddedId
+    private UserGenreRawScoreId id;
+
+    @Column(name = "raw_score", nullable = false)
+    private long rawScore;
+
+    public Long getUserId() {
+        return id.getUserId();
+    }
+
+    public Genre getGenre() {
+        return id.getGenre();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreRawScoreId.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreRawScoreId.java
@@ -1,0 +1,29 @@
+package com.storix.domain.domains.genrescore.domain;
+
+import com.storix.domain.domains.works.domain.Genre;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "of")
+public class UserGenreRawScoreId implements Serializable {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "genre", nullable = false, length = 30)
+    private Genre genre;
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreScoreLog.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreScoreLog.java
@@ -1,0 +1,68 @@
+package com.storix.domain.domains.genrescore.domain;
+
+import com.storix.common.model.BaseTimeEntity;
+import com.storix.domain.domains.genrescore.event.GenreScoreEvent;
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.works.domain.Genre;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_genre_score_log",
+        indexes = {
+                @Index(name = "idx_unprocessed", columnList = "processed_at, created_at"),
+                @Index(name = "idx_user_event", columnList = "user_id, event_type, works_id")
+        }
+)
+public class UserGenreScoreLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "works_id")
+    private Long worksId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "genre", nullable = false, length = 30)
+    private Genre genre;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 40)
+    private GenreScoreEventType eventType;
+
+    @Column(name = "weight", nullable = false)
+    private int weight;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    @Builder
+    private UserGenreScoreLog(Long userId, Long worksId, Genre genre, GenreScoreEventType eventType, int weight) {
+        this.userId = userId;
+        this.worksId = worksId;
+        this.genre = genre;
+        this.eventType = eventType;
+        this.weight = weight;
+    }
+
+    public static UserGenreScoreLog from(GenreScoreEvent event) {
+        return UserGenreScoreLog.builder()
+                .userId(event.userId())
+                .worksId(event.worksId())
+                .genre(event.genre())
+                .eventType(event.type())
+                .weight(event.type().getWeight())
+                .build();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/event/GenreScoreEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/event/GenreScoreEvent.java
@@ -1,0 +1,15 @@
+package com.storix.domain.domains.genrescore.event;
+
+import com.storix.domain.domains.works.domain.Genre;
+
+public record GenreScoreEvent(
+        Long userId,
+        Long worksId,
+        Genre genre,
+        GenreScoreEventType type
+) {
+
+    public static GenreScoreEvent of(Long userId, Long worksId, Genre genre, GenreScoreEventType type) {
+        return new GenreScoreEvent(userId, worksId, genre, type);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/event/GenreScoreEventType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/event/GenreScoreEventType.java
@@ -1,0 +1,17 @@
+package com.storix.domain.domains.genrescore.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GenreScoreEventType {
+
+    ONBOARDING_SELECT(5),
+    TOPIC_ROOM_JOIN(4),
+    REVIEW_WRITE_POSITIVE(4),
+    BOARD_WRITE(3),
+    FAVORITE_WORKS_ADD(3);
+
+    private final int weight;
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/listener/GenreScoreLogListener.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/listener/GenreScoreLogListener.java
@@ -1,0 +1,36 @@
+package com.storix.domain.domains.genrescore.listener;
+
+import com.storix.domain.domains.genrescore.domain.UserGenreScoreLog;
+import com.storix.domain.domains.genrescore.event.GenreScoreEvent;
+import com.storix.domain.domains.genrescore.repository.UserGenreScoreLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GenreScoreLogListener {
+
+    private final UserGenreScoreLogRepository logRepository;
+
+    // 트랜잭션 커밋 후 반영
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void on(GenreScoreEvent event) {
+        if (event.userId() == null || event.genre() == null) {
+            log.warn(">>> [GenreScore] invalid event dropped: {}", event);
+            return;
+        }
+
+        try {
+            logRepository.save(UserGenreScoreLog.from(event));
+        } catch (Exception e) {
+            log.error(">>> [GenreScore] log persist failed for event={}, cause={}", event, e.getMessage());
+        }
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/publisher/GenreScorePublisher.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/publisher/GenreScorePublisher.java
@@ -1,0 +1,66 @@
+package com.storix.domain.domains.genrescore.publisher;
+
+import com.storix.domain.domains.genrescore.event.GenreScoreEvent;
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.works.application.port.LoadWorksPort;
+import com.storix.domain.domains.works.domain.Genre;
+import com.storix.domain.domains.works.domain.Works;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GenreScorePublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+    private final LoadWorksPort loadWorksPort;
+
+    // 작품 id값만 알고 있는 발행 지점 publish
+    public void publish(Long userId, Long worksId, GenreScoreEventType type) {
+        try {
+            Genre genre = loadWorksPort.findById(worksId).getGenre();
+            if (genre == null) {
+                log.warn(">>> [GenreScore] genre missing for worksId={}, type={}", worksId, type);
+                return;
+            }
+            eventPublisher.publishEvent(GenreScoreEvent.of(userId, worksId, genre, type));
+        } catch (Exception e) {
+            log.warn(">>> [GenreScore] publish failed userId={}, worksId={}, type={}, cause={}",
+                    userId, worksId, type, e.getMessage());
+        }
+    }
+
+    // genre 값만 알고 있는 발행 지점 publish
+    public void publishWithGenre(Long userId, Long worksId, Genre genre, GenreScoreEventType type) {
+        if (genre == null) {
+            log.warn(">>> [GenreScore] genre missing publishWithGenre worksId={}, type={}", worksId, type);
+            return;
+        }
+        try {
+            eventPublisher.publishEvent(GenreScoreEvent.of(userId, worksId, genre, type));
+        } catch (Exception e) {
+            log.warn(">>> [GenreScore] publish failed userId={}, worksId={}, type={}, cause={}",
+                    userId, worksId, type, e.getMessage());
+        }
+    }
+
+    // 여러 작품 발행 지점 publish
+    public void publishBatch(Long userId, Collection<Long> worksIds, GenreScoreEventType type) {
+        if (worksIds == null || worksIds.isEmpty()) return;
+        try {
+            for (Works works : loadWorksPort.findWorksByIds(worksIds.stream().toList())) {
+                if (works.getGenre() == null) continue;
+                eventPublisher.publishEvent(
+                        GenreScoreEvent.of(userId, works.getId(), works.getGenre(), type));
+            }
+        } catch (Exception e) {
+            log.warn(">>> [GenreScore] batch publish failed userId={}, type={}, cause={}",
+                    userId, type, e.getMessage());
+        }
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreRawScoreRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreRawScoreRepository.java
@@ -1,0 +1,32 @@
+package com.storix.domain.domains.genrescore.repository;
+
+import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
+import com.storix.domain.domains.genrescore.domain.UserGenreRawScoreId;
+import com.storix.domain.domains.works.domain.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserGenreRawScoreRepository extends JpaRepository<UserGenreRawScore, UserGenreRawScoreId> {
+
+    List<UserGenreRawScore> findAllByIdUserId(Long userId);
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO user_genre_raw_score (user_id, genre, raw_score, created_at, updated_at)
+            VALUES (:userId, :genre, :delta, NOW(), NOW())
+            ON DUPLICATE KEY UPDATE
+                raw_score = raw_score + :delta,
+                updated_at = NOW()
+            """, nativeQuery = true)
+    void upsertAdd(@Param("userId") Long userId,
+                   @Param("genre") String genre,
+                   @Param("delta") long delta);
+
+    default void upsertAdd(Long userId, Genre genre, long delta) {
+        upsertAdd(userId, genre.name(), delta);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreScoreLogRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreScoreLogRepository.java
@@ -1,0 +1,38 @@
+package com.storix.domain.domains.genrescore.repository;
+
+import com.storix.domain.domains.genrescore.domain.UserGenreScoreLog;
+import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface UserGenreScoreLogRepository extends JpaRepository<UserGenreScoreLog, Long> {
+
+    // 미처리 로그를 id 오름차순, 청크 단위로 조회
+    @Query("""
+            SELECT new com.storix.domain.domains.genrescore.dto.UnprocessedLogRow(l.id, l.userId, l.genre, l.weight)
+            FROM UserGenreScoreLog l
+            WHERE l.processedAt IS NULL
+            ORDER BY l.id ASC
+    """)
+    List<UnprocessedLogRow> findUnprocessedChunk(Pageable pageable);
+
+    // 미처리 로그 -> 처리 로그 (벌크 업데이트)
+    @Modifying
+    @Query("""
+            UPDATE UserGenreScoreLog l
+            SET l.processedAt = :now
+            WHERE l.processedAt IS NULL AND l.id <= :maxId
+    """)
+    int markProcessedUntil(@Param("maxId") Long maxId, @Param("now") LocalDateTime now);
+
+
+    @Modifying
+    @Query("DELETE FROM UserGenreScoreLog l WHERE l.processedAt IS NOT NULL AND l.processedAt < :threshold")
+    int deleteProcessedBefore(@Param("threshold") LocalDateTime threshold);
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreAggregationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreAggregationService.java
@@ -1,0 +1,70 @@
+package com.storix.domain.domains.genrescore.service;
+
+import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
+import com.storix.domain.domains.genrescore.repository.UserGenreRawScoreRepository;
+import com.storix.domain.domains.genrescore.repository.UserGenreScoreLogRepository;
+import com.storix.domain.domains.works.domain.Genre;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class GenreScoreAggregationService {
+
+    public static final int DEFAULT_CHUNK_SIZE = 1000;
+    public static final int LOG_RETENTION_DAYS = 30;
+
+    private final UserGenreScoreLogRepository logRepository;
+    private final UserGenreRawScoreRepository rawScoreRepository;
+
+    // 미처리 로그를 청크 단위로 처리
+    @Transactional
+    public ChunkResult processChunk(int chunkSize) {
+        // 1. 미처리 로그 조회
+        List<UnprocessedLogRow> rows = logRepository.findUnprocessedChunk(PageRequest.of(0, chunkSize));
+        if (rows.isEmpty()) return ChunkResult.empty();
+
+        // 2. (user, genre)별 가중치 합산
+        Map<UserGenreKey, Long> sums = new HashMap<>();
+        Set<Long> users = new HashSet<>();
+        long maxId = 0L;
+
+        for (UnprocessedLogRow row : rows) {
+            sums.merge(new UserGenreKey(row.userId(), row.genre()), row.weight().longValue(), Long::sum);
+            users.add(row.userId());
+            if (row.id() > maxId) maxId = row.id();
+        }
+
+        // 3. raw_score 테이블 UPSERT
+        sums.forEach((key, sum) -> rawScoreRepository.upsertAdd(key.userId(), key.genre(), sum));
+
+        // 4. 로그 처리
+        logRepository.markProcessedUntil(maxId, LocalDateTime.now());
+
+        return new ChunkResult(rows.size(), sums.size(), users);
+    }
+
+    // 처리된 로그 삭제
+    @Transactional
+    public int cleanupOldProcessed() {
+        return logRepository.deleteProcessedBefore(LocalDateTime.now().minusDays(LOG_RETENTION_DAYS));
+    }
+
+    public record ChunkResult(int processedLogs, int groups, Set<Long> users) {
+        public static ChunkResult empty() {
+            return new ChunkResult(0, 0, Collections.emptySet());
+        }
+    }
+
+    private record UserGenreKey(Long userId, Genre genre) {}
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
@@ -1,0 +1,38 @@
+package com.storix.domain.domains.genrescore.service;
+
+import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
+import com.storix.domain.domains.genrescore.repository.UserGenreRawScoreRepository;
+import com.storix.domain.domains.preference.dto.GenreScoreInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GenreScoreQueryService {
+
+    private static final double PERCENT_SCALE = 100.0;
+
+    private final UserGenreRawScoreRepository rawScoreRepository;
+
+    // 장르별 raw_score 비율 정규화 (전체 합 대비 백분율 0~100, 정수 반올림 변환)
+    @Transactional(readOnly = true)
+    public List<GenreScoreInfo> getRatioNormalized(Long userId) {
+        return normalize(rawScoreRepository.findAllByIdUserId(userId));
+    }
+
+    private List<GenreScoreInfo> normalize(List<UserGenreRawScore> scores) {
+        long total = scores.stream().mapToLong(UserGenreRawScore::getRawScore).sum();
+        if (total == 0) return Collections.emptyList();
+
+        return scores.stream()
+                .map(s -> new GenreScoreInfo(
+                        s.getGenre().getDbValue(),
+                        (double) Math.round(s.getRawScore() / (double) total * PERCENT_SCALE)
+                ))
+                .toList();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
@@ -3,12 +3,15 @@ package com.storix.domain.domains.genrescore.service;
 import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
 import com.storix.domain.domains.genrescore.repository.UserGenreRawScoreRepository;
 import com.storix.domain.domains.preference.dto.GenreScoreInfo;
+import com.storix.domain.domains.works.domain.Genre;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,20 +22,24 @@ public class GenreScoreQueryService {
     private final UserGenreRawScoreRepository rawScoreRepository;
 
     // 장르별 raw_score 비율 정규화 (전체 합 대비 백분율 0~100, 정수 반올림 변환)
-    @Transactional(readOnly = true)
     public List<GenreScoreInfo> getRatioNormalized(Long userId) {
-        return normalize(rawScoreRepository.findAllByIdUserId(userId));
+        List<UserGenreRawScore> scores = rawScoreRepository.findAllByIdUserId(userId);
+        return normalize(scores);
     }
 
     private List<GenreScoreInfo> normalize(List<UserGenreRawScore> scores) {
         long total = scores.stream().mapToLong(UserGenreRawScore::getRawScore).sum();
-        if (total == 0) return Collections.emptyList();
 
-        return scores.stream()
-                .map(s -> new GenreScoreInfo(
-                        s.getGenre().getDbValue(),
-                        (double) Math.round(s.getRawScore() / (double) total * PERCENT_SCALE)
-                ))
+        Map<Genre, Long> rawByGenre = scores.stream()
+                .collect(Collectors.toMap(UserGenreRawScore::getGenre, UserGenreRawScore::getRawScore));
+
+        return Arrays.stream(Genre.values())
+                .map(g -> {
+                    long raw = rawByGenre.getOrDefault(g, 0L);
+                    double score = total == 0 ? 0.0 : Math.round(raw / (double) total * PERCENT_SCALE);
+                    return new GenreScoreInfo(g.getDbValue(), score);
+                })
+                .sorted(Comparator.comparing(GenreScoreInfo::score).reversed())
                 .toList();
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/BoardService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/BoardService.java
@@ -1,5 +1,7 @@
 package com.storix.domain.domains.plus.service;
 
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
 import com.storix.domain.domains.plus.adaptor.BoardAdaptor;
 import com.storix.domain.domains.plus.adaptor.BoardImageAdaptor;
@@ -21,6 +23,8 @@ public class BoardService {
 
     private final AdultWorksHelper adultWorksHelper;
 
+    private final GenreScorePublisher genreScorePublisher;
+
     // 독자 게시물 생성
     @Transactional
     public void createReaderBoard(CreateReaderBoardCommand cmd) {
@@ -40,6 +44,10 @@ public class BoardService {
         }
 
         libraryAdaptor.incrementBoardCount(cmd.userId());
+
+        if (cmd.isWorksSelected() && cmd.worksId() != null) {
+            genreScorePublisher.publish(cmd.userId(), cmd.worksId(), GenreScoreEventType.BOARD_WRITE);
+        }
     }
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReviewService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReviewService.java
@@ -1,5 +1,7 @@
 package com.storix.domain.domains.plus.service;
 
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
 import com.storix.domain.domains.plus.adaptor.ReviewAdaptor;
 import com.storix.domain.domains.plus.domain.Review;
@@ -42,6 +44,10 @@ public class ReviewService {
 
     private final AdultWorksHelper adultWorksHelper;
 
+    private final GenreScorePublisher genreScorePublisher;
+
+    private static final double POSITIVE_REVIEW_THRESHOLD = 3.0;
+
     // 플러스탭
     @Transactional
     public ReaderReviewRedirectResponse createReview(CreateReviewCommand cmd) {
@@ -58,6 +64,10 @@ public class ReviewService {
 
         // 작품 도메인 업데이트
         loadWorksPort.updateIncrementingReviewInfoToWorks(cmd.worksId(), cmd.rating().getRatingValue());
+
+        if (cmd.rating().getRatingValue() >= POSITIVE_REVIEW_THRESHOLD) {
+            genreScorePublisher.publish(cmd.libraryUserId(), cmd.worksId(), GenreScoreEventType.REVIEW_WRITE_POSITIVE);
+        }
 
         return new ReaderReviewRedirectResponse(review.getWorksId(), review.getLibraryUserId(), review.getId());
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/application/ExplorationUseCase.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/application/ExplorationUseCase.java
@@ -3,7 +3,6 @@ package com.storix.domain.domains.preference.application;
 import com.storix.domain.domains.preference.dto.ExplorationResultResponseDto;
 import com.storix.domain.domains.preference.dto.ExplorationSubmitRequestDto;
 import com.storix.domain.domains.preference.dto.ExplorationWorksResponseDto;
-import com.storix.domain.domains.preference.dto.GenreScoreInfo;
 
 import java.util.List;
 
@@ -17,7 +16,4 @@ public interface ExplorationUseCase {
 
     // 결과 모아보기
     ExplorationResultResponseDto getExplorationResults(Long userId);
-
-    // 마이페이지용 누적 통계
-    List<GenreScoreInfo> getCumulativeStats(Long userId);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/repository/ExplorationRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/repository/ExplorationRepository.java
@@ -28,11 +28,6 @@ public interface ExplorationRepository extends JpaRepository<PreferenceExplorati
             @Param("threshold") LocalDateTime threshold
     );
 
-    // 마이페이지 누적 차트용
-    @Query("SELECT w.genre, COUNT(w) FROM PreferenceExploration pe JOIN Works w ON pe.worksId = w.id " +
-            "WHERE pe.userId = :userId AND pe.isLiked = true GROUP BY w.genre")
-    List<Object[]> countLikedGenresByUserId(@Param("userId") Long userId);
-
     @Query("SELECT pe.worksId FROM PreferenceExploration pe WHERE pe.userId = :userId")
     List<Long> findRespondedWorksIdsByUserId(@Param("userId") Long userId);
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
@@ -9,7 +9,6 @@ import com.storix.domain.domains.favorite.adaptor.FavoriteWorksAdaptor;
 import com.storix.domain.domains.preference.exception.DuplicatedExplorationException;
 import com.storix.domain.domains.preference.repository.ExplorationRepository;
 import com.storix.domain.domains.works.application.port.LoadWorksPort;
-import com.storix.domain.domains.works.domain.Genre;
 import com.storix.domain.domains.works.domain.Works;
 import com.storix.domain.domains.works.dto.LibraryWorksInfo;
 import lombok.RequiredArgsConstructor;
@@ -124,26 +123,6 @@ public class ExplorationService implements ExplorationUseCase {
                 .likedWorks(toLibraryWorksInfoList(allLiked))
                 .dislikedWorks(toLibraryWorksInfoList(allDisliked))
                 .build();
-    }
-
-    @Override
-    public List<GenreScoreInfo> getCumulativeStats(Long userId) {
-        return cacheHelper.getOrGenerateChart(userId, () -> {
-            List<Object[]> raw = explorationRepository.countLikedGenresByUserId(userId);
-            return transformToScoreInfo(raw);
-        });
-    }
-
-    private List<GenreScoreInfo> transformToScoreInfo(List<Object[]> rawCounts) {
-        long totalLiked = rawCounts.stream().mapToLong(row -> (long) row[1]).sum();
-        if (totalLiked == 0) return Collections.emptyList();
-
-        return rawCounts.stream()
-                .map(row -> new GenreScoreInfo(
-                        ((Genre) row[0]).getDbValue(),
-                        Math.round(((long) row[1] / (double) totalLiked) * 5.0 * 10) / 10.0
-                ))
-                .toList();
     }
 
     private List<LibraryWorksInfo> toLibraryWorksInfoList(List<Works> worksList) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -1,5 +1,7 @@
 package com.storix.domain.domains.topicroom.service;
 
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.search.dto.PlusSearchResponseWrapperDto;
 import com.storix.domain.domains.search.dto.SearchResponseWrapperDto;
 import com.storix.domain.domains.search.dto.TrendingItem;
@@ -49,6 +51,7 @@ public class TopicRoomService implements TopicRoomUseCase {
     private final SearchHistoryService searchHistoryService;
     private final ProfanityFilterService profanityFilterService;
     private final LoadTopicRoomUserPort loadTopicRoomMemberPort;
+    private final GenreScorePublisher genreScorePublisher;
 
     @Override
     public Slice<TopicRoomResponseDto> getMyJoinedRooms(Long userId, Pageable pageable) {
@@ -190,6 +193,9 @@ public class TopicRoomService implements TopicRoomUseCase {
             recordTopicRoomPort.saveParticipation(user.getId(), savedRoom, TopicRoomRole.HOST);
             recordTopicRoomPort.incrementActiveUserNumber(savedRoom.getId());
 
+            genreScorePublisher.publishWithGenre(
+                    user.getId(), works.getId(), works.getGenre(), GenreScoreEventType.TOPIC_ROOM_JOIN);
+
             return savedRoom.getId();
         } catch (DataIntegrityViolationException e) {
 
@@ -213,6 +219,9 @@ public class TopicRoomService implements TopicRoomUseCase {
         try {
             recordTopicRoomPort.saveParticipation(userId, room, TopicRoomRole.MEMBER);
             recordTopicRoomPort.incrementActiveUserNumber(roomId);
+
+            genreScorePublisher.publishWithGenre(
+                    userId, works.getId(), works.getGenre(), GenreScoreEventType.TOPIC_ROOM_JOIN);
         } catch (DataIntegrityViolationException e) {
             throw AlreadyJoinedException.EXCEPTION;
         }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.storix.domain.domains.user.service;
 
 import com.storix.domain.domains.favorite.adaptor.FavoriteWorksAdaptor;
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
 import com.storix.domain.domains.onboarding.service.OnboardingWorksHelper;
 import com.storix.domain.domains.user.dto.CreateReaderUserCommand;
@@ -26,6 +28,7 @@ public class AuthService {
     private final LibraryAdaptor libraryAdaptor;
     private final TokenAdaptor tokenAdaptor;
     private final FavoriteWorksAdaptor favoriteWorksAdaptor;
+    private final GenreScorePublisher genreScorePublisher;
 
     // 독자 회원 가입 가능 여부 (토큰 검증, 계정 정보 유무)
     // - 카카오
@@ -79,6 +82,10 @@ public class AuthService {
 
         if (cmd.favoriteWorksIdList() != null && !cmd.favoriteWorksIdList().isEmpty()) {
             favoriteWorksAdaptor.saveFavoriteWorks(authUserDetails.getUserId(), cmd.favoriteWorksIdList());
+            genreScorePublisher.publishBatch(
+                    authUserDetails.getUserId(),
+                    cmd.favoriteWorksIdList(),
+                    GenreScoreEventType.ONBOARDING_SELECT);
         }
         libraryAdaptor.initLibrary(authUserDetails.getUserId());
 


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 유저 행동 로그 기반 장르 점수 도메인 신규 추가

[기존]                                      
취향 탐색(좋아요/싫어요) 카운트만으로 5점 척도 통계를 계산.
                                            
[변경 후]                                                                                                                                            
5가지 가중치 이벤트(+5/+4/+4/+3/+3)를 누적해 장르별 점수를 산출하는 신규 genrescore 도메인 추가.
- GenreScoreEventType (가중치 enum) / GenreScoreEvent (도메인 이벤트 record) 신규                                                                    
- UserGenreScoreLog (행동 이벤트 원장, append-only) 엔티티 + Repository           
- UserGenreRawScore + UserGenreRawScoreId (@EmbeddedId 복합키) 엔티티 + Repository                                                                   
                                                                                                                                                     
### 2. Spring Event 기반 발행/수신 인프라                                                                                                                                           
도메인 트랜잭션 커밋 직후 별도 트랜잭션으로 점수 로그를 적재. 
발행자/도메인 결합도를 끊어 도메인이 점수 시스템을 직접 참조하지 않도록 분리.
- GenreScorePublisher 신규 — publish (worksId만 알 때) / publishWithGenre (genre를 호출자가 보유) / publishBatch (다건 worksId 일괄)                 
- GenreScoreLogListener 신규 — @TransactionalEventListener(AFTER_COMMIT) + @Transactional(REQUIRES_NEW). 메인 트랜잭션 영향 없음, 리스너 실패 시 1건
유실 허용 (자정 배치 멱등성에 의존)                                                                                                                  
                                                                                                                                                     
### 3. 발행 지점 통합 — 5개 도메인                                                                                                                                                     
- FavoriteService.saveFavoriteWorks: FAVORITE_WORKS_ADD (+3) 발행                                                                                    
- ReviewService.createReview: rating ≥ 3.0인 경우만 REVIEW_WRITE_POSITIVE (+4)
- BoardService.createReaderBoard: isWorksSelected && worksId != null일 때만 BOARD_WRITE (+3)                                                         
- TopicRoomService.createRoom / joinRoom: 호스트/멤버 모두 TOPIC_ROOM_JOIN (+4) — 이미 조회된 Works.getGenre() 재활용해 publishWithGenre로 추가
SELECT 회피                                                                                                                                          
- AuthService.signUpReaderUser: 온보딩 작품 리스트로 ONBOARDING_SELECT (+5) batch 발행
                                                                                                                                                     
### 4. 자정 배치 — 청크 단위 집계                                                                                                                                                                                                          
매일 자정(Asia/Seoul) 미처리 로그를 청크 1000건 단위로 트랜잭션 분리해 누적. RDS 락 경합/커넥션 점유 시간 최소화.
- GenreScoreAggregationService.processChunk 신규 — 청크별 @Transactional, 메모리 GROUP BY → raw_score UPSERT → markProcessedUntil                    
- GenreScoreAggregationScheduler 신규 — @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul"), 청크 사이 100ms 휴식, MAX_ITERATIONS = 10_000
- 청크 fetch는 LIMIT 기반 raw 로그 조회 + record projection (UnprocessedLogRow)으로 타입 안전 보장 (Object[] 마법 인덱스 회피)                       
- 30일 이상 처리된 로그 자동 정리 (cleanupOldProcessed)                                                                                              
- self-invocation 회피 위해 도메인 모듈에 Service 분리, 배치 모듈은 루프/안전장치만 담당                                                             
                                                                                                                                                     
### 5. 정규화 응답                                                                                                                            
프로필 도메인 책임으로 이관 + 응답 척도를 백분율(0~100, 정수 반올림)로 변경                                      
- GenreScoreQueryService.getRatioNormalized 신규 — user_genre_raw_score 직접 조회 후 total 대비 100점 환산                                           
- ProfileFavoriteUseCase.getGenreStats 추가 — GenreScoreQueryService 위임                                 
- ProfileController.getStats가 ExplorationUseCase 의존 제거 후 profileFavoriteUseCase.getGenreStats 호출 (응답 스펙은 동일)                          
- SuccessCode.PROFILE_GENRE_STATS_LOAD_SUCCESS (PROFILE_SUCCESS_013) 추가                               

### 6. 기타
- 기존 선호 장르 통계 로직 정리


## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #57 

## 🖇️ 기타
카프카 도입 시 자정 배치 -> 스트림 처리로 전환 고려 중입니다