### PR TITLE
Release v2.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: STORIX CI - Build & Push to ECR
 on:
   push:
     branches:
-      - main
+      - develop
 
 jobs:
   build-and-push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: STORIX CI - Build & Push to ECR
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   build-and-push:

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ out/
 !gradle/wrapper/gradle-wrapper.properties
 
 .omc/state
+/storix-db-tunnel.sh

--- a/STORIX-Api/src/main/java/com/storix/api/domain/preference/PreferenceController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/preference/PreferenceController.java
@@ -60,15 +60,4 @@ public class PreferenceController {
                 explorationUseCase.getExplorationResults(authUserDetails.getUserId()));
     }
 
-    // 마이페이지 누적 조회
-    @Operation(summary = "마이페이지 선호 장르 통계", description = "레이더 차트용 선호 장르별 점수를 조회합니다.")
-    @GetMapping("/stats")
-    public CustomResponse<List<GenreScoreInfo>> getStats(
-            @AuthenticationPrincipal AuthUserDetails authUserDetails
-    ) {
-        return CustomResponse.onSuccess(
-                SuccessCode.SUCCESS,
-                explorationUseCase.getCumulativeStats(authUserDetails.getUserId())
-        );
-    }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/preference/PreferenceController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/preference/PreferenceController.java
@@ -4,7 +4,6 @@ import com.storix.domain.domains.preference.application.ExplorationUseCase;
 import com.storix.domain.domains.preference.dto.ExplorationResultResponseDto;
 import com.storix.domain.domains.preference.dto.ExplorationSubmitRequestDto;
 import com.storix.domain.domains.preference.dto.ExplorationWorksResponseDto;
-import com.storix.domain.domains.preference.dto.GenreScoreInfo;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.common.payload.CustomResponse;
 import com.storix.common.code.SuccessCode;

--- a/STORIX-Api/src/main/java/com/storix/api/domain/profile/controller/ProfileController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/profile/controller/ProfileController.java
@@ -1,6 +1,7 @@
 package com.storix.api.domain.profile.controller;
 
 import com.storix.domain.domains.feed.dto.ReaderBoardReplyInfoWithProfile;
+import com.storix.domain.domains.preference.dto.GenreScoreInfo;
 import com.storix.domain.domains.profile.dto.*;
 import com.storix.api.domain.profile.usecase.ProfileActivityUseCase;
 import com.storix.api.domain.profile.usecase.ProfileFavoriteUseCase;
@@ -22,6 +23,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Validated
 @RestController
@@ -111,6 +114,16 @@ public class ProfileController {
     ) {
         return ResponseEntity.ok()
                 .body(profileFavoriteUseCase.getRatingDistribution(authUserDetails.getUserId()));
+    }
+
+    // 마이페이지 누적 조회
+    @Operation(summary = "[독자] 선호 장르 통계 조회", description = "선호 장르별 점수를 조회합니다.")
+    @GetMapping("/reader/stats")
+    public ResponseEntity<CustomResponse<List<GenreScoreInfo>>> getStats(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails
+    ) {
+        return ResponseEntity.ok()
+                .body(profileFavoriteUseCase.getGenreStats(authUserDetails.getUserId()));
     }
 
     // 선호 해시태그 조회

--- a/STORIX-Api/src/main/java/com/storix/api/domain/profile/usecase/ProfileFavoriteUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/profile/usecase/ProfileFavoriteUseCase.java
@@ -1,6 +1,8 @@
 package com.storix.api.domain.profile.usecase;
 
 import com.storix.common.annotation.UseCase;
+import com.storix.domain.domains.genrescore.service.GenreScoreQueryService;
+import com.storix.domain.domains.preference.dto.GenreScoreInfo;
 import com.storix.domain.domains.profile.dto.FavoriteWorksWithReviewInfo;
 import com.storix.domain.domains.profile.dto.FavoriteHashtagsResponse;
 import com.storix.domain.domains.profile.dto.ProfileFavoriteWorksWrapperDto;
@@ -12,11 +14,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
 @UseCase
 @RequiredArgsConstructor
 public class ProfileFavoriteUseCase {
 
     private final ProfileFavoriteService profileFavoriteService;
+    private final GenreScoreQueryService genreScoreQueryService;
 
     // 관심 작품 조회
     public CustomResponse<ProfileFavoriteWorksWrapperDto<FavoriteWorksWithReviewInfo>> getFavoriteWorksList(Long userId, Pageable pageable) {
@@ -44,5 +49,12 @@ public class ProfileFavoriteUseCase {
 
         FavoriteHashtagsResponse result = profileFavoriteService.findFavoriteHashtagsByUserId(userId);
         return CustomResponse.onSuccess(SuccessCode.PROFILE_FAVORITE_HASHTAGS_LOAD_SUCCESS, result);
+    }
+
+    // 선호 장르 통계 조회 (비율 정규화)
+    public CustomResponse<List<GenreScoreInfo>> getGenreStats(Long userId) {
+
+        List<GenreScoreInfo> result = genreScoreQueryService.getRatioNormalized(userId);
+        return CustomResponse.onSuccess(SuccessCode.PROFILE_GENRE_STATS_LOAD_SUCCESS, result);
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.storix.api.domain.user.controller.dto.AuthorizationResponse;
 import com.storix.api.domain.user.controller.dto.KakaoNativeLoginRequest;
 import com.storix.api.domain.user.controller.dto.NaverNativeLoginRequest;
 import com.storix.api.domain.user.controller.dto.ReaderSocialLoginResponse;
+import com.storix.api.domain.user.controller.dto.RefreshTokenRequest;
 import com.storix.api.domain.user.usecase.*;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.domain.domains.user.adaptor.OnboardingUserDetails;
@@ -117,13 +118,18 @@ public class AuthController {
                 .body(authUseCase.checkAvailableNickname(nickName));
     }
 
-    @Operation(summary = "토큰 재발급", description = "액세스 토큰을 리프레쉬 토큰 쿠키와 함께 재발급하는 api 입니다.   \n액세스 토큰 만료 시 호출해주세요.")
+    @Operation(summary = "토큰 재발급", description = "액세스 토큰을 재발급하는 api 입니다. 액세스 토큰 만료 시 호출해주세요.  \n" +
+            "- Web   : 요청에 Cookie 붙여서 호출 -> 응답 body로 accessToken, Set-Cookie로 refreshToken 재발급  \n" +
+            "- Native: RequestBody에 refreshToken 담아 전송 -> 응답 body로 access/refreshToken 재발급")
     @PostMapping("/tokens/refresh")
     public ResponseEntity<CustomResponse<AuthorizationResponse>> reissueAccessToken(
             @Parameter(hidden = true)
-            @CookieValue(value = "refreshToken", required = false) String refreshToken
+            @CookieValue(value = "refreshToken", required = false) String cookieRefreshToken,
+
+            @RequestBody(required = false) RefreshTokenRequest body
     ) {
-        return authorizationUseCase.getTokenRefresh(refreshToken);
+        String bodyRefreshToken = (body != null) ? body.refreshToken() : null;
+        return authorizationUseCase.getTokenRefresh(cookieRefreshToken, bodyRefreshToken);
     }
 
     @Operation(summary = "로그아웃", description = "로그아웃용 api 입니다.   \n액세스 토큰을 보내주세요.")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.storix.api.domain.user.controller;
 
 import com.storix.api.domain.user.controller.dto.AuthorizationResponse;
+import com.storix.api.domain.user.controller.dto.KakaoNativeLoginRequest;
+import com.storix.api.domain.user.controller.dto.NaverNativeLoginRequest;
 import com.storix.api.domain.user.controller.dto.ReaderSocialLoginResponse;
 import com.storix.api.domain.user.usecase.*;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
@@ -45,7 +47,9 @@ public class AuthController {
         return oauthLoginUseCase.readerOAuthLogin(req, OAuthProvider.KAKAO);
     }
 
-    @Operation(summary = "네이버 로그인", description = "네이버로 로그인 하는 api 입니다.  \n회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
+    @Operation(summary = "네이버 로그인", description = "네이버로 로그인 하는 api 입니다.  \n" +
+            "회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n" +
+            "회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
     @GetMapping("/oauth/naver/login")
     public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> naverLogin(
             @RequestParam("code") String code,
@@ -55,13 +59,37 @@ public class AuthController {
         return oauthLoginUseCase.readerOAuthLogin(req, OAuthProvider.NAVER);
     }
 
-    @Operation(summary = "애플 로그인", description = "애플로 로그인 하는 api 입니다.  \n회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
+    @Operation(summary = "애플 로그인", description = "애플로 로그인 하는 api 입니다.  \n" +
+            "회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n" +
+            "회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
     @GetMapping("/oauth/apple/login")
     public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> appleLogin(
             @RequestParam("code") String code
     ) {
-        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forApple(code);
-        return oauthLoginUseCase.readerOAuthLogin(req, OAuthProvider.APPLE);
+        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forAppleNative(code);
+        return oauthLoginUseCase.readerOAuthNativeLogin(req, OAuthProvider.APPLE);
+    }
+
+    @Operation(summary = "카카오 네이티브 로그인", description = "iOS/Android 네이티브 SDK에서 받은 accessToken/idToken을 그대로 검증하여 로그인합니다.  \n" +
+            "회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n" +
+            "회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
+    @PostMapping("/oauth/kakao-native/login")
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> kakaoNativeLogin(
+            @Valid @RequestBody KakaoNativeLoginRequest body
+    ) {
+        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forKakaoNative(body.accessToken(), body.idToken());
+        return oauthLoginUseCase.readerOAuthNativeLogin(req, OAuthProvider.KAKAO);
+    }
+
+    @Operation(summary = "네이버 네이티브 로그인", description = "iOS/Android 네이티브 SDK에서 받은 accessToken을 그대로 검증하여 로그인합니다.  \n" +
+            "회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n" +
+            "회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
+    @PostMapping("/oauth/naver-native/login")
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> naverNativeLogin(
+            @Valid @RequestBody NaverNativeLoginRequest body
+    ) {
+        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forNaverNative(body.accessToken());
+        return oauthLoginUseCase.readerOAuthNativeLogin(req, OAuthProvider.NAVER);
     }
 
     @Operation(summary = "독자 계정 회원가입", description = "유저 정보를 최종적으로 등록하는 api 입니다.  \n온보딩 토큰을 보내주세요.")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/AuthorizationResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/AuthorizationResponse.java
@@ -1,6 +1,17 @@
 package com.storix.api.domain.user.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record AuthorizationResponse(
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {
+    public static AuthorizationResponse webRefresh(String accessToken) {
+        return new AuthorizationResponse(accessToken, null);
+    }
+
+    public static AuthorizationResponse nativeRefresh(String accessToken, String refreshToken) {
+        return new AuthorizationResponse(accessToken, refreshToken);
+    }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/KakaoNativeLoginRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/KakaoNativeLoginRequest.java
@@ -1,0 +1,12 @@
+package com.storix.api.domain.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoNativeLoginRequest(
+        @NotBlank(message = "accessToken은 필수입니다.")
+        String accessToken,
+
+        @NotBlank(message = "idToken은 필수입니다.")
+        String idToken
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/NaverNativeLoginRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/NaverNativeLoginRequest.java
@@ -1,0 +1,9 @@
+package com.storix.api.domain.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record NaverNativeLoginRequest(
+        @NotBlank(message = "accessToken은 필수입니다.")
+        String accessToken
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderLoginResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderLoginResponse.java
@@ -1,6 +1,17 @@
 package com.storix.api.domain.user.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ReaderLoginResponse(
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {
+    public static ReaderLoginResponse webLogin(String accessToken) {
+        return new ReaderLoginResponse(accessToken, null);
+    }
+
+    public static ReaderLoginResponse nativeLogin(String accessToken, String refreshToken) {
+        return new ReaderLoginResponse(accessToken, refreshToken);
+    }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/RefreshTokenRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/RefreshTokenRequest.java
@@ -1,0 +1,6 @@
+package com.storix.api.domain.user.controller.dto;
+
+public record RefreshTokenRequest(
+        String refreshToken
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/OAuthHelper.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/OAuthHelper.java
@@ -125,21 +125,23 @@ public class OAuthHelper {
         if (cache != null) cache.clear();
     }
 
-    // OIDC 스펙: OIDC Config 정보 조회 (baseUrl, clientId)
-    public OIDCConfigDTO getOIDCConfig(OAuthProvider provider) {
+    // OIDC 스펙: OIDC Config (Web/Native 구분)
+    // - Kakao는 REST API Key(웹) vs Native App Key(모바일 SDK) 분기
+    public OIDCConfigDTO getOIDCConfig(OAuthProvider provider, boolean isNative) {
         switch (provider) {
             case KAKAO -> {
                 var kakao = oauthProperties.getKakao();
-                return new OIDCConfigDTO(kakao.getBaseUri(), kakao.getClientId());
+                String aud = isNative ? kakao.getNativeAppKey() : kakao.getClientId();
+                return new OIDCConfigDTO(kakao.getBaseUri(), aud);
             }
-             case NAVER ->  {
+            case NAVER -> {
                 var naver = oauthProperties.getNaver();
                 return new OIDCConfigDTO(naver.getBaseUri(), naver.getClientId());
-             }
-             case APPLE -> {
+            }
+            case APPLE -> {
                 var apple = oauthProperties.getApple();
                 return new OIDCConfigDTO(apple.getBaseUri(), apple.getClientId());
-             }
+            }
             default -> {
                 return null;
             }
@@ -147,9 +149,10 @@ public class OAuthHelper {
     }
 
     // OIDC 스펙: idToken 검증 후 OIDC Payload 반환 (iss, aud, sub)
-    public OIDCDecodePayload getOIDCDecodePayload(String idToken, OAuthProvider provider) {
+    // - Kakao는 Web(REST API Key) / Native(Native App Key) 에 따라 audience 가 다르므로 isNative 전파 필수.
+    public OIDCDecodePayload getOIDCDecodePayload(String idToken, OAuthProvider provider, boolean isNative) {
 
-        OIDCConfigDTO oidcConfig = getOIDCConfig(provider);
+        OIDCConfigDTO oidcConfig = getOIDCConfig(provider, isNative);
         OIDCPublicKeysResponse oidcPublicKeysResponse = getOIDCPublicKeys(provider);
 
         try {
@@ -162,7 +165,7 @@ public class OAuthHelper {
     }
 
     // OIDC 스펙: 검증된 idToken으로 OAuthInfo 반환 (provider, oid)
-    public OAuthInfo getOauthInfoByIdToken(String idToken, OAuthProvider provider) {
+    public OAuthInfo getOauthInfoByIdToken(String idToken, OAuthProvider provider, boolean isNative) {
         if (provider == OAuthProvider.SLACK) {
             throw UnsupportedOAuthProviderException.EXCEPTION;
         }
@@ -173,7 +176,7 @@ public class OAuthHelper {
                     .build();
         }
         // KAKAO, APPLE: OIDC idToken에서 sub 클레임 추출
-        OIDCDecodePayload oidcDecodePayload = getOIDCDecodePayload(idToken, provider);
+        OIDCDecodePayload oidcDecodePayload = getOIDCDecodePayload(idToken, provider, isNative);
         return OAuthInfo.builder()
                 .provider(provider)
                 .oid(oidcDecodePayload.sub())

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -66,7 +66,7 @@ public class AuthUseCase {
     public ResponseEntity<CustomResponse<AuthorizationResponse>> readerSignup(ReaderSignupRequest req, String jti) {
         AuthUserDetails userDetails = authService.signUpReaderUser(req, jti);
         LoginWithTokenResponse tokenResponse = tokenGenerateHelper.generateLoginWithToken(userDetails);
-        AuthorizationResponse result = new AuthorizationResponse(tokenResponse.accessToken());
+        AuthorizationResponse result = AuthorizationResponse.webRefresh(tokenResponse.accessToken());
 
         return ResponseEntity.ok()
                 .headers(cookieHelper.getTokenCookie(tokenResponse.refreshToken()))

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -35,7 +35,7 @@ public class AuthUseCase {
         return switch (provider) {
             case KAKAO -> {
                 KakaoTokenResponse kakaoToken = oauthHelper.getKakaoOAuthToken(req.authCode(), req.redirectUri());
-                yield validateKakao(kakaoToken.accessToken(), kakaoToken.idToken());
+                yield validateKakao(kakaoToken.accessToken(), kakaoToken.idToken(), false);
             }
             case NAVER -> {
                 NaverTokenResponse naverToken = oauthHelper.getNaverOAuthToken(req.authCode(), req.state());
@@ -51,7 +51,7 @@ public class AuthUseCase {
     // - Apple: SDK가 내려준 authorizationCode로 토큰을 얻은 뒤 공통 검증
     public ValidAuthDTO checkAvailableRegisterNative(OAuthAuthorizationRequest req, OAuthProvider provider) {
         return switch (provider) {
-            case KAKAO -> validateKakao(req.accessToken(), req.idToken());
+            case KAKAO -> validateKakao(req.accessToken(), req.idToken(), true);
             case NAVER -> validateNaver(req.accessToken());
             case APPLE -> {
                 AppleTokenResponse appleToken = oauthHelper.getAppleOAuthToken(req.authCode());
@@ -82,11 +82,13 @@ public class AuthUseCase {
 
 
     // Kakao 공통 검증 로직
-    private ValidAuthDTO validateKakao(String accessToken, String idToken) {
+    // - isNative=true 이면 idToken의 aud(audience) 검증을 Native App Key 로 수행
+    //   (Kakao는 Web=REST API Key / Native=Native App Key 로 idToken.aud 가 다름)
+    private ValidAuthDTO validateKakao(String accessToken, String idToken, boolean isNative) {
         // accessToken으로 사용자 정보 조회
         KakaoUserResponse kakaoUser = oauthHelper.getKakaoInformation(accessToken);
         // idToken으로 OIDC 검증
-        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, OAuthProvider.KAKAO);
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, OAuthProvider.KAKAO, isNative);
 
         // token 간 정보 일치 확인 후 회원가입 여부 반환
         if (!oauthInfo.getOid().equals(kakaoUser.id())) throw UnknownUserException.EXCEPTION;
@@ -104,9 +106,9 @@ public class AuthUseCase {
     }
 
     // Apple 공통 검증 로직
+    // - Apple은 Web/Native 모두 동일한 clientId(서비스 ID) 를 aud 로 사용하므로 isNative 구분 불필요 → false.
     private ValidAuthDTO validateApple(String idToken) {
-        // idToken으로 OIDC 검증 및 회원가입 여부 반환
-        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, OAuthProvider.APPLE);
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, OAuthProvider.APPLE, false);
         return authService.validAppleSignup(oauthInfo.getOid(), idToken);
     }
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -29,27 +29,35 @@ public class AuthUseCase {
     private final TokenGenerateHelper tokenGenerateHelper;
     private final CookieHelper cookieHelper;
 
-    // 독자 회원 가입 가능 여부
+    // 독자 회원 가입 가능 여부 (Web)
+    // - authCode로 토큰을 얻은 뒤 공통 검증
     public ValidAuthDTO checkAvailableRegister(OAuthAuthorizationRequest req, OAuthProvider provider) {
         return switch (provider) {
             case KAKAO -> {
                 KakaoTokenResponse kakaoToken = oauthHelper.getKakaoOAuthToken(req.authCode(), req.redirectUri());
-                KakaoUserResponse kakaoUser = oauthHelper.getKakaoInformation(kakaoToken.accessToken());
-                OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(kakaoToken.idToken(), OAuthProvider.KAKAO);
-                if (!oauthInfo.getOid().equals(kakaoUser.id())) throw UnknownUserException.EXCEPTION;
-                yield authService.validKakaoSignup(kakaoUser.id(), kakaoToken.idToken());
+                yield validateKakao(kakaoToken.accessToken(), kakaoToken.idToken());
             }
             case NAVER -> {
                 NaverTokenResponse naverToken = oauthHelper.getNaverOAuthToken(req.authCode(), req.state());
-                NaverUserResponse naverUser = oauthHelper.getNaverInformation(naverToken.accessToken());
-                if (naverUser.id() == null) throw FeignClientServerErrorException.EXCEPTION;
-                yield authService.validNaverSignup(naverUser.id());
+                yield validateNaver(naverToken.accessToken());
             }
+
+            case APPLE, SLACK -> throw UnsupportedOAuthProviderException.EXCEPTION;
+        };
+    }
+
+    // 독자 회원 가입 가능 여부 (Native)
+    // - Kakao/Naver: SDK가 내려준 accessToken(+idToken)으로 검증
+    // - Apple: SDK가 내려준 authorizationCode로 토큰을 얻은 뒤 공통 검증
+    public ValidAuthDTO checkAvailableRegisterNative(OAuthAuthorizationRequest req, OAuthProvider provider) {
+        return switch (provider) {
+            case KAKAO -> validateKakao(req.accessToken(), req.idToken());
+            case NAVER -> validateNaver(req.accessToken());
             case APPLE -> {
                 AppleTokenResponse appleToken = oauthHelper.getAppleOAuthToken(req.authCode());
-                OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(appleToken.idToken(), OAuthProvider.APPLE);
-                yield authService.validAppleSignup(oauthInfo.getOid(), appleToken.idToken());
+                yield validateApple(appleToken.idToken());
             }
+
             case SLACK -> throw UnsupportedOAuthProviderException.EXCEPTION;
         };
     }
@@ -69,6 +77,37 @@ public class AuthUseCase {
     public CustomResponse<Void> checkAvailableNickname(String nickName) {
         authService.validNickname(nickName);
         return CustomResponse.onSuccess(SuccessCode.AUTH_NICKNAME_SUCCESS);
+    }
+
+
+
+    // Kakao 공통 검증 로직
+    private ValidAuthDTO validateKakao(String accessToken, String idToken) {
+        // accessToken으로 사용자 정보 조회
+        KakaoUserResponse kakaoUser = oauthHelper.getKakaoInformation(accessToken);
+        // idToken으로 OIDC 검증
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, OAuthProvider.KAKAO);
+
+        // token 간 정보 일치 확인 후 회원가입 여부 반환
+        if (!oauthInfo.getOid().equals(kakaoUser.id())) throw UnknownUserException.EXCEPTION;
+        return authService.validKakaoSignup(kakaoUser.id(), idToken);
+    }
+
+    // Naver 공통 검증 로직
+    private ValidAuthDTO validateNaver(String accessToken) {
+        // accessToken으로 사용자 정보 조회
+        NaverUserResponse naverUser = oauthHelper.getNaverInformation(accessToken);
+
+        // token 간 정보 일치 확인 후 회원가입 여부 반환
+        if (naverUser.id() == null) throw FeignClientServerErrorException.EXCEPTION;
+        return authService.validNaverSignup(naverUser.id());
+    }
+
+    // Apple 공통 검증 로직
+    private ValidAuthDTO validateApple(String idToken) {
+        // idToken으로 OIDC 검증 및 회원가입 여부 반환
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, OAuthProvider.APPLE);
+        return authService.validAppleSignup(oauthInfo.getOid(), idToken);
     }
 
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthorizationUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthorizationUseCase.java
@@ -19,15 +19,28 @@ public class AuthorizationUseCase {
 
     private final CookieHelper cookieHelper;
 
-    public ResponseEntity<CustomResponse<AuthorizationResponse>> getTokenRefresh(String refreshToken) {
+    // 토큰 재발급
+    public ResponseEntity<CustomResponse<AuthorizationResponse>> getTokenRefresh(
+            String cookieRefreshToken, String bodyRefreshToken
+    ) {
+        boolean useBodyToken = cookieRefreshToken == null || cookieRefreshToken.isBlank();
+        String refreshToken = useBodyToken ? bodyRefreshToken : cookieRefreshToken;
 
         if (refreshToken == null || refreshToken.isBlank()) throw RefreshTokenNotExistException.EXCEPTION;
 
         LoginWithTokenResponse tokenResponse = tokenGenerateHelper.reissueTokens(refreshToken);
-        AuthorizationResponse result = new AuthorizationResponse(tokenResponse.accessToken());
 
+        // Native: body로 access/refresh 둘 다 반환
+        if (useBodyToken) {
+            return ResponseEntity.ok()
+                    .body(CustomResponse.onSuccess(SuccessCode.AUTH_REISSUE_ACCESSTOKEN_SUCCESS,
+                            AuthorizationResponse.nativeRefresh(tokenResponse.accessToken(), tokenResponse.refreshToken())));
+        }
+
+        // Web: accessToken만 body, refreshToken은 Set-Cookie 로 재발급
         return ResponseEntity.ok()
                 .headers(cookieHelper.getTokenCookie(tokenResponse.refreshToken()))
-                .body(CustomResponse.onSuccess(SuccessCode.AUTH_REISSUE_ACCESSTOKEN_SUCCESS, result));
+                .body(CustomResponse.onSuccess(SuccessCode.AUTH_REISSUE_ACCESSTOKEN_SUCCESS,
+                        AuthorizationResponse.webRefresh(tokenResponse.accessToken())));
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/DeveloperAuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/DeveloperAuthUseCase.java
@@ -57,7 +57,7 @@ public class DeveloperAuthUseCase {
     public ResponseEntity<CustomResponse<AuthorizationResponse>> developerLogin(DeveloperLoginRequest req) {
         AuthUserDetails userDetails = developerAuthService.loginDeveloper(req.pendingId());
         LoginWithTokenResponse tokenResponse = tokenGenerateHelper.generateLoginWithToken(userDetails);
-        AuthorizationResponse result = new AuthorizationResponse(tokenResponse.accessToken());
+        AuthorizationResponse result = AuthorizationResponse.webRefresh(tokenResponse.accessToken());
 
         return ResponseEntity.ok()
                 .headers(cookieHelper.getTokenCookie(tokenResponse.refreshToken()))

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LoginUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LoginUseCase.java
@@ -40,14 +40,22 @@ public class LoginUseCase {
         AuthUserDetails userDetails = readerLoginService.execute(oauthInfo);
         LoginWithTokenResponse loginToken = tokenGenerateHelper.generateLoginWithToken(userDetails);
 
-        ReaderLoginResponse readerLoginResponse = new ReaderLoginResponse(
-                loginToken.accessToken()
-        );
+        // Native: body로 access/refresh 둘 다 반환
+        if (isNative) {
+            return ResponseEntity.ok()
+                    .body(CustomResponse.onSuccess(SuccessCode.OAUTH_LOGIN_SUCCESS,
+                            new ReaderSocialLoginResponse(true,
+                                    ReaderLoginResponse.nativeLogin(loginToken.accessToken(), loginToken.refreshToken()),
+                                    null)));
+        }
 
+        // Web: accessToken만 body, refreshToken은 Set-Cookie
         return ResponseEntity.ok()
                 .headers(cookieHelper.getTokenCookie(loginToken.refreshToken()))
                 .body(CustomResponse.onSuccess(SuccessCode.OAUTH_LOGIN_SUCCESS,
-                        new ReaderSocialLoginResponse(true, readerLoginResponse, null)));
+                        new ReaderSocialLoginResponse(true,
+                                ReaderLoginResponse.webLogin(loginToken.accessToken()),
+                                null)));
     }
 
     // 회원가입하지 않은 경우 로그인

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LoginUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LoginUseCase.java
@@ -34,8 +34,8 @@ public class LoginUseCase {
      * 독자용
      * */
     // 회원가입한 경우 로그인
-    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerLoginWithIdToken(String idToken, OAuthProvider provider) {
-        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, provider);
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerLoginWithIdToken(String idToken, OAuthProvider provider, boolean isNative) {
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, provider, isNative);
 
         AuthUserDetails userDetails = readerLoginService.execute(oauthInfo);
         LoginWithTokenResponse loginToken = tokenGenerateHelper.generateLoginWithToken(userDetails);
@@ -51,8 +51,8 @@ public class LoginUseCase {
     }
 
     // 회원가입하지 않은 경우 로그인
-    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerPreLoginWithIdToken(String idToken, OAuthProvider provider) {
-        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, provider);
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerPreLoginWithIdToken(String idToken, OAuthProvider provider, boolean isNative) {
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, provider, isNative);
 
         OAuthLoginWithTokenResponse onboardingToken = tokenGenerateHelper.generateOAuthLoginWithToken(oauthInfo);
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/OAuthLoginUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/OAuthLoginUseCase.java
@@ -19,13 +19,13 @@ public class OAuthLoginUseCase {
     // Web: authCode로 accessToken(+idToken) 요청 및 검증
     public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerOAuthLogin(OAuthAuthorizationRequest req, OAuthProvider provider) {
         ValidAuthDTO valid = authUseCase.checkAvailableRegister(req, provider);
-        return dispatchLoginByRegistration(valid, provider);
+        return dispatchLoginByRegistration(valid, provider, false);
     }
 
     // Native: Kakao/Naver SDK에서 받은 accessToken(+idToken)을 그대로 검증
     public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerOAuthNativeLogin(OAuthAuthorizationRequest req, OAuthProvider provider) {
         ValidAuthDTO valid = authUseCase.checkAvailableRegisterNative(req, provider);
-        return dispatchLoginByRegistration(valid, provider);
+        return dispatchLoginByRegistration(valid, provider, true);
     }
 
     /**
@@ -35,12 +35,12 @@ public class OAuthLoginUseCase {
      * (2) isRegistered = false -> 온보딩 토큰 반환 (회원가입 필요)
      */
     private ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> dispatchLoginByRegistration(
-            ValidAuthDTO valid, OAuthProvider provider
+            ValidAuthDTO valid, OAuthProvider provider, boolean isNative
     ) {
         if (valid.isRegistered()) {
-            return loginUseCase.readerLoginWithIdToken(valid.idToken(), provider);
+            return loginUseCase.readerLoginWithIdToken(valid.idToken(), provider, isNative);
         }
-        return loginUseCase.readerPreLoginWithIdToken(valid.idToken(), provider);
+        return loginUseCase.readerPreLoginWithIdToken(valid.idToken(), provider, isNative);
     }
 
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/OAuthLoginUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/OAuthLoginUseCase.java
@@ -16,23 +16,31 @@ public class OAuthLoginUseCase {
     private final AuthUseCase authUseCase;
     private final LoginUseCase loginUseCase;
 
+    // Web: authCode로 accessToken(+idToken) 요청 및 검증
     public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerOAuthLogin(OAuthAuthorizationRequest req, OAuthProvider provider) {
         ValidAuthDTO valid = authUseCase.checkAvailableRegister(req, provider);
+        return dispatchLoginByRegistration(valid, provider);
+    }
 
-        /**
-         * (1) isRegistered = true (계정 정보 있음) -> 로그인 시키기
-         *     return 1)isRegistered 2)AccessToken 3)RefreshToken
-         * */
+    // Native: Kakao/Naver SDK에서 받은 accessToken(+idToken)을 그대로 검증
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerOAuthNativeLogin(OAuthAuthorizationRequest req, OAuthProvider provider) {
+        ValidAuthDTO valid = authUseCase.checkAvailableRegisterNative(req, provider);
+        return dispatchLoginByRegistration(valid, provider);
+    }
+
+    /**
+     * 회원 등록 여부에 따라 로그인 응답을 분기
+     *
+     * (1) isRegistered = true  -> 액세스 토큰 + 리프레쉬 토큰 쿠키 반환
+     * (2) isRegistered = false -> 온보딩 토큰 반환 (회원가입 필요)
+     */
+    private ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> dispatchLoginByRegistration(
+            ValidAuthDTO valid, OAuthProvider provider
+    ) {
         if (valid.isRegistered()) {
             return loginUseCase.readerLoginWithIdToken(valid.idToken(), provider);
         }
-        /**
-         * (2) isRegistered = false (계정 정보 없음) -> 회원가입에 필요한 유저 정보를 담은 온보딩 토큰 반환 (OAuthInfo)
-         *     return 1)isRegistered 2)OnboardingToken
-         * */
-        else {
-            return loginUseCase.readerPreLoginWithIdToken(valid.idToken(), provider);
-        }
+        return loginUseCase.readerPreLoginWithIdToken(valid.idToken(), provider);
     }
 
 }

--- a/STORIX-Batch/Dockerfile
+++ b/STORIX-Batch/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
 
 ENV TZ=Asia/Seoul
 WORKDIR /app

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
@@ -1,0 +1,63 @@
+package com.storix.batch.scheduler;
+
+import com.storix.domain.domains.genrescore.service.GenreScoreAggregationService;
+import com.storix.domain.domains.genrescore.service.GenreScoreAggregationService.ChunkResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GenreScoreAggregationScheduler {
+
+    private static final int CHUNK_SIZE = GenreScoreAggregationService.DEFAULT_CHUNK_SIZE;
+    private static final long INTER_CHUNK_DELAY_MS = 100L;
+    private static final int MAX_ITERATIONS = 10_000;
+
+    private final GenreScoreAggregationService aggregationService;
+
+
+    // 매일 자정, 미처리 로그 청크 단위로 집계
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void run() {
+        long started = System.currentTimeMillis();
+        Set<Long> touchedUsers = new HashSet<>();
+        int totalLogs = 0;
+        int totalGroups = 0;
+        int iter = 0;
+
+        while (iter++ < MAX_ITERATIONS) {
+            ChunkResult result = aggregationService.processChunk(CHUNK_SIZE);
+            if (result.processedLogs() == 0) break;
+
+            totalLogs += result.processedLogs();
+            totalGroups += result.groups();
+            touchedUsers.addAll(result.users());
+
+            sleep(INTER_CHUNK_DELAY_MS);
+        }
+
+        if (iter >= MAX_ITERATIONS) {
+            log.warn(">>> [GenreScoreBatch] MAX_ITERATIONS({}) 도달 — 다음 실행 시 잔여분 처리", MAX_ITERATIONS);
+        }
+
+        int oldDeleted = aggregationService.cleanupOldProcessed();
+
+        log.info(">>> [GenreScoreBatch] processedLogs={}, groups={}, users={}, oldDeleted={}, iterations={}, took={}ms",
+                totalLogs, totalGroups, touchedUsers.size(), oldDeleted, iter - 1,
+                System.currentTimeMillis() - started);
+    }
+
+    private void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -45,6 +45,7 @@ public enum SuccessCode {
     PROFILE_MY_BOARDS_LIKE_LIST_LOAD_SUCCESS(HttpStatus.OK, "PROFILE_SUCCESS_010", "프로필 내 활동 좋아요 리스트 조회에 성공했습니다."),
     PROFILE_RATING_DISTRIBUTION_LOAD_SUCCESS(HttpStatus.OK, "PROFILE_SUCCESS_011", "프로필 리뷰 별점 분포 조회에 성공했습니다."),
     PROFILE_FAVORITE_HASHTAGS_LOAD_SUCCESS(HttpStatus.OK, "PROFILE_SUCCESS_012", "프로필 선호 해시태그 조회에 성공했습니다."),
+    PROFILE_GENRE_STATS_LOAD_SUCCESS(HttpStatus.OK, "PROFILE_SUCCESS_013", "프로필 선호 장르 통계 조회에 성공했습니다."),
 
     // Image success
     IMAGE_ISSUE_PRESIGNED_URL_SUCCESS(HttpStatus.OK, "IMAGE_SUCCESS_001", "이미지를 업로드할 Presigned Url 발급에 성공했습니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/property/KakaoProperties.java
+++ b/STORIX-Common/src/main/java/com/storix/common/property/KakaoProperties.java
@@ -6,15 +6,17 @@ import lombok.Getter;
 public class KakaoProperties {
 
     private final String baseUri;
-    private final String clientId;
+    private final String clientId;       // REST API Key (웹 플로우 OIDC aud)
     private final String clientSecret;
     private final String adminKey;
+    private final String nativeAppKey;   // Native App Key (iOS/Android SDK 플로우 OIDC aud)
 
-    public KakaoProperties(String baseUri, String clientId, String clientSecret, String adminKey) {
+    public KakaoProperties(String baseUri, String clientId, String clientSecret, String adminKey, String nativeAppKey) {
         this.baseUri = baseUri;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.adminKey = adminKey;
+        this.nativeAppKey = nativeAppKey;
     }
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/favorite/service/FavoriteService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/favorite/service/FavoriteService.java
@@ -2,6 +2,8 @@ package com.storix.domain.domains.favorite.service;
 
 import com.storix.domain.domains.favorite.adaptor.FavoriteWorksAdaptor;
 import com.storix.domain.domains.favorite.exception.DuplicateFavoriteWorksRequestException;
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FavoriteService {
 
     private final FavoriteWorksAdaptor favoriteWorksAdaptor;
+    private final GenreScorePublisher genreScorePublisher;
 
     // [작품] 관심 작품 관련
     @Transactional(readOnly = true)
@@ -26,6 +29,7 @@ public class FavoriteService {
         }
 
         favoriteWorksAdaptor.saveSingleFavoriteWorks(userId, worksId);
+        genreScorePublisher.publish(userId, worksId, GenreScoreEventType.FAVORITE_WORKS_ADD);
     }
 
     @Transactional

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreRawScore.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreRawScore.java
@@ -1,0 +1,33 @@
+package com.storix.domain.domains.genrescore.domain;
+
+import com.storix.common.model.BaseTimeEntity;
+import com.storix.domain.domains.works.domain.Genre;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_genre_raw_score",
+        indexes = {
+                @Index(name = "idx_user", columnList = "user_id")
+        }
+)
+public class UserGenreRawScore extends BaseTimeEntity {
+
+    @EmbeddedId
+    private UserGenreRawScoreId id;
+
+    @Column(name = "raw_score", nullable = false)
+    private long rawScore;
+
+    public Long getUserId() {
+        return id.getUserId();
+    }
+
+    public Genre getGenre() {
+        return id.getGenre();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreRawScoreId.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreRawScoreId.java
@@ -1,0 +1,29 @@
+package com.storix.domain.domains.genrescore.domain;
+
+import com.storix.domain.domains.works.domain.Genre;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "of")
+public class UserGenreRawScoreId implements Serializable {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "genre", nullable = false, length = 30)
+    private Genre genre;
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreScoreLog.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreScoreLog.java
@@ -1,0 +1,68 @@
+package com.storix.domain.domains.genrescore.domain;
+
+import com.storix.common.model.BaseTimeEntity;
+import com.storix.domain.domains.genrescore.event.GenreScoreEvent;
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.works.domain.Genre;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_genre_score_log",
+        indexes = {
+                @Index(name = "idx_unprocessed", columnList = "processed_at, created_at"),
+                @Index(name = "idx_user_event", columnList = "user_id, event_type, works_id")
+        }
+)
+public class UserGenreScoreLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "works_id")
+    private Long worksId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "genre", nullable = false, length = 30)
+    private Genre genre;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 40)
+    private GenreScoreEventType eventType;
+
+    @Column(name = "weight", nullable = false)
+    private int weight;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    @Builder
+    private UserGenreScoreLog(Long userId, Long worksId, Genre genre, GenreScoreEventType eventType, int weight) {
+        this.userId = userId;
+        this.worksId = worksId;
+        this.genre = genre;
+        this.eventType = eventType;
+        this.weight = weight;
+    }
+
+    public static UserGenreScoreLog from(GenreScoreEvent event) {
+        return UserGenreScoreLog.builder()
+                .userId(event.userId())
+                .worksId(event.worksId())
+                .genre(event.genre())
+                .eventType(event.type())
+                .weight(event.type().getWeight())
+                .build();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/event/GenreScoreEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/event/GenreScoreEvent.java
@@ -1,0 +1,15 @@
+package com.storix.domain.domains.genrescore.event;
+
+import com.storix.domain.domains.works.domain.Genre;
+
+public record GenreScoreEvent(
+        Long userId,
+        Long worksId,
+        Genre genre,
+        GenreScoreEventType type
+) {
+
+    public static GenreScoreEvent of(Long userId, Long worksId, Genre genre, GenreScoreEventType type) {
+        return new GenreScoreEvent(userId, worksId, genre, type);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/event/GenreScoreEventType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/event/GenreScoreEventType.java
@@ -1,0 +1,17 @@
+package com.storix.domain.domains.genrescore.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GenreScoreEventType {
+
+    ONBOARDING_SELECT(5),
+    TOPIC_ROOM_JOIN(4),
+    REVIEW_WRITE_POSITIVE(4),
+    BOARD_WRITE(3),
+    FAVORITE_WORKS_ADD(3);
+
+    private final int weight;
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/listener/GenreScoreLogListener.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/listener/GenreScoreLogListener.java
@@ -1,0 +1,36 @@
+package com.storix.domain.domains.genrescore.listener;
+
+import com.storix.domain.domains.genrescore.domain.UserGenreScoreLog;
+import com.storix.domain.domains.genrescore.event.GenreScoreEvent;
+import com.storix.domain.domains.genrescore.repository.UserGenreScoreLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GenreScoreLogListener {
+
+    private final UserGenreScoreLogRepository logRepository;
+
+    // 트랜잭션 커밋 후 반영
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void on(GenreScoreEvent event) {
+        if (event.userId() == null || event.genre() == null) {
+            log.warn(">>> [GenreScore] invalid event dropped: {}", event);
+            return;
+        }
+
+        try {
+            logRepository.save(UserGenreScoreLog.from(event));
+        } catch (Exception e) {
+            log.error(">>> [GenreScore] log persist failed for event={}, cause={}", event, e.getMessage());
+        }
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/publisher/GenreScorePublisher.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/publisher/GenreScorePublisher.java
@@ -1,0 +1,66 @@
+package com.storix.domain.domains.genrescore.publisher;
+
+import com.storix.domain.domains.genrescore.event.GenreScoreEvent;
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.works.application.port.LoadWorksPort;
+import com.storix.domain.domains.works.domain.Genre;
+import com.storix.domain.domains.works.domain.Works;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GenreScorePublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+    private final LoadWorksPort loadWorksPort;
+
+    // 작품 id값만 알고 있는 발행 지점 publish
+    public void publish(Long userId, Long worksId, GenreScoreEventType type) {
+        try {
+            Genre genre = loadWorksPort.findById(worksId).getGenre();
+            if (genre == null) {
+                log.warn(">>> [GenreScore] genre missing for worksId={}, type={}", worksId, type);
+                return;
+            }
+            eventPublisher.publishEvent(GenreScoreEvent.of(userId, worksId, genre, type));
+        } catch (Exception e) {
+            log.warn(">>> [GenreScore] publish failed userId={}, worksId={}, type={}, cause={}",
+                    userId, worksId, type, e.getMessage());
+        }
+    }
+
+    // genre 값만 알고 있는 발행 지점 publish
+    public void publishWithGenre(Long userId, Long worksId, Genre genre, GenreScoreEventType type) {
+        if (genre == null) {
+            log.warn(">>> [GenreScore] genre missing publishWithGenre worksId={}, type={}", worksId, type);
+            return;
+        }
+        try {
+            eventPublisher.publishEvent(GenreScoreEvent.of(userId, worksId, genre, type));
+        } catch (Exception e) {
+            log.warn(">>> [GenreScore] publish failed userId={}, worksId={}, type={}, cause={}",
+                    userId, worksId, type, e.getMessage());
+        }
+    }
+
+    // 여러 작품 발행 지점 publish
+    public void publishBatch(Long userId, Collection<Long> worksIds, GenreScoreEventType type) {
+        if (worksIds == null || worksIds.isEmpty()) return;
+        try {
+            for (Works works : loadWorksPort.findWorksByIds(worksIds.stream().toList())) {
+                if (works.getGenre() == null) continue;
+                eventPublisher.publishEvent(
+                        GenreScoreEvent.of(userId, works.getId(), works.getGenre(), type));
+            }
+        } catch (Exception e) {
+            log.warn(">>> [GenreScore] batch publish failed userId={}, type={}, cause={}",
+                    userId, type, e.getMessage());
+        }
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreRawScoreRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreRawScoreRepository.java
@@ -1,0 +1,32 @@
+package com.storix.domain.domains.genrescore.repository;
+
+import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
+import com.storix.domain.domains.genrescore.domain.UserGenreRawScoreId;
+import com.storix.domain.domains.works.domain.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserGenreRawScoreRepository extends JpaRepository<UserGenreRawScore, UserGenreRawScoreId> {
+
+    List<UserGenreRawScore> findAllByIdUserId(Long userId);
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO user_genre_raw_score (user_id, genre, raw_score, created_at, updated_at)
+            VALUES (:userId, :genre, :delta, NOW(), NOW())
+            ON DUPLICATE KEY UPDATE
+                raw_score = raw_score + :delta,
+                updated_at = NOW()
+            """, nativeQuery = true)
+    void upsertAdd(@Param("userId") Long userId,
+                   @Param("genre") String genre,
+                   @Param("delta") long delta);
+
+    default void upsertAdd(Long userId, Genre genre, long delta) {
+        upsertAdd(userId, genre.name(), delta);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreScoreLogRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreScoreLogRepository.java
@@ -1,0 +1,38 @@
+package com.storix.domain.domains.genrescore.repository;
+
+import com.storix.domain.domains.genrescore.domain.UserGenreScoreLog;
+import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface UserGenreScoreLogRepository extends JpaRepository<UserGenreScoreLog, Long> {
+
+    // 미처리 로그를 id 오름차순, 청크 단위로 조회
+    @Query("""
+            SELECT new com.storix.domain.domains.genrescore.dto.UnprocessedLogRow(l.id, l.userId, l.genre, l.weight)
+            FROM UserGenreScoreLog l
+            WHERE l.processedAt IS NULL
+            ORDER BY l.id ASC
+    """)
+    List<UnprocessedLogRow> findUnprocessedChunk(Pageable pageable);
+
+    // 미처리 로그 -> 처리 로그 (벌크 업데이트)
+    @Modifying
+    @Query("""
+            UPDATE UserGenreScoreLog l
+            SET l.processedAt = :now
+            WHERE l.processedAt IS NULL AND l.id <= :maxId
+    """)
+    int markProcessedUntil(@Param("maxId") Long maxId, @Param("now") LocalDateTime now);
+
+
+    @Modifying
+    @Query("DELETE FROM UserGenreScoreLog l WHERE l.processedAt IS NOT NULL AND l.processedAt < :threshold")
+    int deleteProcessedBefore(@Param("threshold") LocalDateTime threshold);
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreAggregationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreAggregationService.java
@@ -1,0 +1,70 @@
+package com.storix.domain.domains.genrescore.service;
+
+import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
+import com.storix.domain.domains.genrescore.repository.UserGenreRawScoreRepository;
+import com.storix.domain.domains.genrescore.repository.UserGenreScoreLogRepository;
+import com.storix.domain.domains.works.domain.Genre;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class GenreScoreAggregationService {
+
+    public static final int DEFAULT_CHUNK_SIZE = 1000;
+    public static final int LOG_RETENTION_DAYS = 30;
+
+    private final UserGenreScoreLogRepository logRepository;
+    private final UserGenreRawScoreRepository rawScoreRepository;
+
+    // 미처리 로그를 청크 단위로 처리
+    @Transactional
+    public ChunkResult processChunk(int chunkSize) {
+        // 1. 미처리 로그 조회
+        List<UnprocessedLogRow> rows = logRepository.findUnprocessedChunk(PageRequest.of(0, chunkSize));
+        if (rows.isEmpty()) return ChunkResult.empty();
+
+        // 2. (user, genre)별 가중치 합산
+        Map<UserGenreKey, Long> sums = new HashMap<>();
+        Set<Long> users = new HashSet<>();
+        long maxId = 0L;
+
+        for (UnprocessedLogRow row : rows) {
+            sums.merge(new UserGenreKey(row.userId(), row.genre()), row.weight().longValue(), Long::sum);
+            users.add(row.userId());
+            if (row.id() > maxId) maxId = row.id();
+        }
+
+        // 3. raw_score 테이블 UPSERT
+        sums.forEach((key, sum) -> rawScoreRepository.upsertAdd(key.userId(), key.genre(), sum));
+
+        // 4. 로그 처리
+        logRepository.markProcessedUntil(maxId, LocalDateTime.now());
+
+        return new ChunkResult(rows.size(), sums.size(), users);
+    }
+
+    // 처리된 로그 삭제
+    @Transactional
+    public int cleanupOldProcessed() {
+        return logRepository.deleteProcessedBefore(LocalDateTime.now().minusDays(LOG_RETENTION_DAYS));
+    }
+
+    public record ChunkResult(int processedLogs, int groups, Set<Long> users) {
+        public static ChunkResult empty() {
+            return new ChunkResult(0, 0, Collections.emptySet());
+        }
+    }
+
+    private record UserGenreKey(Long userId, Genre genre) {}
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
@@ -1,0 +1,38 @@
+package com.storix.domain.domains.genrescore.service;
+
+import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
+import com.storix.domain.domains.genrescore.repository.UserGenreRawScoreRepository;
+import com.storix.domain.domains.preference.dto.GenreScoreInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GenreScoreQueryService {
+
+    private static final double PERCENT_SCALE = 100.0;
+
+    private final UserGenreRawScoreRepository rawScoreRepository;
+
+    // 장르별 raw_score 비율 정규화 (전체 합 대비 백분율 0~100, 정수 반올림 변환)
+    @Transactional(readOnly = true)
+    public List<GenreScoreInfo> getRatioNormalized(Long userId) {
+        return normalize(rawScoreRepository.findAllByIdUserId(userId));
+    }
+
+    private List<GenreScoreInfo> normalize(List<UserGenreRawScore> scores) {
+        long total = scores.stream().mapToLong(UserGenreRawScore::getRawScore).sum();
+        if (total == 0) return Collections.emptyList();
+
+        return scores.stream()
+                .map(s -> new GenreScoreInfo(
+                        s.getGenre().getDbValue(),
+                        (double) Math.round(s.getRawScore() / (double) total * PERCENT_SCALE)
+                ))
+                .toList();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
@@ -3,12 +3,15 @@ package com.storix.domain.domains.genrescore.service;
 import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
 import com.storix.domain.domains.genrescore.repository.UserGenreRawScoreRepository;
 import com.storix.domain.domains.preference.dto.GenreScoreInfo;
+import com.storix.domain.domains.works.domain.Genre;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,20 +22,24 @@ public class GenreScoreQueryService {
     private final UserGenreRawScoreRepository rawScoreRepository;
 
     // 장르별 raw_score 비율 정규화 (전체 합 대비 백분율 0~100, 정수 반올림 변환)
-    @Transactional(readOnly = true)
     public List<GenreScoreInfo> getRatioNormalized(Long userId) {
-        return normalize(rawScoreRepository.findAllByIdUserId(userId));
+        List<UserGenreRawScore> scores = rawScoreRepository.findAllByIdUserId(userId);
+        return normalize(scores);
     }
 
     private List<GenreScoreInfo> normalize(List<UserGenreRawScore> scores) {
         long total = scores.stream().mapToLong(UserGenreRawScore::getRawScore).sum();
-        if (total == 0) return Collections.emptyList();
 
-        return scores.stream()
-                .map(s -> new GenreScoreInfo(
-                        s.getGenre().getDbValue(),
-                        (double) Math.round(s.getRawScore() / (double) total * PERCENT_SCALE)
-                ))
+        Map<Genre, Long> rawByGenre = scores.stream()
+                .collect(Collectors.toMap(UserGenreRawScore::getGenre, UserGenreRawScore::getRawScore));
+
+        return Arrays.stream(Genre.values())
+                .map(g -> {
+                    long raw = rawByGenre.getOrDefault(g, 0L);
+                    double score = total == 0 ? 0.0 : Math.round(raw / (double) total * PERCENT_SCALE);
+                    return new GenreScoreInfo(g.getDbValue(), score);
+                })
+                .sorted(Comparator.comparing(GenreScoreInfo::score).reversed())
                 .toList();
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/repository/ReaderBoardRankingRepositoryImpl.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/repository/ReaderBoardRankingRepositoryImpl.java
@@ -22,7 +22,7 @@ public class ReaderBoardRankingRepositoryImpl implements ReaderBoardRankingRepos
             UPDATE reader_board
             SET popularity_score = (like_count * 4 + reply_count * 3)
             WHERE created_at >= ?
-                AND (popularity_score IS NULL OR popularity_score <> (like_count*3 + reply_count*4))
+                AND (popularity_score IS NULL OR popularity_score <> (like_count * 4 + reply_count * 3))
         """;
 
         return jdbcTemplate.update(sql, threshold);

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/BoardService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/BoardService.java
@@ -1,5 +1,7 @@
 package com.storix.domain.domains.plus.service;
 
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
 import com.storix.domain.domains.plus.adaptor.BoardAdaptor;
 import com.storix.domain.domains.plus.adaptor.BoardImageAdaptor;
@@ -21,6 +23,8 @@ public class BoardService {
 
     private final AdultWorksHelper adultWorksHelper;
 
+    private final GenreScorePublisher genreScorePublisher;
+
     // 독자 게시물 생성
     @Transactional
     public void createReaderBoard(CreateReaderBoardCommand cmd) {
@@ -40,6 +44,10 @@ public class BoardService {
         }
 
         libraryAdaptor.incrementBoardCount(cmd.userId());
+
+        if (cmd.isWorksSelected() && cmd.worksId() != null) {
+            genreScorePublisher.publish(cmd.userId(), cmd.worksId(), GenreScoreEventType.BOARD_WRITE);
+        }
     }
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReviewService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReviewService.java
@@ -1,5 +1,7 @@
 package com.storix.domain.domains.plus.service;
 
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
 import com.storix.domain.domains.plus.adaptor.ReviewAdaptor;
 import com.storix.domain.domains.plus.domain.Review;
@@ -42,6 +44,10 @@ public class ReviewService {
 
     private final AdultWorksHelper adultWorksHelper;
 
+    private final GenreScorePublisher genreScorePublisher;
+
+    private static final double POSITIVE_REVIEW_THRESHOLD = 3.0;
+
     // 플러스탭
     @Transactional
     public ReaderReviewRedirectResponse createReview(CreateReviewCommand cmd) {
@@ -58,6 +64,10 @@ public class ReviewService {
 
         // 작품 도메인 업데이트
         loadWorksPort.updateIncrementingReviewInfoToWorks(cmd.worksId(), cmd.rating().getRatingValue());
+
+        if (cmd.rating().getRatingValue() >= POSITIVE_REVIEW_THRESHOLD) {
+            genreScorePublisher.publish(cmd.libraryUserId(), cmd.worksId(), GenreScoreEventType.REVIEW_WRITE_POSITIVE);
+        }
 
         return new ReaderReviewRedirectResponse(review.getWorksId(), review.getLibraryUserId(), review.getId());
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/application/ExplorationUseCase.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/application/ExplorationUseCase.java
@@ -3,7 +3,6 @@ package com.storix.domain.domains.preference.application;
 import com.storix.domain.domains.preference.dto.ExplorationResultResponseDto;
 import com.storix.domain.domains.preference.dto.ExplorationSubmitRequestDto;
 import com.storix.domain.domains.preference.dto.ExplorationWorksResponseDto;
-import com.storix.domain.domains.preference.dto.GenreScoreInfo;
 
 import java.util.List;
 
@@ -17,7 +16,4 @@ public interface ExplorationUseCase {
 
     // 결과 모아보기
     ExplorationResultResponseDto getExplorationResults(Long userId);
-
-    // 마이페이지용 누적 통계
-    List<GenreScoreInfo> getCumulativeStats(Long userId);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/repository/ExplorationRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/repository/ExplorationRepository.java
@@ -28,11 +28,6 @@ public interface ExplorationRepository extends JpaRepository<PreferenceExplorati
             @Param("threshold") LocalDateTime threshold
     );
 
-    // 마이페이지 누적 차트용
-    @Query("SELECT w.genre, COUNT(w) FROM PreferenceExploration pe JOIN Works w ON pe.worksId = w.id " +
-            "WHERE pe.userId = :userId AND pe.isLiked = true GROUP BY w.genre")
-    List<Object[]> countLikedGenresByUserId(@Param("userId") Long userId);
-
     @Query("SELECT pe.worksId FROM PreferenceExploration pe WHERE pe.userId = :userId")
     List<Long> findRespondedWorksIdsByUserId(@Param("userId") Long userId);
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
@@ -5,6 +5,7 @@ import com.storix.common.code.ErrorCode;
 import com.storix.common.exception.STORIXCodeException;
 import com.storix.domain.domains.preference.application.ExplorationUseCase;
 import com.storix.domain.domains.preference.dto.*;
+import com.storix.domain.domains.favorite.adaptor.FavoriteWorksAdaptor;
 import com.storix.domain.domains.preference.exception.DuplicatedExplorationException;
 import com.storix.domain.domains.preference.repository.ExplorationRepository;
 import com.storix.domain.domains.works.application.port.LoadWorksPort;
@@ -25,6 +26,7 @@ public class ExplorationService implements ExplorationUseCase {
     private final ExplorationRepository explorationRepository;
     private final LoadWorksPort loadWorksPort;
     private final ExplorationCacheHelper cacheHelper;
+    private final FavoriteWorksAdaptor favoriteWorksAdaptor;
 
     @Override
     @Transactional(readOnly = true)
@@ -37,9 +39,11 @@ public class ExplorationService implements ExplorationUseCase {
 
         List<Long> dbHistoryIds = explorationRepository.findRespondedWorksIdsByUserId(userId);
         Set<Long> pendingIds = cacheHelper.getPendingWorksIds(userId);
+        List<Long> favoriteWorksIds = favoriteWorksAdaptor.findAllFavoriteWorksIdsByUserId(userId);
 
         Set<Long> allHistoryIds = new HashSet<>(dbHistoryIds);
         allHistoryIds.addAll(pendingIds);
+        allHistoryIds.addAll(favoriteWorksIds);
 
         int sessionCount = explorationRepository.countByUserIdAndCreatedAtAfter(userId, threshold)
                 + pendingIds.size();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
@@ -9,7 +9,6 @@ import com.storix.domain.domains.favorite.adaptor.FavoriteWorksAdaptor;
 import com.storix.domain.domains.preference.exception.DuplicatedExplorationException;
 import com.storix.domain.domains.preference.repository.ExplorationRepository;
 import com.storix.domain.domains.works.application.port.LoadWorksPort;
-import com.storix.domain.domains.works.domain.Genre;
 import com.storix.domain.domains.works.domain.Works;
 import com.storix.domain.domains.works.dto.LibraryWorksInfo;
 import lombok.RequiredArgsConstructor;
@@ -124,26 +123,6 @@ public class ExplorationService implements ExplorationUseCase {
                 .likedWorks(toLibraryWorksInfoList(allLiked))
                 .dislikedWorks(toLibraryWorksInfoList(allDisliked))
                 .build();
-    }
-
-    @Override
-    public List<GenreScoreInfo> getCumulativeStats(Long userId) {
-        return cacheHelper.getOrGenerateChart(userId, () -> {
-            List<Object[]> raw = explorationRepository.countLikedGenresByUserId(userId);
-            return transformToScoreInfo(raw);
-        });
-    }
-
-    private List<GenreScoreInfo> transformToScoreInfo(List<Object[]> rawCounts) {
-        long totalLiked = rawCounts.stream().mapToLong(row -> (long) row[1]).sum();
-        if (totalLiked == 0) return Collections.emptyList();
-
-        return rawCounts.stream()
-                .map(row -> new GenreScoreInfo(
-                        ((Genre) row[0]).getDbValue(),
-                        Math.round(((long) row[1] / (double) totalLiked) * 5.0 * 10) / 10.0
-                ))
-                .toList();
     }
 
     private List<LibraryWorksInfo> toLibraryWorksInfoList(List<Works> worksList) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
@@ -48,7 +48,7 @@ public class ExplorationService implements ExplorationUseCase {
         int sessionCount = explorationRepository.countByUserIdAndCreatedAtAfter(userId, threshold)
                 + pendingIds.size();
 
-        int needed = 15 - sessionCount;
+        int needed = 10 - sessionCount;
         if (needed <= 0) return Collections.emptyList();
 
         return loadWorksPort.findRandomWorksExcluding(new ArrayList<>(allHistoryIds), needed)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -1,5 +1,7 @@
 package com.storix.domain.domains.topicroom.service;
 
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.search.dto.PlusSearchResponseWrapperDto;
 import com.storix.domain.domains.search.dto.SearchResponseWrapperDto;
 import com.storix.domain.domains.search.dto.TrendingItem;
@@ -49,6 +51,7 @@ public class TopicRoomService implements TopicRoomUseCase {
     private final SearchHistoryService searchHistoryService;
     private final ProfanityFilterService profanityFilterService;
     private final LoadTopicRoomUserPort loadTopicRoomMemberPort;
+    private final GenreScorePublisher genreScorePublisher;
 
     @Override
     public Slice<TopicRoomResponseDto> getMyJoinedRooms(Long userId, Pageable pageable) {
@@ -190,6 +193,9 @@ public class TopicRoomService implements TopicRoomUseCase {
             recordTopicRoomPort.saveParticipation(user.getId(), savedRoom, TopicRoomRole.HOST);
             recordTopicRoomPort.incrementActiveUserNumber(savedRoom.getId());
 
+            genreScorePublisher.publishWithGenre(
+                    user.getId(), works.getId(), works.getGenre(), GenreScoreEventType.TOPIC_ROOM_JOIN);
+
             return savedRoom.getId();
         } catch (DataIntegrityViolationException e) {
 
@@ -213,6 +219,9 @@ public class TopicRoomService implements TopicRoomUseCase {
         try {
             recordTopicRoomPort.saveParticipation(userId, room, TopicRoomRole.MEMBER);
             recordTopicRoomPort.incrementActiveUserNumber(roomId);
+
+            genreScorePublisher.publishWithGenre(
+                    userId, works.getId(), works.getGenre(), GenreScoreEventType.TOPIC_ROOM_JOIN);
         } catch (DataIntegrityViolationException e) {
             throw AlreadyJoinedException.EXCEPTION;
         }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
@@ -97,11 +97,12 @@ public class User extends BaseTimeEntity {
     protected User() {}
 
     @Builder
-    public User(boolean marketingAgree, OAuthInfo oauthInfo, String nickName, Set<Genre> favoriteGenreList, Role role) {
+    public User(boolean marketingAgree, OAuthInfo oauthInfo, String nickName, Set<Genre> favoriteGenreList, String profileDescription, Role role) {
         this.marketingAgree = marketingAgree;
         this.oauthInfo = oauthInfo;
         this.nickName = nickName;
         this.favoriteGenreList = favoriteGenreList;
+        this.profileDescription = profileDescription;
         if (role != null) this.role = role;
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateReaderUserCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateReaderUserCommand.java
@@ -14,7 +14,8 @@ public record CreateReaderUserCommand(
         OAuthProvider provider,
         String oid,
         String nickName,
-        Set<Genre> favoriteGenreList
+        Set<Genre> favoriteGenreList,
+        String profileDescription
 ) {
     public User toEntity() {
         OAuthInfo oauthInfo = new OAuthInfo(provider, oid);
@@ -26,6 +27,7 @@ public record CreateReaderUserCommand(
                 .oauthInfo(oauthInfo)
                 .nickName(nickName)
                 .favoriteGenreList(genres)
+                .profileDescription(profileDescription)
                 .role(Role.READER)
                 .build();
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OAuthAuthorizationRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OAuthAuthorizationRequest.java
@@ -2,22 +2,37 @@ package com.storix.domain.domains.user.dto;
 
 public record OAuthAuthorizationRequest(
         String authCode,
-        String redirectUri, // kakao
-        String state // naver
+        String redirectUri, // kakao (web)
+        String state,       // naver (web)
+        String accessToken, // native (kakao, naver)
+        String idToken      // native (kakao OIDC)
 ) {
+    // Web: Kakao Redirect Uri -> authCode
     public static OAuthAuthorizationRequest forKakao(
             String authCode, String redirectUri
     ) {
-        return new OAuthAuthorizationRequest(authCode, redirectUri, null);
+        return new OAuthAuthorizationRequest(authCode, redirectUri, null, null, null);
     }
 
+    // Web: Naver Redirect Uri -> authCode + state
     public static OAuthAuthorizationRequest forNaver(
             String authCode, String state
     ) {
-        return new OAuthAuthorizationRequest(authCode, null, state);
+        return new OAuthAuthorizationRequest(authCode, null, state, null, null);
     }
 
-    public static OAuthAuthorizationRequest forApple(String authCode) {
-        return new OAuthAuthorizationRequest(authCode, null, null);
+    // Native: Apple SDK -> authCode
+    public static OAuthAuthorizationRequest forAppleNative(String authCode) {
+        return new OAuthAuthorizationRequest(authCode, null, null, null, null);
+    }
+
+    // Native: Kakao SDK -> accessToken + idToken
+    public static OAuthAuthorizationRequest forKakaoNative(String accessToken, String idToken) {
+        return new OAuthAuthorizationRequest(null, null, null, accessToken, idToken);
+    }
+
+    // Native: Naver SDK -> accessToken
+    public static OAuthAuthorizationRequest forNaverNative(String accessToken) {
+        return new OAuthAuthorizationRequest(null, null, null, accessToken, null);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ReaderSignupRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ReaderSignupRequest.java
@@ -18,14 +18,15 @@ public record ReaderSignupRequest(
     )
     String nickName,
 
+    @Size(max = 30, message = "한 줄 소개는 30자까지 가능합니다.")
+    String profileDescription,
+
     @NotNull(message = "관심 장르는 필수입니다.")
     @Size(min = 1, max = 3, message = "관심 장르는 1개 이상 3개 이하로 선택해야 합니다.")
     Set<Genre> favoriteGenreList,
 
-    @Size(min = 2, max = 18, message = "관심 작품은 2개 이상 18개 이하로 선택해야 합니다.")
-    Set<Long> favoriteWorksIdList,
+    @Size(max = 18, message = "관심 작품은 18개 이하로 선택해야 합니다.")
+    Set<Long> favoriteWorksIdList
 
-    @Size(max = 30, message = "한 줄 소개는 30자까지 가능합니다.")
-    String profileDescription
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ReaderSignupRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ReaderSignupRequest.java
@@ -23,6 +23,9 @@ public record ReaderSignupRequest(
     Set<Genre> favoriteGenreList,
 
     @Size(min = 2, max = 18, message = "관심 작품은 2개 이상 18개 이하로 선택해야 합니다.")
-    Set<Long> favoriteWorksIdList
+    Set<Long> favoriteWorksIdList,
+
+    @Size(max = 30, message = "한 줄 소개는 30자까지 가능합니다.")
+    String profileDescription
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.storix.domain.domains.user.service;
 
 import com.storix.domain.domains.favorite.adaptor.FavoriteWorksAdaptor;
+import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
+import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
 import com.storix.domain.domains.onboarding.service.OnboardingWorksHelper;
 import com.storix.domain.domains.user.dto.CreateReaderUserCommand;
@@ -26,6 +28,7 @@ public class AuthService {
     private final LibraryAdaptor libraryAdaptor;
     private final TokenAdaptor tokenAdaptor;
     private final FavoriteWorksAdaptor favoriteWorksAdaptor;
+    private final GenreScorePublisher genreScorePublisher;
 
     // 독자 회원 가입 가능 여부 (토큰 검증, 계정 정보 유무)
     // - 카카오
@@ -79,6 +82,10 @@ public class AuthService {
 
         if (cmd.favoriteWorksIdList() != null && !cmd.favoriteWorksIdList().isEmpty()) {
             favoriteWorksAdaptor.saveFavoriteWorks(authUserDetails.getUserId(), cmd.favoriteWorksIdList());
+            genreScorePublisher.publishBatch(
+                    authUserDetails.getUserId(),
+                    cmd.favoriteWorksIdList(),
+                    GenreScoreEventType.ONBOARDING_SELECT);
         }
         libraryAdaptor.initLibrary(authUserDetails.getUserId());
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -70,7 +70,8 @@ public class AuthService {
                 provider,
                 oid,
                 cmd.nickName(),
-                cmd.favoriteGenreList()
+                cmd.favoriteGenreList(),
+                cmd.profileDescription()
         );
 
         AuthUserDetails authUserDetails = userAdaptor.saveReaderUser(m);

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
@@ -152,7 +152,9 @@ public class SecurityConfig {
                 "http://localhost:3000",
                 "http://localhost:5173",
                 "https://storix-fe-git-develop-kim-yunseongs-projects.vercel.app",
-                "https://storix-fe-git-main-kim-yunseongs-projects.vercel.app"
+                "https://storix-fe-git-main-kim-yunseongs-projects.vercel.app",
+                "capacitor://localhost",
+                "https://localhost"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/WebSocketConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/WebSocketConfig.java
@@ -28,6 +28,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 "https://api.storix.kr",
                 "http://localhost:3000",
                 "http://localhost:5173",
+                "capacitor://localhost",
+                "https://localhost",
                 "https://storix-fe-git-develop-kim-yunseongs-projects.vercel.app",
                 "https://storix-fe-git-main-kim-yunseongs-projects.vercel.app"
         );


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] PR #47의 커밋 cherry-pick (Refactor: QA 전 2차 리팩토링)
> - [x] PR #48의 커밋 cherry-pick (Refactor: QA 전 3차 리팩토링)
> - [x] PR #49의 커밋 cherry-pick (Refactor: QA 전 4차 리팩토링)
> - [x] PR #50의 커밋 cherry-pick (Feat: 카카오&네이버 네이티브 소셜 로그인 지원 + 웹소켓 Capacitor CORS)
> - [x] PR #51의 커밋 cherry-pick (Fix: 카카오 App key 분리 검증)
> - [x] PR #52의 커밋 cherry-pick (Refactor: QA 후 리팩토링)
> - [x] PR #53의 커밋 cherry-pick (Refactor: [웹/네이티브 지원] RefreshToken 분기 처리)
> - [x] PR #54의 커밋 cherry-pick (Chore: RefreshTokenRequest DTO 추가)
> - [x] PR #56의 커밋 cherry-pick (Chore: CI 이벤트 수정 및 .gitignore 편집)
> - [x] PR #58의 커밋 cherry-pick (Refactor: [프로필 - 선호 장르 통계] 유저 행동 로그 기반 도메인 이벤트 발행)
> - [x] release/v2.2.1 구성

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #12

## 🖇️ 기타