### PR TITLE
Feat: [알림 시스템] 푸시 알림 디바이스 관련 API (+인증 로직 개편)

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/controller/PushDeviceController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/controller/PushDeviceController.java
@@ -1,0 +1,59 @@
+package com.storix.api.domain.pushdevice.controller;
+
+import com.storix.api.domain.pushdevice.controller.dto.DeviceSyncRequest;
+import com.storix.api.domain.pushdevice.controller.dto.RefreshFcmTokenRequest;
+import com.storix.api.domain.pushdevice.usecase.PushDeviceUseCase;
+import com.storix.common.code.SuccessCode;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.user.adaptor.AuthUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/devices")
+@RequiredArgsConstructor
+@Tag(name = "푸시 알림 디바이스", description = "푸시 알림 발송용 디바이스 토큰 등록/해제 API")
+public class PushDeviceController {
+
+    private final PushDeviceUseCase pushDeviceUseCase;
+
+    @PostMapping("/sync")
+    @Operation(summary = "단일 디바이스 푸시 알림 상태 동기화", description = "단일 디바이스 정보와 FCM 토큰 정보를 BE 서버에 동기화합니다.   \n" +
+            "1) 앱 foreground 진입 후 토큰 재발급을 통한 자동로그인 / 회원가입 / 로그인 시 호출해주세요.   \n" +
+            "2) OS 푸시 알림 권한이 OFF -> ON 으로 변경될 떄 호출해주세요.   \n" +
+            "3) 디바이스 관련 메타 정보(OS 버전 / 앱 버전)가 변경될 때 호출해주세요.")
+    public CustomResponse<Void> sync(
+            @AuthenticationPrincipal AuthUserDetails authUser,
+            @RequestBody @Valid DeviceSyncRequest request
+    ) {
+        pushDeviceUseCase.sync(authUser.getUserId(), request);
+        return CustomResponse.onSuccess(SuccessCode.DEVICE_SYNC_SUCCESS);
+    }
+
+    @DeleteMapping("/{installationId}")
+    @Operation(summary = "단일 디바이스 푸시 알림 해제", description = "단일 디바이스에 할당된 FCM 토큰을 BE 서버에서 비활성화합니다.   \n" +
+            "1) OS 푸시 알림 권한이 ON -> OFF 로 변경될 때 호출해주세요.")
+    public CustomResponse<Void> unregister(
+            @AuthenticationPrincipal AuthUserDetails authUser,
+            @PathVariable String installationId
+    ) {
+        pushDeviceUseCase.unregister(authUser.getUserId(), installationId);
+        return CustomResponse.onSuccess(SuccessCode.DEVICE_UNREGISTER_SUCCESS);
+    }
+
+    @PatchMapping("/token")
+    @Operation(summary = "FCM 토큰 갱신", description = "FCM 토큰 정보만 갱신하는 api 입니다. 단일 디바이스 푸시 알림 등록(/sync)이 선행되어야 합니다.  \n" +
+            "1) FCM onTokenRefresh 콜백 시 호출해주세요. (앱 재설치 / 데이터 초기화 등)  \n" +
+            "2) WorkManager 주기(30일) 호출 시 직전 캐시 토큰과 비교해 갱신된 경우에만 호출해주세요.")
+    public CustomResponse<Void> refreshFcmToken(
+            @AuthenticationPrincipal AuthUserDetails authUser,
+            @RequestBody @Valid RefreshFcmTokenRequest request
+    ) {
+        pushDeviceUseCase.refreshFcmToken(authUser.getUserId(), request);
+        return CustomResponse.onSuccess(SuccessCode.DEVICE_TOKEN_REFRESH_SUCCESS);
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/controller/PushDeviceController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/controller/PushDeviceController.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/devices")
+@RequestMapping("/api/v1/push-devices")
 @RequiredArgsConstructor
 @Tag(name = "푸시 알림 디바이스", description = "푸시 알림 발송용 디바이스 토큰 등록/해제 API")
 public class PushDeviceController {
@@ -45,7 +45,7 @@ public class PushDeviceController {
         return CustomResponse.onSuccess(SuccessCode.DEVICE_UNREGISTER_SUCCESS);
     }
 
-    @PatchMapping("/token")
+    @PatchMapping("/fcm-token")
     @Operation(summary = "FCM 토큰 갱신", description = "FCM 토큰 정보만 갱신하는 api 입니다. 단일 디바이스 푸시 알림 등록(/sync)이 선행되어야 합니다.  \n" +
             "1) FCM onTokenRefresh 콜백 시 호출해주세요. (앱 재설치 / 데이터 초기화 등)  \n" +
             "2) WorkManager 주기(30일) 호출 시 직전 캐시 토큰과 비교해 갱신된 경우에만 호출해주세요.")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/controller/dto/DeviceSyncRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/controller/dto/DeviceSyncRequest.java
@@ -1,0 +1,38 @@
+package com.storix.api.domain.pushdevice.controller.dto;
+
+import com.storix.domain.domains.pushdevice.domain.OSPlatform;
+import com.storix.domain.domains.pushdevice.dto.SyncDeviceCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record DeviceSyncRequest(
+        // 1. FCM 전송을 위해 필요한 정보
+        @NotBlank(message = "기기 식별을 위한 uuid를 생성하여 storage 저장 후 보내주세요.")
+        @Size(max = 64)
+        String installationId,
+
+        @NotBlank(message = "fcm 토큰을 보내주세요.")
+        @Size(max = 512)
+        String fcmToken,
+
+        @NotNull(message = "osPlatform(IOS / ANDROID) 정보를 보내주세요.")
+        OSPlatform osPlatform,
+
+        // 2. FCM 모니터링을 위해 필요한 정보
+        @NotBlank(message = "설치된 앱 버전을 보내주세요.")
+        @Size(max = 32)
+        String appVersion,
+
+        @NotBlank(message = "디바이스의 OS 버전 정보를 보내주세요.")
+        @Size(max = 32)
+        String osVersion,
+
+        @NotBlank(message = "디바이스의 모델명 정보를 보내주세요.")
+        @Size(max = 64)
+        String deviceModel
+) {
+    public SyncDeviceCommand toCommand() {
+        return new SyncDeviceCommand(installationId, fcmToken, osPlatform, appVersion, osVersion, deviceModel);
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/controller/dto/RefreshFcmTokenRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/controller/dto/RefreshFcmTokenRequest.java
@@ -1,0 +1,16 @@
+package com.storix.api.domain.pushdevice.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// FCM 토큰 갱신 (WorkManager 주기 갱신 / onTokenRefresh) 전용 요청. 디바이스 메타는 보존.
+public record RefreshFcmTokenRequest(
+        @NotBlank(message = "installationId 는 필수입니다.")
+        @Size(max = 64)
+        String installationId,
+
+        @NotBlank(message = "fcmToken 은 필수입니다.")
+        @Size(max = 512)
+        String fcmToken
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/usecase/PushDeviceUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/usecase/PushDeviceUseCase.java
@@ -1,0 +1,41 @@
+package com.storix.api.domain.pushdevice.usecase;
+
+import com.storix.api.domain.pushdevice.controller.dto.DeviceSyncRequest;
+import com.storix.api.domain.pushdevice.controller.dto.RefreshFcmTokenRequest;
+import com.storix.common.annotation.UseCase;
+import com.storix.domain.domains.pushdevice.service.PushDeviceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class PushDeviceUseCase {
+
+    private final PushDeviceService pushDeviceService;
+
+    // 1. 단일 디바이스 푸시 알림 상태 동기화
+    public void sync(Long userId, DeviceSyncRequest request) {
+        boolean isNew = pushDeviceService.sync(userId, request.toCommand());
+
+        if (isNew) {
+            log.info(">>>> [PushDevice] register userId={}, installationId={}", userId, request.installationId());
+        } else {
+            log.info(">>>> [PushDevice] refresh userId={}, installationId={}", userId, request.installationId());
+        }
+    }
+
+    // 2. 단일 디바이스 푸시 알림 해제
+    public void unregister(Long userId, String installationId) {
+        int affected = pushDeviceService.unregister(userId, installationId);
+        if (affected == 0) {
+            log.warn(">>>> [PushDevice] unregister target not found (already inactive or never registered) userId={}, installationId={}",
+                    userId, installationId);
+        }
+    }
+
+    // 3. FCM 토큰 갱신
+    public void refreshFcmToken(Long userId, RefreshFcmTokenRequest request) {
+        pushDeviceService.refreshFcmToken(userId, request.installationId(), request.fcmToken());
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-@Tag(name = "온보딩", description = "온보딩 관련 API")
+@Tag(name = "인증", description = "인증 관련 API")
 public class AuthController {
 
     private final AuthUseCase authUseCase;
@@ -132,15 +132,17 @@ public class AuthController {
         return authorizationUseCase.getTokenRefresh(cookieRefreshToken, bodyRefreshToken);
     }
 
-    @Operation(summary = "로그아웃", description = "로그아웃용 api 입니다.   \n액세스 토큰을 보내주세요.")
+    @Operation(summary = "[v1] 로그아웃", description = "[v1 > v2 마이그레이션 필요] 로그아웃용 api 입니다.   \n" +
+            "액세스 토큰을 보내주세요.")
     @PostMapping("/user/logout")
     public ResponseEntity<CustomResponse<Void>> logout(
             @AuthenticationPrincipal AuthUserDetails authUserDetails
     ) {
-        return logoutUseCase.execute(authUserDetails.getUserId());
+        return logoutUseCase.execute(authUserDetails.getUserId(), null);
     }
 
-    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴용 api 입니다.   \n액세스 토큰을 보내주세요.")
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴용 api 입니다.   \n" +
+            "회원 계정과 관련된 Refresh 토큰과 모든 디바이스의 FCM 토큰을 비활성화합니다.")
     @DeleteMapping("/user/withdraw")
     public ResponseEntity<CustomResponse<Void>> withdraw(
             @AuthenticationPrincipal AuthUserDetails authUserDetails

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
@@ -1,0 +1,37 @@
+package com.storix.api.domain.user.controller;
+
+import com.storix.api.domain.user.controller.dto.LogoutRequest;
+import com.storix.api.domain.user.usecase.LogoutUseCase;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.user.adaptor.AuthUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/auth")
+@RequiredArgsConstructor
+@Tag(name = "인증", description = "인증 관련 API")
+public class AuthV2Controller {
+
+    private final LogoutUseCase logoutUseCase;
+
+    @Operation(summary = "[v2] 로그아웃", description = "로그아웃용 api 입니다. 헤더로 액세스 토큰을 보내주세요.  \n" +
+            "- Native: RequestBody에 installationId(기기 식별자)를 함께 보내주세요.  \n" +
+            "          —> BE에서 해당 디바이스의 FCM 토큰을 즉시 비활성화 합니다.  \n" +
+            "- Web   : RequestBody 생략하고 요청")
+    @PostMapping("/user/logout")
+    public ResponseEntity<CustomResponse<Void>> logout(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @RequestBody(required = false) LogoutRequest body
+    ) {
+        String installationId = body != null ? body.installationId() : null;
+        return logoutUseCase.execute(authUserDetails.getUserId(), installationId);
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
@@ -24,12 +24,11 @@ public class AuthV2Controller {
 
     @Operation(summary = "[v2] 로그아웃", description = "로그아웃용 api 입니다. 헤더로 액세스 토큰을 보내주세요.  \n" +
             "- Native: RequestBody에 installationId(기기 식별자)를 함께 보내주세요.  \n" +
-            "          —> BE에서 해당 디바이스의 FCM 토큰을 즉시 비활성화 합니다.  \n" +
-            "- Web   : RequestBody 생략하고 요청")
+            "          —> BE에서 해당 디바이스의 FCM 토큰을 즉시 비활성화 합니다.  \n")
     @PostMapping("/user/logout")
     public ResponseEntity<CustomResponse<Void>> logout(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
-            @RequestBody(required = false) LogoutRequest body
+            @RequestBody LogoutRequest body
     ) {
         String installationId = body != null ? body.installationId() : null;
         return logoutUseCase.execute(authUserDetails.getUserId(), installationId);

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/LogoutRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/LogoutRequest.java
@@ -1,0 +1,6 @@
+package com.storix.api.domain.user.controller.dto;
+
+public record LogoutRequest(
+        String installationId   // 기기 식별자
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/LogoutRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/LogoutRequest.java
@@ -1,6 +1,11 @@
 package com.storix.api.domain.user.controller.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record LogoutRequest(
-        String installationId   // 기기 식별자
+        @NotBlank(message = "storage에 저장된 기기 식별자를 보내주세요.")
+        @Size(max = 64)
+        String installationId
 ) {
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LogoutUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LogoutUseCase.java
@@ -1,28 +1,37 @@
 package com.storix.api.domain.user.usecase;
 
-import com.storix.common.annotation.UseCase;
-import com.storix.domain.domains.user.adaptor.TokenAdaptor;
 import com.storix.api.domain.user.helper.CookieHelper;
-import com.storix.common.payload.CustomResponse;
+import com.storix.common.annotation.UseCase;
 import com.storix.common.code.SuccessCode;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.user.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @UseCase
 @RequiredArgsConstructor
 public class LogoutUseCase {
 
-    private final TokenAdaptor tokenAdaptor;
+    private final AuthService authService;
 
     private final CookieHelper cookieHelper;
 
-    @Transactional
-    public ResponseEntity<CustomResponse<Void>> execute(Long userId) {
-        tokenAdaptor.deleteRefreshTokenByUserId(userId);
+    // 로그아웃
+    public ResponseEntity<CustomResponse<Void>> execute(Long userId, String installationId) {
+
+        // 1. refreshToken 삭제 + [Native] 해당 디바이스 FCM 토큰 비활성화
+        authService.logout(userId, installationId);
+
+        // 2-1. [Native]
+        if (StringUtils.hasText(installationId)) {
+            return ResponseEntity.ok()
+                    .body(CustomResponse.onSuccess(SuccessCode.AUTH_LOGOUT_SUCCESS));
+        }
+
+        // 2-2. [Web] refreshToken 쿠키 삭제 (Header)
         return ResponseEntity.ok()
                 .headers(cookieHelper.deleteCookie())
                 .body(CustomResponse.onSuccess(SuccessCode.AUTH_LOGOUT_SUCCESS));
     }
-
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LogoutUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LogoutUseCase.java
@@ -20,18 +20,10 @@ public class LogoutUseCase {
     // 로그아웃
     public ResponseEntity<CustomResponse<Void>> execute(Long userId, String installationId) {
 
-        // 1. refreshToken 삭제 + [Native] 해당 디바이스 FCM 토큰 비활성화
+        // refreshToken 삭제 + [Native] 해당 디바이스 FCM 토큰 비활성화
         authService.logout(userId, installationId);
 
-        // 2-1. [Native]
-        if (StringUtils.hasText(installationId)) {
-            return ResponseEntity.ok()
-                    .body(CustomResponse.onSuccess(SuccessCode.AUTH_LOGOUT_SUCCESS));
-        }
-
-        // 2-2. [Web] refreshToken 쿠키 삭제 (Header)
         return ResponseEntity.ok()
-                .headers(cookieHelper.deleteCookie())
-                .body(CustomResponse.onSuccess(SuccessCode.AUTH_LOGOUT_SUCCESS));
+                    .body(CustomResponse.onSuccess(SuccessCode.AUTH_LOGOUT_SUCCESS));
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
@@ -1,9 +1,7 @@
 package com.storix.api.domain.user.usecase;
 
 import com.storix.common.annotation.UseCase;
-import com.storix.domain.domains.user.adaptor.UserAdaptor;
-import com.storix.domain.domains.user.domain.Role;
-import com.storix.domain.domains.user.domain.User;
+import com.storix.domain.domains.user.domain.OAuthInfo;
 import com.storix.domain.domains.user.service.AuthService;
 import com.storix.api.domain.user.helper.OAuthHelper;
 import com.storix.api.domain.user.helper.CookieHelper;
@@ -11,29 +9,32 @@ import com.storix.common.payload.CustomResponse;
 import com.storix.common.code.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
 public class WithDrawUseCase {
 
     private final AuthService authService;
-    private final UserAdaptor userAdaptor;
 
     private final OAuthHelper oauthHelper;
     private final CookieHelper cookieHelper;
 
-    @Transactional
     public ResponseEntity<CustomResponse<Void>> execute(Long userId) {
-        User user = userAdaptor.findUserById(userId);
-        if (user.getRole() == Role.READER) {
-            switch (user.getOauthInfo().getProvider()) {
-                case KAKAO -> oauthHelper.unlinkKakaoUser(user.getOauthInfo().getOid());
-                case NAVER -> oauthHelper.unlinkNaverUser(user.getOauthInfo().getOid());
-                case SLACK -> {} // Slack은 별도 연동 해제 불필요
-            }
+
+        // 1. OAuth 연결 해제
+        // TODO: 현재 외부 api 호출 실패 시 feignException 터짐 -> 회원 탈퇴 X -> best-effort + 재시도 워커 처리 고려중
+        OAuthInfo oauthInfo = authService.findOAuthInfoByUserId(userId);
+        switch (oauthInfo.getProvider()) {
+            case KAKAO -> oauthHelper.unlinkKakaoUser(oauthInfo.getOid());
+            case NAVER -> oauthHelper.unlinkNaverUser(oauthInfo.getOid());
+            case SLACK -> {} // admin 만 해당 (연결 해제 불필요)
+            // TODO: Apple 은 refresh_token 저장 후 unlinkAppleUser 호출 필요
+            case APPLE -> {}
         }
+
+        // 2. 유저 탈퇴 처리 (RefreshToken / 관심작품 / 서재 삭제 + 푸시 알림 발송 대상 제외)
         authService.withDrawUser(userId);
+
         return ResponseEntity.ok()
                 .headers(cookieHelper.deleteCookie())
                 .body(CustomResponse.onSuccess(SuccessCode.AUTH_WITHDRAW_SUCCESS));

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
@@ -8,8 +8,10 @@ import com.storix.api.domain.user.helper.CookieHelper;
 import com.storix.common.payload.CustomResponse;
 import com.storix.common.code.SuccessCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 
+@Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class WithDrawUseCase {
@@ -22,15 +24,21 @@ public class WithDrawUseCase {
     public ResponseEntity<CustomResponse<Void>> execute(Long userId) {
 
         // 1. OAuth 연결 해제
-        // TODO: 현재 외부 api 호출 실패 시 feignException 터짐 -> 회원 탈퇴 X -> best-effort + 재시도 워커 처리 고려중
         OAuthInfo oauthInfo = authService.findOAuthInfoByUserId(userId);
-        switch (oauthInfo.getProvider()) {
-            case KAKAO -> oauthHelper.unlinkKakaoUser(oauthInfo.getOid());
-            case NAVER -> oauthHelper.unlinkNaverUser(oauthInfo.getOid());
-            case SLACK -> {} // admin 만 해당 (연결 해제 불필요)
-            // TODO: Apple 은 refresh_token 저장 후 unlinkAppleUser 호출 필요
-            case APPLE -> {}
+        try {
+            switch (oauthInfo.getProvider()) {
+                case KAKAO -> oauthHelper.unlinkKakaoUser(oauthInfo.getOid());
+                case NAVER -> oauthHelper.unlinkNaverUser(oauthInfo.getOid());
+                case SLACK -> {} // admin 만 해당 (연결 해제 불필요)
+                // TODO: Apple 은 refresh_token 저장 후 unlinkAppleUser 호출 필요
+                case APPLE -> {}
+            }
+        } catch (Exception e) {
+            log.warn("OAuth unlink failed; continuing withdraw. userId={}, provider={}",
+                    userId, oauthInfo.getProvider(), e);
+            // TODO: best-effort + 재시도 워커 처리 고려중
         }
+
 
         // 2. 유저 탈퇴 처리 (RefreshToken / 관심작품 / 서재 삭제 + 푸시 알림 발송 대상 제외)
         authService.withDrawUser(userId);

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -103,6 +103,9 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_ERROR_001", "알림을 찾을 수 없습니다"),
     NOTIFICATION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NOTIFICATION_ERROR_002", "인가되지 않은 접근입니다."),
 
+    // PushDevice error
+    PUSH_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE_ERROR_001", "해당 기기 식별자로 등록된 디바이스가 없습니다."),
+
     // Topic Room error
     ADULT_VERIFICATION_REQUIRED(HttpStatus.BAD_REQUEST, "TOPIC_ROOM_ERROR_001", "성인인증이 되지 않은 사용자입니다."),
     TOPIC_ROOM_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "TOPIC_ROOM_ERROR_002", "토픽룸 최대 개수는 9개입니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -17,6 +17,11 @@ public enum SuccessCode {
     NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "NOTI2003", "알림을 읽음 처리했습니다."),
     NOTIFICATION_READ_ALL_SUCCESS(HttpStatus.OK, "NOTI2004", "모든 알림을 읽음 처리했습니다."),
 
+    // PushDevice success
+    DEVICE_SYNC_SUCCESS(HttpStatus.OK, "DEVICE2001", "디바이스 동기화에 성공했습니다."),
+    DEVICE_UNREGISTER_SUCCESS(HttpStatus.OK, "DEVICE2002", "디바이스 해제에 성공했습니다."),
+    DEVICE_TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "DEVICE2003", "FCM 토큰 갱신에 성공했습니다."),
+
     // Auth success
     OAUTH_LOGIN_SUCCESS(HttpStatus.OK, "OAUTH_SUCCESS_001", "소셜 로그인에 성공했습니다."),
     OAUTH_PRE_LOGIN_SUCCESS(HttpStatus.OK, "OAUTH_SUCCESS_002", "소셜 로그인에 성공했습니다. 회원가입이 필요합니다."),

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
@@ -1,0 +1,54 @@
+package com.storix.domain.domains.pushdevice.adaptor;
+
+import com.storix.domain.domains.pushdevice.domain.PushDevice;
+import com.storix.domain.domains.pushdevice.dto.SyncDeviceCommand;
+import com.storix.domain.domains.pushdevice.exception.UnknownPushDeviceException;
+import com.storix.domain.domains.pushdevice.repository.PushDeviceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class PushDeviceAdaptor {
+
+    private final PushDeviceRepository pushDeviceRepository;
+
+    /** 조회 작업 관련 메서드 */
+    // [PushDevice] FCM 토큰 갱신
+    public PushDevice getByUserIdAndInstallationId(Long userId, String installationId) {
+        // (userId, installationId) 기존 row 없을 경우 예외 처리
+        return pushDeviceRepository.findByUserIdAndInstallationId(userId, installationId)
+                .orElseThrow(() -> UnknownPushDeviceException.EXCEPTION);
+    }
+
+    /** 쓰기 작업 관련 메서드 */
+    // [PushDevice] 사용자 디바이스 및 FCM 토큰 등록 (upsert)
+    @Transactional
+    public boolean upsert(Long userId, SyncDeviceCommand cmd) {
+        // 1. (userId, installationId) 기존 row 조회
+        Optional<PushDevice> existing = pushDeviceRepository.findByUserIdAndInstallationId(userId, cmd.installationId());
+
+        // 2-1. 기존 row 있으면 갱신 (dirty checking)
+        if (existing.isPresent()) {
+            existing.get().refresh(cmd);
+            return false;
+        }
+
+        // 2-2. 기존 row 없으면 등록
+        pushDeviceRepository.save(PushDevice.from(userId, cmd));
+        return true;
+    }
+
+    // [PushDevice] 단일 디바이스 비활성화
+    public int deactivateByUserIdAndInstallationId(Long userId, String installationId) {
+        return pushDeviceRepository.deactivateByUserIdAndInstallationId(userId, installationId);
+    }
+
+    // [PushDevice] 유저 탈퇴 시 모든 디바이스 일괄 비활성화
+    public int deactivateAllByUserId(Long userId) {
+        return pushDeviceRepository.deactivateAllByUserId(userId);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/domain/OSPlatform.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/domain/OSPlatform.java
@@ -1,0 +1,6 @@
+package com.storix.domain.domains.pushdevice.domain;
+
+public enum OSPlatform {
+    IOS,
+    ANDROID
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/domain/PushDevice.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/domain/PushDevice.java
@@ -1,0 +1,115 @@
+package com.storix.domain.domains.pushdevice.domain;
+
+import com.storix.common.model.BaseTimeEntity;
+import com.storix.domain.domains.pushdevice.dto.SyncDeviceCommand;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(
+        name = "push_devices",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_push_device_installation",
+                columnNames = {"user_id", "installation_id"}
+        ),
+        indexes = {
+                @Index(name = "idx_push_device_user_active", columnList = "user_id, is_active"),
+                @Index(name = "idx_push_device_fcm_token", columnList = "fcm_token")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PushDevice extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "push_device_id")
+    private Long id;
+
+    // 유저 식별자
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    // 기기 식별자
+    @Column(name = "installation_id", nullable = false, length = 64)
+    private String installationId;
+
+    // FCM 토큰
+    @Column(name = "fcm_token", nullable = false, length = 512)
+    private String fcmToken;
+
+    // 기기 정보
+    @Enumerated(EnumType.STRING)
+    @Column(name = "os_platform", nullable = false, length = 16)
+    private OSPlatform osPlatform;
+
+    @Column(name = "app_version", nullable = false, length = 32)
+    private String appVersion;
+
+    @Column(name = "os_version", nullable = false, length = 32)
+    private String osVersion;
+
+    @Column(name = "device_model", nullable = false, length = 64)
+    private String deviceModel;
+
+    // 기기 알림 권한
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    // FCM 발송에 성공한 마지막 시각
+    @Column(name = "last_success_at")
+    private LocalDateTime lastSuccessAt;
+
+
+    /** 생성자 메서드 */
+    @Builder
+    public PushDevice(Long userId,
+                      String installationId,
+                      String fcmToken,
+                      OSPlatform osPlatform,
+                      String appVersion,
+                      String osVersion,
+                      String deviceModel) {
+        this.userId = userId;
+        this.installationId = installationId;
+        this.fcmToken = fcmToken;
+        this.osPlatform = osPlatform;
+        this.appVersion = appVersion;
+        this.osVersion = osVersion;
+        this.deviceModel = deviceModel;
+        this.isActive = true;
+    }
+
+    public static PushDevice from(Long userId, SyncDeviceCommand cmd) {
+        return PushDevice.builder()
+                .userId(userId)
+                .installationId(cmd.installationId())
+                .fcmToken(cmd.fcmToken())
+                .osPlatform(cmd.osPlatform())
+                .appVersion(cmd.appVersion())
+                .osVersion(cmd.osVersion())
+                .deviceModel(cmd.deviceModel())
+                .build();
+    }
+
+
+    /** 비즈니스 메서드 */
+    // 1. 디바이스 정보 + FCM 토큰 갱신
+    public void refresh(SyncDeviceCommand cmd) {
+        this.fcmToken = cmd.fcmToken();
+        this.appVersion = cmd.appVersion();
+        this.osVersion = cmd.osVersion();
+        this.isActive = true;
+    }
+
+    // 2. FCM 토큰 갱신
+    public void refreshFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+        this.isActive = true;
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/dto/SyncDeviceCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/dto/SyncDeviceCommand.java
@@ -1,0 +1,13 @@
+package com.storix.domain.domains.pushdevice.dto;
+
+import com.storix.domain.domains.pushdevice.domain.OSPlatform;
+
+public record SyncDeviceCommand(
+        String installationId,
+        String fcmToken,
+        OSPlatform osPlatform,
+        String appVersion,
+        String osVersion,
+        String deviceModel
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/exception/UnknownPushDeviceException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/exception/UnknownPushDeviceException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.pushdevice.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class UnknownPushDeviceException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new UnknownPushDeviceException();
+
+    private UnknownPushDeviceException() { super(ErrorCode.PUSH_DEVICE_NOT_FOUND); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
@@ -1,0 +1,26 @@
+package com.storix.domain.domains.pushdevice.repository;
+
+import com.storix.domain.domains.pushdevice.domain.PushDevice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
+
+    // 단일 디바이스 조회
+    Optional<PushDevice> findByUserIdAndInstallationId(Long userId, String installationId);
+
+    // 단일 디바이스 비활성화
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PushDevice d SET d.isActive = false WHERE d.userId = :userId AND d.installationId = :installationId")
+    int deactivateByUserIdAndInstallationId(@Param("userId") Long userId,
+                                            @Param("installationId") String installationId);
+
+    // 유저 탈퇴 시 해당 유저의 모든 활성 디바이스 일괄 비활성화
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PushDevice d SET d.isActive = false WHERE d.userId = :userId AND d.isActive = true")
+    int deactivateAllByUserId(@Param("userId") Long userId);
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/service/PushDeviceService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/service/PushDeviceService.java
@@ -1,0 +1,47 @@
+package com.storix.domain.domains.pushdevice.service;
+
+import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
+import com.storix.domain.domains.pushdevice.domain.PushDevice;
+import com.storix.domain.domains.pushdevice.dto.SyncDeviceCommand;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 사용자 디바이스 관련 서비스
+ * */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PushDeviceService {
+
+    private final PushDeviceAdaptor pushDeviceAdaptor;
+
+    // 단일 디바이스 푸시 알림 상태 동기화
+    public boolean sync(Long userId, SyncDeviceCommand cmd) {
+        try {
+            // 1-1. 단일 디바이스 정보 upsert
+            return pushDeviceAdaptor.upsert(userId, cmd);
+        } catch (DataIntegrityViolationException e) {
+            // 1-2. (userId, installationId) unique constraint 충돌 시 > 재시도 (update)
+            log.warn(">>>> [PushDevice] register race detected, retrying. userId={}, installationId={}",
+                    userId, cmd.installationId());
+            return pushDeviceAdaptor.upsert(userId, cmd);
+        }
+    }
+
+    // 단일 디바이스 비활성화
+    @Transactional
+    public int unregister(Long userId, String installationId) {
+        return pushDeviceAdaptor.deactivateByUserIdAndInstallationId(userId, installationId);
+    }
+
+    // FCM 토큰 갱신
+    @Transactional
+    public void refreshFcmToken(Long userId, String installationId, String fcmToken) {
+        PushDevice device = pushDeviceAdaptor.getByUserIdAndInstallationId(userId, installationId);
+        device.refreshFcmToken(fcmToken);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -5,6 +5,7 @@ import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
 import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
 import com.storix.domain.domains.onboarding.service.OnboardingWorksHelper;
+import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
 import com.storix.domain.domains.user.dto.CreateReaderUserCommand;
 import com.storix.domain.domains.user.dto.OnboardingPrincipal;
 import com.storix.domain.domains.user.dto.ReaderSignupRequest;
@@ -13,21 +14,26 @@ import com.storix.domain.domains.user.exception.me.DuplicateUserException;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.domain.domains.user.adaptor.TokenAdaptor;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
+import com.storix.domain.domains.user.domain.OAuthInfo;
 import com.storix.domain.domains.user.domain.OAuthProvider;
 import com.storix.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
     private final UserAdaptor userAdaptor;
-    private final OnboardingWorksHelper onboardingWorksHelper;
-    private final LibraryAdaptor libraryAdaptor;
     private final TokenAdaptor tokenAdaptor;
+    private final LibraryAdaptor libraryAdaptor;
     private final FavoriteWorksAdaptor favoriteWorksAdaptor;
+
+    private final PushDeviceAdaptor pushDeviceAdaptor;
+
+    private final OnboardingWorksHelper onboardingWorksHelper; // -> usecase 리팩토링 필요
     private final GenreScorePublisher genreScorePublisher;
 
     // 독자 회원 가입 가능 여부 (토큰 검증, 계정 정보 유무)
@@ -97,13 +103,37 @@ public class AuthService {
         userAdaptor.checkNicknameDuplicate(nickName);
     }
 
+    // 유저 OAuth 정보 조회
+    @Transactional(readOnly = true)
+    public OAuthInfo findOAuthInfoByUserId(Long userId) {
+        return userAdaptor.findUserById(userId).getOauthInfo();
+    }
+
+    // 유저 로그아웃
+    @Transactional
+    public void logout(Long userId, String installationId) {
+        // 1. refreshToken 삭제 (Redis)
+        tokenAdaptor.deleteRefreshTokenByUserId(userId);
+
+        // 2. [Native] 해당 디바이스 FCM 토큰 비활성화
+        if (StringUtils.hasText(installationId)) {
+            pushDeviceAdaptor.deactivateByUserIdAndInstallationId(userId, installationId);
+        }
+    }
+
     // 유저 회원 탈퇴
     @Transactional
     public void withDrawUser(Long userId) {
+        // 1. 유저 soft-delete
         User user = userAdaptor.findUserById(userId);
         user.withdraw();
+
+        // 2. 유저 관련 정보 (refresh 토큰, 관심 작품, 서재) 삭제
         tokenAdaptor.deleteRefreshTokenByUserId(userId);
         favoriteWorksAdaptor.deleteFavoriteWorks(userId);
         libraryAdaptor.deleteLibrary(userId);
+
+        // 3. 푸시 알림 디바아스 일괄 비활성화
+        pushDeviceAdaptor.deactivateAllByUserId(userId);
     }
 }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 푸시 디바이스(PushDevice) 도메인 추가
- 유저 식별자, 디바이스 식별자, 디바이스 정보(OS/디바이스에 설치된 앱), FCM 토큰, 토큰 상태 정보를 저장합니다. 
- 한 유저가 N개 디바이스를 동시에 보유할 수 있는 환경(멀티 디바이스)을 전제로, (userId, installationId) 유니크 키를 걸어두었습니다.
  - [installationId] 디바이스 고유 식별자입니다. FE 측에서 앱 설치 시점에 생성/보관하도록 요청할 예정이며, 토큰 회전이나 앱 재설치에도 안정적으로 같은 디바이스를 식별할 수 있도록 합니다.


### 2. 디바이스 등록/해제/토큰 갱신 API 구현
- `[POST /api/v1/push-devices/sync]` 단일 디바이스 동기화 (upsert)
  - 동일 (userId, installationId) row 존재 시 dirty checking 으로 fcmToken, appVersion, osPlatform 갱신합니다.
  - 미존재 시 신규 row를 등록합니다.
  -> 동일 디바이스에서 짧은 시간 안에 sync 가 두 번 호출되어 두 요청이 모두 "row 없음 → insert" 분기를 타는 경우 → 두 번째 insert 가 unique constraint 위반(DataIntegrityViolationException) 으로 실패합니다. 이를 PushDeviceService.sync 에서 catch 후 1회 재시도하여 갱신하도록 하였습니다.
- `[DELETE /api/v1/push-devices]` 단일 디바이스 비활성화
- `[PATCH /api/v1/push-devices/fcm-token]` FCM 토큰 단독 갱신

### 3. 인증 로직 개편 (로그아웃 v2, 회원탈퇴)
1. 로그아웃 v2 API 추가
- `[v1] POST /api/v1/auth/user/logout` — 기존 동작 유지(웹 쿠키 삭제) + 마이그레이션 안내 description 추가.
- `[v2] POST /api/v2/auth/user/logout` — 신규. Body 로 installationId 를 받아, 해당 디바이스의 FCM 토큰을 비활성화합니다.
  - [Native] ~~installationId 가 있을 경우 →~~ 해당 디바이스 row 의 isActive=false + RefreshToken 삭제.
  - ~~[Web] installationId 가 없을 경우 → 기존처럼 RefreshToken 쿠키 삭제 헤더 반환.~~
     (update at 26.5.19)
  

2. 회원탈퇴 시 FCM 토큰 비활성화 로직 추가
- AuthService.withDrawUser 안에 pushDeviceAdaptor.deactivateAllByUserId(userId) 호출을 추가하여, 탈퇴한 유저에게 푸시가 더 이상 가지 않도록 보장합니다. (탈퇴 후 알림 발송 방지)

### 4. 기타
- LogoutUseCase, WithDrawUseCase 의 로직 흐름을 파사드 패턴에 맞게 최대한 정리하였습니다.
- AuthController 스웨거 태그명을 "온보딩" → "인증" 으로 변경


## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #61 

## 🖇️ 기타
알림 시스템 관련 작업량이 많은 관계로, 다음과 같이 PR을 쪼개서 올릴 예정입니다.
```
develop
    └─ feature/2.0/SPRINT-2-alarm-system   ← 현재 브랜치 (PushDevice + Auth)
          └─ feature/2.0/SPRINT-2-notifications   ← 새 브랜치 (알림 시스템)

GitHub PR:
- PR-1: base=develop, head=SPRINT-2-alarm-system
- PR-2: base=SPRINT-2-alarm-system, head=SPRINT-2-notifications
```
-> PR-1 머지후 SPRINT-2-alarm-system 브랜치 삭제 시 PR-2의 base가 자동으로 develop으로 변경됩니다.


[추가 작업]
- 애플 소셜 로그인 유저가 회원탈퇴 시 unlink 하는 절차가 반드시 필요하다고 합니다. 알림 기능 이후 PR에서 추가 작업할 예정입니다.
  - 외부 API(OAuth unlink) 호출 실패 시 회원 탈퇴 자체가 막히는 현재 동작에 대해, 추후 best-effort + 재시도 워커 도입을 고려중입니다. 
- 비활성화된 토큰들을 한 번에 정리하는 로직이 필요합니다. 추가 작업할 예정입니다.

+논의한 대로 응답값을 controller에서 조합하도록 하였습니다. 다만, 기존 인증 로직 대부분의 응답 구조가 helper 클래스에 의존하고 있어서 usecase에서 조합해서 controller로 올리는 부분은 건들이지 않았습니다..