### PR TITLE
Feat: [알림 시스템] 이벤트 기반 FCM 푸시 알림 기능 구현

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
@@ -1,15 +1,13 @@
-package com.storix.api.domain.notification;
+package com.storix.api.domain.notification.controller;
 
-import com.storix.domain.domains.notification.dto.NotificationResponseDto;
-import com.storix.domain.domains.notification.service.NotificationService;
-import com.storix.domain.domains.user.adaptor.AuthUserDetails;
+import com.storix.api.domain.notification.usecase.NotificationUseCase;
 import com.storix.common.payload.CustomResponse;
-import com.storix.common.code.SuccessCode;
+import com.storix.domain.domains.notification.dto.NotificationResponseDto;
+import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -20,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "사용자 알림", description = "알림 관련 API")
 public class NotificationController {
 
-    private final NotificationService notificationService;
+    private final NotificationUseCase notificationUseCase;
 
     // 1. 전체 알림 목록 조회
     @GetMapping
@@ -32,8 +30,7 @@ public class NotificationController {
             @Parameter(description = "한 번에 가져올 개수 (기본 10)")
             @RequestParam(name = "size", defaultValue = "10") int size
     ) {
-        Slice<NotificationResponseDto> result = notificationService.getNotifications(authUser.getUserId(), cursorId, PageRequest.of(0, size));
-        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_LOAD_SUCCESS, result);
+        return notificationUseCase.getNotifications(authUser.getUserId(), cursorId, size);
     }
 
     // 2. 안 읽은 알림 개수 조회
@@ -42,8 +39,7 @@ public class NotificationController {
     public CustomResponse<Long> getUnreadCount(
             @AuthenticationPrincipal AuthUserDetails authUser
     ) {
-        long count = notificationService.getUnreadCount(authUser.getUserId());
-        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_COUNT_SUCCESS, count);
+        return notificationUseCase.getUnreadCount(authUser.getUserId());
     }
 
     // 3. 단건 알림 읽음 처리
@@ -53,8 +49,7 @@ public class NotificationController {
             @AuthenticationPrincipal AuthUserDetails authUser,
             @PathVariable("id") Long notificationId
     ) {
-        notificationService.readNotification(authUser.getUserId(), notificationId);
-        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_READ_SUCCESS);
+        return notificationUseCase.readNotification(authUser.getUserId(), notificationId);
     }
 
     // 4. 전체 알림 읽음 처리
@@ -63,7 +58,6 @@ public class NotificationController {
     public CustomResponse<Void> readAllNotifications(
             @AuthenticationPrincipal AuthUserDetails authUser
     ) {
-        notificationService.readAllNotifications(authUser.getUserId());
-        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_READ_ALL_SUCCESS);
+        return notificationUseCase.readAllNotifications(authUser.getUserId());
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
@@ -1,8 +1,11 @@
 package com.storix.api.domain.notification.controller;
 
+import com.storix.api.domain.notification.usecase.NotificationSettingUseCase;
 import com.storix.api.domain.notification.usecase.NotificationUseCase;
 import com.storix.common.payload.CustomResponse;
 import com.storix.domain.domains.notification.dto.NotificationResponseDto;
+import com.storix.domain.domains.notification.dto.NotificationSettingResponse;
+import com.storix.domain.domains.notification.dto.UpdateNotificationSettingRequest;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,7 +22,9 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
 
     private final NotificationUseCase notificationUseCase;
+    private final NotificationSettingUseCase notificationSettingUseCase;
 
+    /** 사용자 알림함 */
     // 1. 전체 알림 목록 조회
     @GetMapping
     @Operation(summary = "전체 알림 목록 조회", description = "커서 기반 무한 스크롤입니다. cursorId는 직전 응답의 마지막 알림 ID이며, 첫 요청은 cursorId를 제외합니다.")
@@ -59,5 +64,25 @@ public class NotificationController {
             @AuthenticationPrincipal AuthUserDetails authUser
     ) {
         return notificationUseCase.readAllNotifications(authUser.getUserId());
+    }
+
+    /** 알림 설정 */
+    // 5. 알림 설정 조회
+    @GetMapping("/settings")
+    @Operation(summary = "알림 설정 조회", description = "푸시 알림 수신 여부와 알림 종류별 수신 여부를 조회합니다.")
+    public CustomResponse<NotificationSettingResponse> getSettings(
+            @AuthenticationPrincipal AuthUserDetails authUser
+    ) {
+        return notificationSettingUseCase.getNotificationSetting(authUser.getUserId());
+    }
+
+    // 6. 알림 설정 변경
+    @PatchMapping("/settings")
+    @Operation(summary = "알림 설정 변경", description = "알림 수신 여부를 갱신합니다. 변경하려는 항목만 requestBody 에 포함하면 됩니다.")
+    public CustomResponse<NotificationSettingResponse> updateSettings(
+            @AuthenticationPrincipal AuthUserDetails authUser,
+            @RequestBody UpdateNotificationSettingRequest request
+    ) {
+        return notificationSettingUseCase.updateNotificationSetting(authUser.getUserId(), request);
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
@@ -1,6 +1,9 @@
 package com.storix.api.domain.notification.controller;
 
+import com.storix.api.domain.notification.controller.dto.FcmSendRequest;
+import com.storix.api.domain.notification.controller.dto.NotificationDispatchTestRequest;
 import com.storix.api.domain.notification.usecase.NotificationSettingUseCase;
+import com.storix.api.domain.notification.usecase.NotificationTestUseCase;
 import com.storix.api.domain.notification.usecase.NotificationUseCase;
 import com.storix.common.payload.CustomResponse;
 import com.storix.domain.domains.notification.dto.NotificationResponseDto;
@@ -10,6 +13,7 @@ import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,6 +27,7 @@ public class NotificationController {
 
     private final NotificationUseCase notificationUseCase;
     private final NotificationSettingUseCase notificationSettingUseCase;
+    private final NotificationTestUseCase notificationTestUseCase;
 
     /** 사용자 알림함 */
     // 1. 전체 알림 목록 조회
@@ -84,5 +89,26 @@ public class NotificationController {
             @RequestBody UpdateNotificationSettingRequest request
     ) {
         return notificationSettingUseCase.updateNotificationSetting(authUser.getUserId(), request);
+    }
+
+
+    /** 테스트용 FCM 알림 전송 */
+    // [ADMIN][test] FCM 환경변수 세팅 검증
+    @PostMapping("/admin/test-push")
+    @Operation(summary = "[ADMIN][테스트] FCM 푸시 전송", description = "요청 body 의 token 으로 알림 1건 전송하고 FCM messageId 반환.")
+    public CustomResponse<String> sendTestPush(
+            @RequestBody @Valid FcmSendRequest request
+    ) {
+        return notificationTestUseCase.sendTestPush(request);
+    }
+
+    // [ADMIN][test] 알림 E2E 검증 (인앱 저장 + 멀티 디바이스 푸시)
+    @PostMapping("/admin/test-dispatch")
+    @Operation(summary = "[ADMIN][테스트] 알림 E2E (인앱 + 푸시)", description = "지정한 recipientUserId 로 NotificationEvent 를 publish.  \n" +
+            "AFTER_COMMIT 후 listener 가 인앱 저장 + 활성 디바이스에 FCM 발송.")
+    public CustomResponse<Void> testDispatch(
+            @RequestBody @Valid NotificationDispatchTestRequest request
+    ) {
+        return notificationTestUseCase.testDispatch(request);
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/FcmSendRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/FcmSendRequest.java
@@ -1,0 +1,19 @@
+package com.storix.api.domain.notification.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record FcmSendRequest(
+        @NotBlank(message = "FCM device token 을 보내주세요.")
+        @Size(max = 512)
+        String token,
+
+        @NotBlank(message = "알림 제목을 보내주세요.")
+        @Size(max = 50)
+        String title,
+
+        @NotBlank(message = "알림 본문을 보내주세요.")
+        @Size(max = 200)
+        String body
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/NotificationDispatchTestRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/NotificationDispatchTestRequest.java
@@ -1,0 +1,37 @@
+package com.storix.api.domain.notification.controller.dto;
+
+import com.storix.domain.domains.notification.domain.NotificationType;
+import com.storix.domain.domains.notification.domain.TargetType;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record NotificationDispatchTestRequest(
+        @NotNull(message = "수신자 userId 를 보내주세요.")
+        Long recipientUserId,
+
+        @NotNull(message = "Schema에 맞게 알림 타입을 보내주세요.")
+        NotificationType type,
+
+        @NotNull(message = "Schema에 맞게 타겟 타입을 보내주세요.")
+        TargetType targetType,
+
+        Long targetId,
+
+        Long parentTargetId,
+
+        @NotBlank(message = "알림 제목을 보내주세요.")
+        @Size(max = 50)
+        String title,
+
+        @NotBlank(message = "알림 본문을 보내주세요.")
+        @Size(max = 200)
+        String content
+) {
+    public NotificationEvent toEvent() {
+        return new NotificationEvent(
+                recipientUserId, type, targetType, targetId, parentTargetId, title, content
+        );
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/NotificationSettingUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/NotificationSettingUseCase.java
@@ -1,0 +1,39 @@
+package com.storix.api.domain.notification.usecase;
+
+import com.storix.common.annotation.UseCase;
+import com.storix.common.code.SuccessCode;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.notification.domain.NotificationSetting;
+import com.storix.domain.domains.notification.dto.NotificationSettingResponse;
+import com.storix.domain.domains.notification.dto.UpdateNotificationSettingRequest;
+import com.storix.domain.domains.notification.service.NotificationSettingService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class NotificationSettingUseCase {
+
+    private final NotificationSettingService notificationSettingService;
+
+    // 알림 설정 조회
+    public CustomResponse<NotificationSettingResponse> getNotificationSetting(Long userId) {
+        NotificationSetting setting = notificationSettingService.get(userId);
+        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_PREFERENCE_LOAD_SUCCESS, NotificationSettingResponse.from(setting));
+    }
+
+    // 알림 설정 변경
+    public CustomResponse<NotificationSettingResponse> updateNotificationSetting(Long userId, UpdateNotificationSettingRequest request) {
+        NotificationSetting updated = notificationSettingService.update(
+                userId,
+                request.likeFeedEnabled(),
+                request.likeReviewEnabled(),
+                request.likeCommentEnabled(),
+                request.commentOnFeedEnabled(),
+                request.replyOnCommentEnabled(),
+                request.todayFeedEnabled(),
+                request.hotTopicRoomEnabled(),
+                request.marketingEnabled()
+        );
+        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_PREFERENCE_UPDATE_SUCCESS, NotificationSettingResponse.from(updated));
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/NotificationSettingUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/NotificationSettingUseCase.java
@@ -23,17 +23,7 @@ public class NotificationSettingUseCase {
 
     // 알림 설정 변경
     public CustomResponse<NotificationSettingResponse> updateNotificationSetting(Long userId, UpdateNotificationSettingRequest request) {
-        NotificationSetting updated = notificationSettingService.update(
-                userId,
-                request.likeFeedEnabled(),
-                request.likeReviewEnabled(),
-                request.likeCommentEnabled(),
-                request.commentOnFeedEnabled(),
-                request.replyOnCommentEnabled(),
-                request.todayFeedEnabled(),
-                request.hotTopicRoomEnabled(),
-                request.marketingEnabled()
-        );
+        NotificationSetting updated = notificationSettingService.update(userId, request.toCommand());
         return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_PREFERENCE_UPDATE_SUCCESS, NotificationSettingResponse.from(updated));
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/NotificationTestUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/NotificationTestUseCase.java
@@ -1,0 +1,57 @@
+package com.storix.api.domain.notification.usecase;
+
+import com.storix.api.domain.notification.controller.dto.FcmSendRequest;
+import com.storix.api.domain.notification.controller.dto.NotificationDispatchTestRequest;
+import com.storix.common.annotation.UseCase;
+import com.storix.common.code.SuccessCode;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.notification.exception.FcmSendFailedException;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
+import com.storix.domain.domains.pushdevice.service.PushDispatchService;
+import com.storix.infrastructure.external.fcm.FcmSender;
+import com.storix.infrastructure.external.fcm.dto.SingleSendResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@UseCase
+@RequiredArgsConstructor
+public class NotificationTestUseCase {
+
+    private final PushDispatchService pushDispatchService;
+
+    private final NotificationPublisher notificationPublisher;
+    private final FcmSender fcmSender;
+
+
+    // [test] FCM 환경변수 검증용 (data-only)
+    public CustomResponse<String> sendTestPush(FcmSendRequest request) {
+        // 1. data payload — title/body 도 data 에 담아 보냄 (data-only 정책)
+        Map<String, String> data = new HashMap<>();
+        data.put("title", request.title());
+        data.put("body", request.body());
+
+        // 2. FCM 알림 전송
+        SingleSendResult result = fcmSender.sendToToken(request.token(), data);
+
+        // 2-1. FCM 알림 전송에 invalid FCM 토큰이 포함되어 있었을 경우 > FCM 토큰 비활성화
+        if (result.invalidToken() != null) {
+            pushDispatchService.deactivateTokens(List.of(result.invalidToken()));
+            throw FcmSendFailedException.EXCEPTION;
+        }
+
+        // 2-2. FCM 알림 전송 성공 시 lastSuccessAt 갱신 (추후 장기 미사용 토큰 청소용)
+        pushDispatchService.markTokensSuccess(List.of(request.token()));
+        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_TEST_PUSH_SUCCESS, result.messageId());
+    }
+
+    // [test] 단일 유저
+    @Transactional
+    public CustomResponse<Void> testDispatch(NotificationDispatchTestRequest request) {
+        notificationPublisher.publish(request.toEvent());
+        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_TEST_PUSH_SUCCESS);
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/NotificationUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/NotificationUseCase.java
@@ -1,0 +1,41 @@
+package com.storix.api.domain.notification.usecase;
+
+import com.storix.common.annotation.UseCase;
+import com.storix.common.code.SuccessCode;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.notification.dto.NotificationResponseDto;
+import com.storix.domain.domains.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+@UseCase
+@RequiredArgsConstructor
+public class NotificationUseCase {
+
+    private final NotificationService notificationService;
+
+    // 전체 알림 목록 조회
+    public CustomResponse<Slice<NotificationResponseDto>> getNotifications(Long userId, Long cursorId, int size) {
+        Slice<NotificationResponseDto> result = notificationService.getNotifications(userId, cursorId, PageRequest.of(0, size));
+        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_LOAD_SUCCESS, result);
+    }
+
+    // 안 읽은 알림 개수 조회
+    public CustomResponse<Long> getUnreadCount(Long userId) {
+        long count = notificationService.getUnreadCount(userId);
+        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_COUNT_SUCCESS, count);
+    }
+
+    // 단건 알림 읽음 처리
+    public CustomResponse<Void> readNotification(Long userId, Long notificationId) {
+        notificationService.readNotification(userId, notificationId);
+        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_READ_SUCCESS);
+    }
+
+    // 전체 알림 읽음 처리
+    public CustomResponse<Void> readAllNotifications(Long userId) {
+        notificationService.readAllNotifications(userId);
+        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_READ_ALL_SUCCESS);
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -11,7 +11,7 @@ import com.storix.domain.domains.user.adaptor.OnboardingUserDetails;
 import com.storix.domain.domains.user.domain.OAuthProvider;
 import com.storix.common.payload.CustomResponse;
 import com.storix.domain.domains.user.dto.OAuthAuthorizationRequest;
-import com.storix.domain.domains.user.dto.ReaderSignupRequest;
+import com.storix.api.domain.user.controller.dto.ReaderSignupRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -93,13 +93,14 @@ public class AuthController {
         return oauthLoginUseCase.readerOAuthNativeLogin(req, OAuthProvider.NAVER);
     }
 
-    @Operation(summary = "독자 계정 회원가입", description = "유저 정보를 최종적으로 등록하는 api 입니다.  \n온보딩 토큰을 보내주세요.")
+    @Operation(summary = "[v1] 독자 계정 회원가입", description = "[v1 > v2 마이그레이션 필요] 유저 정보를 최종적으로 등록하는 api 입니다.   \n" +
+            "온보딩 토큰을 보내주세요.")
     @PostMapping("/users/reader/signup")
     public ResponseEntity<CustomResponse<AuthorizationResponse>> readerUserSignup(
             @AuthenticationPrincipal OnboardingUserDetails onboardingUser,
             @Valid @RequestBody ReaderSignupRequest req
     ) {
-        return authUseCase.readerSignup(req, onboardingUser.getJti());
+        return authUseCase.readerSignup(req.toData(), onboardingUser.getJti());
     }
 
     @Operation(summary = "닉네임 중복 체크", description = "닉네임 중복 여부를 체크하는 api 입니다.")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
@@ -1,11 +1,16 @@
 package com.storix.api.domain.user.controller;
 
+import com.storix.api.domain.user.controller.dto.AuthorizationResponse;
 import com.storix.api.domain.user.controller.dto.LogoutRequest;
+import com.storix.api.domain.user.usecase.AuthUseCase;
 import com.storix.api.domain.user.usecase.LogoutUseCase;
 import com.storix.common.payload.CustomResponse;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
+import com.storix.domain.domains.user.adaptor.OnboardingUserDetails;
+import com.storix.api.domain.user.controller.dto.ReaderSignupRequestV2;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,7 +25,20 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "인증", description = "인증 관련 API")
 public class AuthV2Controller {
 
+    private final AuthUseCase authUseCase;
     private final LogoutUseCase logoutUseCase;
+
+    @Operation(summary = "[v2] 독자 계정 회원가입", description = "유저 정보를 최종적으로 등록하는 api 입니다.   \n" +
+            "- 온보딩 토큰을 헤더로 보내주세요.  \n" +
+            "- v1 의 marketingAgree 필드 대신 termsAgree(서비스 이용약관 동의) 필드를 받습니다.  \n" +
+            "- 마케팅 알림 수신 동의 여부는 가입 후 별도 모달에서 받습니다.")
+    @PostMapping("/users/reader/signup")
+    public ResponseEntity<CustomResponse<AuthorizationResponse>> readerUserSignup(
+            @AuthenticationPrincipal OnboardingUserDetails onboardingUser,
+            @Valid @RequestBody ReaderSignupRequestV2 req
+    ) {
+        return authUseCase.readerSignup(req.toData(), onboardingUser.getJti());
+    }
 
     @Operation(summary = "[v2] 로그아웃", description = "로그아웃용 api 입니다. 헤더로 액세스 토큰을 보내주세요.  \n" +
             "- Native: RequestBody에 installationId(기기 식별자)를 함께 보내주세요.  \n" +

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderSignupRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderSignupRequest.java
@@ -1,5 +1,6 @@
-package com.storix.domain.domains.user.dto;
+package com.storix.api.domain.user.controller.dto;
 
+import com.storix.domain.domains.user.dto.ReaderSignUpData;
 import com.storix.domain.domains.works.domain.Genre;
 import jakarta.validation.constraints.*;
 
@@ -29,4 +30,8 @@ public record ReaderSignupRequest(
     Set<Long> favoriteWorksIdList
 
 ) {
+    // [v1] marketingAgree 를 termsAgree 로 매핑
+    public ReaderSignUpData toData() {
+        return new ReaderSignUpData(marketingAgree, nickName, profileDescription, favoriteGenreList, favoriteWorksIdList);
+    }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderSignupRequestV2.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderSignupRequestV2.java
@@ -1,0 +1,36 @@
+package com.storix.api.domain.user.controller.dto;
+
+import com.storix.domain.domains.user.dto.ReaderSignUpData;
+import com.storix.domain.domains.works.domain.Genre;
+import jakarta.validation.constraints.*;
+
+import java.util.Set;
+
+public record ReaderSignupRequestV2(
+
+    @AssertTrue(message = "서비스 이용약관 동의는 필수입니다.")
+    Boolean termsAgree,
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 10, message = "닉네임은 2~10자까지 가능합니다.")
+    @Pattern(
+            regexp = "^[가-힣a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ ]+$",
+            message = "닉네임은 한글, 영문, 숫자, 공백만 가능하며 자음/모음/공백만으로는 불가능합니다."
+    )
+    String nickName,
+
+    @Size(max = 30, message = "한 줄 소개는 30자까지 가능합니다.")
+    String profileDescription,
+
+    @NotNull(message = "관심 장르는 필수입니다.")
+    @Size(min = 1, max = 3, message = "관심 장르는 1개 이상 3개 이하로 선택해야 합니다.")
+    Set<Genre> favoriteGenreList,
+
+    @Size(max = 18, message = "관심 작품은 18개 이하로 선택해야 합니다.")
+    Set<Long> favoriteWorksIdList
+
+) {
+    public ReaderSignUpData toData() {
+        return new ReaderSignUpData(termsAgree, nickName, profileDescription, favoriteGenreList, favoriteWorksIdList);
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderSignupRequestV2.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderSignupRequestV2.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 public record ReaderSignupRequestV2(
 
+    @NotNull(message = "서비스 이용약관 동의는 필수입니다.")
     @AssertTrue(message = "서비스 이용약관 동의는 필수입니다.")
     Boolean termsAgree,
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -63,8 +63,8 @@ public class AuthUseCase {
     }
 
     // 독자 유저 정보 등록
-    public ResponseEntity<CustomResponse<AuthorizationResponse>> readerSignup(ReaderSignupRequest req, String jti) {
-        AuthUserDetails userDetails = authService.signUpReaderUser(req, jti);
+    public ResponseEntity<CustomResponse<AuthorizationResponse>> readerSignup(ReaderSignUpData data, String jti) {
+        AuthUserDetails userDetails = authService.signUpReaderUser(data, jti);
         LoginWithTokenResponse tokenResponse = tokenGenerateHelper.generateLoginWithToken(userDetails);
         AuthorizationResponse result = AuthorizationResponse.webRefresh(tokenResponse.accessToken());
 

--- a/STORIX-Api/src/main/java/com/storix/api/global/GlobalExceptionHandler.java
+++ b/STORIX-Api/src/main/java/com/storix/api/global/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.storix.api.global;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.storix.api.domain.user.helper.CookieHelper;
 import com.storix.common.code.ErrorCode;
 import com.storix.common.payload.ErrorResponse;
@@ -12,14 +13,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
@@ -154,8 +159,56 @@ public class GlobalExceptionHandler {
                 .body(response);
     }
 
+    /**
+     * 요청 body 파싱 실패 — Jackson 단계에서 발생.
+     * cause 가 InvalidFormatException (enum 값 불일치 / 타입 변환 실패) 이면
+     * 어느 필드가 어떤 값으로 거부됐는지, enum 의 경우 허용값 목록까지 응답에 포함.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleNotReadable(HttpMessageNotReadableException e) {
+
+        log.warn("Body parse exception", e);
+
+        if (e.getCause() instanceof InvalidFormatException ife) {
+            String field = ife.getPath().stream()
+                    .map(InvalidFormatException.Reference::getFieldName)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.joining("."));
+            if (field.isEmpty()) field = "unknown";
+
+            Class<?> target = ife.getTargetType();
+            String reason;
+            if (target != null && target.isEnum()) {
+                String allowed = Arrays.stream(target.getEnumConstants())
+                        .map(Object::toString)
+                        .collect(Collectors.joining(", "));
+                reason = "허용되지 않는 값입니다. 허용값: [" + allowed + "]";
+            } else {
+                String typeName = target != null ? target.getSimpleName() : "올바른 타입";
+                reason = typeName + " 형식이 아닙니다.";
+            }
+
+            FieldErrorResponse fer = FieldErrorResponse.builder()
+                    .field(field)
+                    .rejectedValue(ife.getValue())
+                    .reason(reason)
+                    .build();
+
+            ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+            return ResponseEntity
+                    .status(errorCode.getHttpStatus())
+                    .body(new ErrorResponse(errorCode, List.of(fer)));
+        }
+
+        ErrorCode errorCode = ErrorCode.INVALID_JSON_REQUEST;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(new ErrorResponse(errorCode));
+    }
+
+    /** 그 외 변환 오류 (response 직렬화 실패 등) — fallback */
     @ExceptionHandler(HttpMessageConversionException.class)
-    public ResponseEntity<ErrorResponse> handleNotReadable(HttpMessageConversionException e) {
+    public ResponseEntity<ErrorResponse> handleConversion(HttpMessageConversionException e) {
 
         log.warn("Format exception", e);
 

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -103,6 +103,7 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_ERROR_001", "알림을 찾을 수 없습니다"),
     NOTIFICATION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NOTIFICATION_ERROR_002", "인가되지 않은 접근입니다."),
     FCM_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION_ERROR_003", "FCM 푸시 전송에 실패했습니다."),
+    NOTIFICATION_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_ERROR_004", "유저의 알림 설정이 존재하지 않습니다."),
 
     // PushDevice error
     PUSH_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE_ERROR_001", "해당 기기 식별자로 등록된 디바이스가 없습니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -102,6 +102,7 @@ public enum ErrorCode {
     // Notification error
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_ERROR_001", "알림을 찾을 수 없습니다"),
     NOTIFICATION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NOTIFICATION_ERROR_002", "인가되지 않은 접근입니다."),
+    FCM_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION_ERROR_003", "FCM 푸시 전송에 실패했습니다."),
 
     // PushDevice error
     PUSH_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE_ERROR_001", "해당 기기 식별자로 등록된 디바이스가 없습니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -16,6 +16,8 @@ public enum SuccessCode {
     NOTIFICATION_COUNT_SUCCESS(HttpStatus.OK, "NOTI2002", "안 읽은 알림 개수를 성공적으로 조회했습니다."),
     NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "NOTI2003", "알림을 읽음 처리했습니다."),
     NOTIFICATION_READ_ALL_SUCCESS(HttpStatus.OK, "NOTI2004", "모든 알림을 읽음 처리했습니다."),
+    NOTIFICATION_PREFERENCE_LOAD_SUCCESS(HttpStatus.OK, "NOTI2006", "알림 설정을 성공적으로 조회했습니다."),
+    NOTIFICATION_PREFERENCE_UPDATE_SUCCESS(HttpStatus.OK, "NOTI2007", "알림 설정이 변경되었습니다."),
 
     // PushDevice success
     DEVICE_SYNC_SUCCESS(HttpStatus.OK, "DEVICE2001", "디바이스 동기화에 성공했습니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -18,6 +18,7 @@ public enum SuccessCode {
     NOTIFICATION_READ_ALL_SUCCESS(HttpStatus.OK, "NOTI2004", "모든 알림을 읽음 처리했습니다."),
     NOTIFICATION_PREFERENCE_LOAD_SUCCESS(HttpStatus.OK, "NOTI2006", "알림 설정을 성공적으로 조회했습니다."),
     NOTIFICATION_PREFERENCE_UPDATE_SUCCESS(HttpStatus.OK, "NOTI2007", "알림 설정이 변경되었습니다."),
+    NOTIFICATION_TEST_PUSH_SUCCESS(HttpStatus.OK, "NOTI2008", "테스트 푸시 알림 전송에 성공했습니다."),
 
     // PushDevice success
     DEVICE_SYNC_SUCCESS(HttpStatus.OK, "DEVICE2001", "디바이스 동기화에 성공했습니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/property/FirebaseConfig.java
+++ b/STORIX-Common/src/main/java/com/storix/common/property/FirebaseConfig.java
@@ -1,0 +1,9 @@
+package com.storix.common.property;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(FirebaseProperties.class)
+public class FirebaseConfig {
+}

--- a/STORIX-Common/src/main/java/com/storix/common/property/FirebaseProperties.java
+++ b/STORIX-Common/src/main/java/com/storix/common/property/FirebaseProperties.java
@@ -1,0 +1,17 @@
+package com.storix.common.property;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "firebase")
+public class FirebaseProperties {
+
+    private final String projectId;
+    private final String credentialsBase64;
+
+    public FirebaseProperties(String projectId, String credentialsBase64) {
+        this.projectId = projectId;
+        this.credentialsBase64 = credentialsBase64;
+    }
+}

--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -22,4 +22,50 @@ public class STORIXStatic {
     public static final List<String> SWAGGER_URI= List.of(
             new String[]{"/swagger-resources/", "/swagger-ui/", "/v3/api-docs"}
     );
+
+    // 알림 메시지 타이틀/본문 템플릿
+    public static class Notification {
+
+        // 타이틀 — 서비스
+        public static final String TITLE_FEED       = "피드";
+        public static final String TITLE_REVIEW     = "리뷰";
+        public static final String TITLE_TOPIC_ROOM = "토픽룸";
+
+        // 타이틀 — 운영 정책
+        public static final String TITLE_REPORT_RECEIVED   = "신고 접수 안내";
+        public static final String TITLE_REPORT_PROCESSED  = "신고 처리 완료";
+        public static final String TITLE_RESTRICTION       = "서비스 이용 제한 안내";
+        public static final String TITLE_TOS_UPDATE        = "약관 변경 안내";
+        public static final String TITLE_PRIVACY_UPDATE    = "개인정보 처리방침 변경 안내";
+        public static final String TITLE_FEATURE_UPDATE    = "신기능 업데이트";
+
+        // 타이틀 — 마케팅/광고 (고정 prefix '(광고) ' + 운영자 입력)
+        public static final String TITLE_MARKETING = "(광고) %s";
+
+        // 본문 템플릿 — 유저 인터랙션
+        public static final String TPL_LIKE_FEED        = "%s님이 회원님의 피드에 하트를 보냈어요.";
+        public static final String TPL_LIKE_REVIEW      = "%s님이 회원님의 리뷰에 하트를 보냈어요.";
+        public static final String TPL_LIKE_COMMENT     = "%s님이 회원님의 댓글에 하트를 보냈어요.";
+        public static final String TPL_COMMENT_ON_FEED  = "%s님이 댓글을 남겼어요 : %s";
+        public static final String TPL_REPLY_ON_COMMENT = "%s님이 대댓글을 남겼어요 : %s";
+
+        public static final String TPL_TODAY_FEED      = "회원님의 피드가 오늘의 피드로 선정되었어요!";
+        public static final String TPL_HOT_TOPIC_ROOM  = "회원님이 참여한 '%s' 토픽룸이 HOT으로 선정되었어요!";
+
+        // 본문 템플릿 — 운영 정책
+        public static final String TPL_REPORT_RECEIVED  = "회원님이 접수한 신고가 정상적으로 접수되었습니다.";
+        public static final String TPL_REPORT_PROCESSED = "접수해주신 신고에 대한 검토 및 처리가 완료되었습니다.";
+        public static final String TPL_RESTRICTION_7D   = "운영 정책 위반으로 인해 7일간 서비스 이용이 제한되었습니다.";
+        public static final String TPL_RESTRICTION_30D  = "운영 정책 위반으로 인해 30일간 서비스 이용이 제한되었습니다.";
+        public static final String TPL_TOS_UPDATE       = "서비스 이용약관이 일부 개정되어 안내드립니다.";
+        public static final String TPL_PRIVACY_UPDATE   = "개인정보 처리방침이 변경되어 안내드립니다.";
+        public static final String TPL_FEATURE_UPDATE   = "새로운 기능이 추가되어 안내드립니다.";
+
+        // 본문 템플릿 — 마케팅/광고 (운영자 입력 + 고정 suffix '(수신거부 : 설정)')
+        public static final String TPL_MARKETING = "%s (수신거부 : 설정)";
+
+        // 댓글 본문 미리보기 — 10자 노출 후 ...
+        public static final int CONTENT_PREVIEW_MAX = 10;
+        public static final String CONTENT_PREVIEW_SUFFIX = "...";
+    }
 }

--- a/STORIX-Domain/build.gradle
+++ b/STORIX-Domain/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
+    compileOnly 'io.swagger.core.v3:swagger-annotations-jakarta:2.2.22'
+
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/adaptor/ReaderFeedAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/adaptor/ReaderFeedAdaptor.java
@@ -52,6 +52,12 @@ public class ReaderFeedAdaptor {
         }
     }
 
+    // 게시글 작성자 userId 조회
+    public Long findBoardOwnerUserId(Long boardId) {
+        return readerBoardRepository.findUserIdById(boardId)
+                .orElseThrow(() -> InvalidBoardRequestException.EXCEPTION);
+    }
+
     // 전체 게시글 확인
     public Slice<ReaderBoard> findAllByOrderByCreatedAtDesc(Pageable pageable) {
         return readerBoardRepository.findAllByOrderByCreatedAtDesc(pageable);
@@ -148,6 +154,18 @@ public class ReaderFeedAdaptor {
         }
     }
 
+    // 댓글 조회 (boardId 일치 검증 포함)
+    public ReaderBoardReply findReplyByBoardIdAndReplyId(Long boardId, Long replyId) {
+        return readerBoardReplyRepository.findByIdAndBoard_Id(replyId, boardId)
+                .orElseThrow(() -> BoardReplyNotFoundException.EXCEPTION);
+    }
+
+    // 댓글 작성자 userId 조회 (boardId 일치 검증 포함)
+    public Long findReplyOwnerUserId(Long boardId, Long replyId) {
+        return readerBoardReplyRepository.findUserIdByIdAndBoardId(replyId, boardId)
+                .orElseThrow(() -> BoardReplyNotFoundException.EXCEPTION);
+    }
+
     // 댓글 좋아요 관련
     public int isReplyLikeDeleted(Long userId, Long replyId) {
         return readerBoardReplyLikeRepository.deleteLike(userId, replyId);
@@ -216,12 +234,12 @@ public class ReaderFeedAdaptor {
         return readerBoardReplyRepository.findAllByParentReplyId(parentReplyId, pageable);
     }
 
-    // 게시물 - 댓글 정보 확인
+    // 게시물 댓글 정보 확인
     public Slice<ReaderBoardReply> findAllByBoardId(Long boardId, Pageable pageable) {
         return readerBoardReplyRepository.findAllByBoard_Id(boardId, pageable);
     }
 
-    // 게시물 - 댓글 좋아요 여부 확인
+    // 게시물 댓글 좋아요 여부 확인
     public Set<Long> findLikedReplyIds(Long userId, List<Long> replyIds) {
         if (userId == null || replyIds == null || replyIds.isEmpty()) {
             return Collections.emptySet();
@@ -230,12 +248,12 @@ public class ReaderFeedAdaptor {
         return new HashSet<>(readerBoardReplyLikeRepository.findLikedReplyIds(userId, replyIds));
     }
 
-    // 프로필 - 댓글 정보 확인
+    // 프로필 댓글 정보 확인
     public Slice<ReaderBoardReply> findAllByUserId(Long userId, Pageable pageable) {
         return readerBoardReplyRepository.findAllByUserId(userId, pageable);
     }
 
-    // 프로필 - 좋아요한 게시글 정보 확인
+    // 프로필 좋아요한 게시글 정보 확인
     public Slice<ReaderBoard> findAllLikedReaderBoards(Long userId, Pageable pageable) {
         return readerBoardRepository.findAllLikedReaderBoards(userId, pageable);
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/repository/ReaderBoardReplyRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/repository/ReaderBoardReplyRepository.java
@@ -8,10 +8,18 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface ReaderBoardReplyRepository extends JpaRepository<ReaderBoardReply, Long> {
 
-    // 피드 댓글 - 좋아요
+    // 피드 댓글 좋아요
     boolean existsByIdAndBoard_Id(Long replyId, Long boardId);
+
+    Optional<ReaderBoardReply> findByIdAndBoard_Id(Long replyId, Long boardId);
+
+    // 댓글 작성자 userId 단건 조회 (boardId 일치 검증 포함)
+    @Query("SELECT r.userId FROM ReaderBoardReply r WHERE r.id = :replyId AND r.board.id = :boardId")
+    Optional<Long> findUserIdByIdAndBoardId(@Param("replyId") Long replyId, @Param("boardId") Long boardId);
 
     @Query("SELECT r.likeCount " +
             "FROM ReaderBoardReply r " +
@@ -30,7 +38,7 @@ public interface ReaderBoardReplyRepository extends JpaRepository<ReaderBoardRep
             "WHERE r.id = :id AND r.likeCount > 0")
     void decrementLikeCount(@Param("id") Long id);
 
-    // 답댓글 - childReplyCount
+    // 답댓글 childReplyCount
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE ReaderBoardReply r " +
             "SET r.childReplyCount = r.childReplyCount + 1 " +
@@ -43,7 +51,7 @@ public interface ReaderBoardReplyRepository extends JpaRepository<ReaderBoardRep
             "WHERE r.id = :id AND r.childReplyCount > 0")
     void decrementChildReplyCount(@Param("id") Long id);
 
-    // 피드 댓글 - 조회 (최상위 댓글 + 답댓글 fetch join)
+    // 피드 댓글 조회 (최상위 댓글 + 답댓글 fetch join)
     @Query("SELECT DISTINCT r FROM ReaderBoardReply r " +
             "LEFT JOIN FETCH r.childReplies c " +
             "WHERE r.board.id = :boardId AND r.parentReply IS NULL")
@@ -55,7 +63,7 @@ public interface ReaderBoardReplyRepository extends JpaRepository<ReaderBoardRep
             "ORDER BY r.createdAt ASC")
     Slice<ReaderBoardReply> findAllByParentReplyId(@Param("parentReplyId") Long parentReplyId, Pageable pageable);
 
-    // 프로필 댓글 - 조회
+    // 프로필 댓글 조회
     Slice<ReaderBoardReply> findAllByUserId(Long userId, Pageable pageable);
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedReactionService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedReactionService.java
@@ -7,9 +7,12 @@ import com.storix.domain.domains.feed.dto.LikeToggleResponse;
 import com.storix.domain.domains.feed.dto.ReaderBoardReplyResponse;
 import com.storix.domain.domains.feed.dto.StandardReplyInfo;
 import com.storix.domain.domains.feed.exception.ReplyDepthExceededException;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
 import com.storix.domain.domains.plus.domain.ReaderBoard;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import com.storix.domain.domains.user.dto.StandardProfileInfo;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,19 +24,25 @@ public class FeedReactionService {
     private final UserAdaptor userAdaptor;
     private final ReaderFeedAdaptor readerFeedAdaptor;
 
+    private final NotificationPublisher notificationPublisher;
+
     // 게시글 좋아요
     @Transactional
     public LikeToggleResponse toggleReaderBoardLike(Long userId, Long boardId) {
 
-        readerFeedAdaptor.checkReaderBoardExist(boardId);
+        // 게시글 작성자 조회
+        Long boardOwnerUserId = readerFeedAdaptor.findBoardOwnerUserId(boardId);
 
         int isDeleted = readerFeedAdaptor.isBoardLikeDeleted(userId, boardId);
         if (isDeleted == 1) {
             return readerFeedAdaptor.deleteReaderBoardLike(boardId);
-        } else {
-            return readerFeedAdaptor.insertReaderBoardLike(userId, boardId);
         }
 
+        LikeToggleResponse response = readerFeedAdaptor.insertReaderBoardLike(userId, boardId);
+
+        // 알림 발행
+        publishFeedLikeNotification(userId, boardOwnerUserId, boardId);
+        return response;
     }
 
     // 게시물 댓글 등록
@@ -45,22 +54,29 @@ public class FeedReactionService {
         CreateFeedReplyCommand cmd =
                 new CreateFeedReplyCommand(readerBoard, userId, comment, null);
 
-        // 1) 댓글 정보
+        // 1. 댓글 정보
         StandardReplyInfo reply = readerFeedAdaptor.uploadReaderBoardReply(cmd);
 
-        // 2) 프로필 정보
+        // 2. 프로필 정보
         StandardProfileInfo profile = userAdaptor.findStandardProfileInfoByUserId(userId);
+
+        // 3. 알림 발행
+        notificationPublisher.publishUnlessSelf(
+                userId,
+                NotificationEvent.commentOnFeed(readerBoard.getUserId(), boardId, profile.nickName(), comment)
+        );
 
         return ReaderBoardReplyResponse.of(profile, reply);
     }
 
-    // 답댓글 등록 (depth 1 제한: 답댓글에 대한 답댓글 불가)
+    // 답댓글 등록
     @Transactional
     public ReaderBoardReplyResponse uploadReaderBoardChildReply(Long userId, Long boardId, Long parentReplyId, String comment) {
 
         ReaderBoard readerBoard = readerFeedAdaptor.findReaderBoardById(boardId);
         ReaderBoardReply parentReply = readerFeedAdaptor.findReplyById(parentReplyId);
 
+        // depth 1 제한 (답댓글에 대한 답댓글 불가)
         if (parentReply.getDepth() >= 1) {
             throw ReplyDepthExceededException.EXCEPTION;
         }
@@ -68,11 +84,17 @@ public class FeedReactionService {
         CreateFeedReplyCommand cmd =
                 new CreateFeedReplyCommand(readerBoard, userId, comment, parentReply);
 
-        // 1) 댓글 정보
+        // 1. 댓글 정보
         StandardReplyInfo reply = readerFeedAdaptor.uploadReaderBoardChildReply(cmd);
 
-        // 2) 프로필 정보
+        // 2. 프로필 정보
         StandardProfileInfo profile = userAdaptor.findStandardProfileInfoByUserId(userId);
+
+        // 3. 알림
+        notificationPublisher.publishUnlessSelf(
+                userId,
+                NotificationEvent.replyOnComment(parentReply.getUserId(), parentReplyId, boardId, profile.nickName(), comment)
+        );
 
         return ReaderBoardReplyResponse.of(profile, reply);
     }
@@ -81,17 +103,34 @@ public class FeedReactionService {
     @Transactional
     public LikeToggleResponse toggleReaderBoardReplyLike(Long userId, Long boardId, Long replyId) {
 
-        readerFeedAdaptor.checkReplyExist(boardId, replyId);
+        // 댓글 작성자 조회
+        Long replyOwnerUserId = readerFeedAdaptor.findReplyOwnerUserId(boardId, replyId);
 
         int isDeleted = readerFeedAdaptor.isReplyLikeDeleted(userId, replyId);
         if (isDeleted == 1) {
             return readerFeedAdaptor.deleteReaderBoardReplyLike(replyId);
-        } else {
-            return readerFeedAdaptor.insertReaderBoardReplyLike(userId, replyId);
         }
 
+        LikeToggleResponse response = readerFeedAdaptor.insertReaderBoardReplyLike(userId, replyId);
+        publishReplyLikeNotification(userId, replyOwnerUserId, boardId, replyId);
+        return response;
     }
 
+    /* ─────────── 알림 발행 헬퍼 ─────────── */
 
+    private void publishFeedLikeNotification(Long actorUserId, Long boardOwnerUserId, Long boardId) {
+        StandardProfileInfo actor = userAdaptor.findStandardProfileInfoByUserId(actorUserId);
+        notificationPublisher.publishUnlessSelf(
+                actorUserId,
+                NotificationEvent.likeFeed(boardOwnerUserId, boardId, actor.nickName())
+        );
+    }
 
+    private void publishReplyLikeNotification(Long actorUserId, Long replyOwnerUserId, Long boardId, Long replyId) {
+        StandardProfileInfo actor = userAdaptor.findStandardProfileInfoByUserId(actorUserId);
+        notificationPublisher.publishUnlessSelf(
+                actorUserId,
+                NotificationEvent.likeComment(replyOwnerUserId, replyId, boardId, actor.nickName())
+        );
+    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedReactionService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedReactionService.java
@@ -30,17 +30,15 @@ public class FeedReactionService {
     @Transactional
     public LikeToggleResponse toggleReaderBoardLike(Long userId, Long boardId) {
 
-        // 게시글 작성자 조회
-        Long boardOwnerUserId = readerFeedAdaptor.findBoardOwnerUserId(boardId);
-
+        // unlike > 작성자 조회 불필요
         int isDeleted = readerFeedAdaptor.isBoardLikeDeleted(userId, boardId);
         if (isDeleted == 1) {
             return readerFeedAdaptor.deleteReaderBoardLike(boardId);
         }
 
+        // like > 알림 발행을 위해 게시글 작성자 조회
+        Long boardOwnerUserId = readerFeedAdaptor.findBoardOwnerUserId(boardId);
         LikeToggleResponse response = readerFeedAdaptor.insertReaderBoardLike(userId, boardId);
-
-        // 알림 발행
         publishFeedLikeNotification(userId, boardOwnerUserId, boardId);
         return response;
     }
@@ -103,14 +101,14 @@ public class FeedReactionService {
     @Transactional
     public LikeToggleResponse toggleReaderBoardReplyLike(Long userId, Long boardId, Long replyId) {
 
-        // 댓글 작성자 조회
-        Long replyOwnerUserId = readerFeedAdaptor.findReplyOwnerUserId(boardId, replyId);
-
+        // unlike(취소) 분기 — 작성자 조회 불필요
         int isDeleted = readerFeedAdaptor.isReplyLikeDeleted(userId, replyId);
         if (isDeleted == 1) {
             return readerFeedAdaptor.deleteReaderBoardReplyLike(replyId);
         }
 
+        // like 분기 — 알림 발행을 위해 댓글 작성자 조회
+        Long replyOwnerUserId = readerFeedAdaptor.findReplyOwnerUserId(boardId, replyId);
         LikeToggleResponse response = readerFeedAdaptor.insertReaderBoardReplyLike(userId, replyId);
         publishReplyLikeNotification(userId, replyOwnerUserId, boardId, replyId);
         return response;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/NotificationAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/NotificationAdaptor.java
@@ -1,0 +1,50 @@
+package com.storix.domain.domains.notification.adaptor;
+
+import com.storix.domain.domains.notification.domain.Notification;
+import com.storix.domain.domains.notification.exception.UnknownNotificationException;
+import com.storix.domain.domains.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationAdaptor {
+
+    private final NotificationRepository notificationRepository;
+
+    /** 조회 작업 관련 메서드 */
+    // 단건 조회 — 없으면 UnknownNotificationException
+    public Notification findById(Long notificationId) {
+        return notificationRepository.findById(notificationId)
+                .orElseThrow(() -> UnknownNotificationException.EXCEPTION);
+    }
+
+    // 최신순 첫 페이지
+    public Slice<Notification> findRecentByUserId(Long userId, Pageable pageable) {
+        return notificationRepository.findAllByUserIdOrderByIdDesc(userId, pageable);
+    }
+
+    // 커서 기반 다음 페이지 — cursorId 보다 과거
+    public Slice<Notification> findOlderByUserId(Long userId, Long cursorId, Pageable pageable) {
+        return notificationRepository.findAllByUserIdAndIdLessThanOrderByIdDesc(userId, cursorId, pageable);
+    }
+
+    // 안 읽은 알림 개수
+    public int countUnreadByUserId(Long userId) {
+        return notificationRepository.countByUserIdAndIsReadFalse(userId);
+    }
+
+
+    /** 쓰기 작업 관련 메서드 */
+    // 알림 저장
+    public Notification save(Notification notification) {
+        return notificationRepository.save(notification);
+    }
+
+    // 한 유저의 모든 알림 읽음 처리
+    public void bulkMarkAsRead(Long userId) {
+        notificationRepository.bulkMarkAsRead(userId);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/NotificationSettingAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/NotificationSettingAdaptor.java
@@ -1,0 +1,33 @@
+package com.storix.domain.domains.notification.adaptor;
+
+import com.storix.domain.domains.notification.domain.NotificationSetting;
+import com.storix.domain.domains.notification.exception.UnknownNotificationSettingException;
+import com.storix.domain.domains.notification.repository.NotificationSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationSettingAdaptor {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    /** 조회 작업 관련 메서드 */
+    // 유저 알림 설정 조회 — 없으면 예외 (모든 유저는 회원가입 시 row 가 생성되어 있다는 invariant)
+    public NotificationSetting getByUserId(Long userId) {
+        return notificationSettingRepository.findById(userId)
+                .orElseThrow(() -> UnknownNotificationSettingException.EXCEPTION);
+    }
+
+
+    /** 쓰기 작업 관련 메서드 */
+    // 신규 유저 가입 시 기본값으로 저장
+    public void save(Long userId) {
+        notificationSettingRepository.save(NotificationSetting.defaultFor(userId));
+    }
+
+    // 유저 탈퇴 시 삭제
+    public void deleteByUserId(Long userId) {
+        notificationSettingRepository.deleteById(userId);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/Notification.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/Notification.java
@@ -17,34 +17,51 @@ public class Notification extends BaseTimeEntity {
     @Column(name = "notification_id")
     private Long id;
 
+    // 수신자
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    // 알림 타입
     @Enumerated(EnumType.STRING)
-    @Column(name = "notification_type", nullable = false)
+    @Column(name = "notification_type", nullable = false, length = 32)
     private NotificationType notificationType;
 
-    @Column(nullable = false)
-    private String content;
+    // 알림 클릭 시 이동할 타겟
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 16)
+    private TargetType targetType;
 
-    // 알림 클릭 시 이동할 타겟 id
     @Column(name = "target_id")
     private Long targetId;
 
+    @Column(name = "parent_target_id")
+    private Long parentTargetId;
+
+    // 본문
+    @Column(nullable = false, length = 200)
+    private String content;
+
+    // 읽음 여부
     @Column(name = "is_read", nullable = false)
     private boolean isRead;
 
+
+    /** 생성자 메서드 */
+    @Builder
+    public Notification(Long userId, NotificationType notificationType, TargetType targetType, Long targetId, Long parentTargetId, String content) {
+        this.userId = userId;
+        this.notificationType = notificationType;
+        this.targetType = targetType != null ? targetType : TargetType.NONE;
+        this.targetId = targetId;
+        this.parentTargetId = parentTargetId;
+        this.content = content;
+        this.isRead = false;
+    }
+
+
+    /** 비즈니스 메서드 */
     // 알림 읽음 처리
     public void read() {
         this.isRead = true;
-    }
-
-    @Builder
-    public Notification(Long userId, NotificationType notificationType, String content, Long targetId) {
-        this.userId = userId;
-        this.notificationType = notificationType;
-        this.content = content;
-        this.targetId = targetId;
-        this.isRead = false;
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/Notification.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/Notification.java
@@ -39,6 +39,9 @@ public class Notification extends BaseTimeEntity {
 
     // 본문
     @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, length = 200)
     private String content;
 
     // 읽음 여부
@@ -48,12 +51,13 @@ public class Notification extends BaseTimeEntity {
 
     /** 생성자 메서드 */
     @Builder
-    public Notification(Long userId, NotificationType notificationType, TargetType targetType, Long targetId, Long parentTargetId, String content) {
+    public Notification(Long userId, NotificationType notificationType, TargetType targetType, Long targetId, Long parentTargetId, String title, String content) {
         this.userId = userId;
         this.notificationType = notificationType;
         this.targetType = targetType != null ? targetType : TargetType.NONE;
         this.targetId = targetId;
         this.parentTargetId = parentTargetId;
+        this.title = title;
         this.content = content;
         this.isRead = false;
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationCategory.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationCategory.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.notification.domain;
+
+// FE 아이콘 분기용 알림 카테고리. NotificationType 13개를 6개로 묶음.
+public enum NotificationCategory {
+    FEED,
+    REVIEW,
+    TOPIC_ROOM,
+    MARKETING,
+    REPORT,
+    POLICY
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationSetting.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationSetting.java
@@ -1,0 +1,105 @@
+package com.storix.domain.domains.notification.domain;
+
+import com.storix.common.model.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "notification_settings")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationSetting extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    // 서비스 알림 수신 여부
+    @Column(name = "like_feed_enabled", nullable = false)
+    private boolean likeFeedEnabled;
+
+    @Column(name = "like_review_enabled", nullable = false)
+    private boolean likeReviewEnabled;
+
+    @Column(name = "like_comment_enabled", nullable = false)
+    private boolean likeCommentEnabled;
+
+    @Column(name = "comment_on_feed_enabled", nullable = false)
+    private boolean commentOnFeedEnabled;
+
+    @Column(name = "reply_on_comment_enabled", nullable = false)
+    private boolean replyOnCommentEnabled;
+
+    @Column(name = "today_feed_enabled", nullable = false)
+    private boolean todayFeedEnabled;
+
+    @Column(name = "hot_topic_room_enabled", nullable = false)
+    private boolean hotTopicRoomEnabled;
+
+    // 마케팅/광고 수신 여부
+    @Column(name = "marketing_enabled", nullable = false)
+    private boolean marketingEnabled;
+
+
+    /** 생성자 메서드 */
+    // 신규 유저용 기본값 — 마케팅만 OFF, 나머지 ON
+    public static NotificationSetting defaultFor(Long userId) {
+        NotificationSetting p = new NotificationSetting();
+        p.userId = userId;
+        p.likeFeedEnabled = true;
+        p.likeReviewEnabled = true;
+        p.likeCommentEnabled = true;
+        p.commentOnFeedEnabled = true;
+        p.replyOnCommentEnabled = true;
+        p.todayFeedEnabled = true;
+        p.hotTopicRoomEnabled = true;
+        p.marketingEnabled = false;
+        return p;
+    }
+
+
+    /** 비즈니스 메서드 */
+    // 부분 갱신 — null 인자는 변경하지 않음
+    public void update(Boolean likeFeedEnabled,
+                       Boolean likeReviewEnabled,
+                       Boolean likeCommentEnabled,
+                       Boolean commentOnFeedEnabled,
+                       Boolean replyOnCommentEnabled,
+                       Boolean todayFeedEnabled,
+                       Boolean hotTopicRoomEnabled,
+                       Boolean marketingEnabled) {
+        if (likeFeedEnabled != null) this.likeFeedEnabled = likeFeedEnabled;
+        if (likeReviewEnabled != null) this.likeReviewEnabled = likeReviewEnabled;
+        if (likeCommentEnabled != null) this.likeCommentEnabled = likeCommentEnabled;
+        if (commentOnFeedEnabled != null) this.commentOnFeedEnabled = commentOnFeedEnabled;
+        if (replyOnCommentEnabled != null) this.replyOnCommentEnabled = replyOnCommentEnabled;
+        if (todayFeedEnabled != null) this.todayFeedEnabled = todayFeedEnabled;
+        if (hotTopicRoomEnabled != null) this.hotTopicRoomEnabled = hotTopicRoomEnabled;
+        if (marketingEnabled != null) this.marketingEnabled = marketingEnabled;
+    }
+
+    // 알림 타입별 수신 여부
+    public boolean acceptsType(NotificationType type) {
+        return switch (type) {
+            // 서비스 알림 — 타입별 토글
+            case LIKE_FEED          -> likeFeedEnabled;
+            case LIKE_REVIEW        -> likeReviewEnabled;
+            case LIKE_COMMENT       -> likeCommentEnabled;
+            case COMMENT_ON_FEED    -> commentOnFeedEnabled;
+            case REPLY_ON_COMMENT   -> replyOnCommentEnabled;
+            case TODAY_FEED         -> todayFeedEnabled;
+            case HOT_TOPIC_ROOM     -> hotTopicRoomEnabled;
+            // 마케팅/광고
+            case MARKETING          -> marketingEnabled;
+            // 운영 정책상 알림 — 수신 동의 무관, 항상 발송
+            case REPORT_RECEIVED, REPORT_PROCESSED,
+                 RESTRICTION_7D, RESTRICTION_30D,
+                 TOS_UPDATE, PRIVACY_UPDATE, FEATURE_UPDATE -> true;
+        };
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationSetting.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationSetting.java
@@ -45,6 +45,10 @@ public class NotificationSetting extends BaseTimeEntity {
     @Column(name = "marketing_enabled", nullable = false)
     private boolean marketingEnabled;
 
+    // 운영/정책 수신 여부
+    @Column(name = "operation_policy_enabled", nullable = false)
+    private boolean operationPolicyEnabled;
+
 
     /** 생성자 메서드 */
     // 신규 유저용 기본값 — 마케팅만 OFF, 나머지 ON
@@ -59,6 +63,7 @@ public class NotificationSetting extends BaseTimeEntity {
         p.todayFeedEnabled = true;
         p.hotTopicRoomEnabled = true;
         p.marketingEnabled = false;
+        p.operationPolicyEnabled = true;
         return p;
     }
 
@@ -72,7 +77,8 @@ public class NotificationSetting extends BaseTimeEntity {
                        Boolean replyOnCommentEnabled,
                        Boolean todayFeedEnabled,
                        Boolean hotTopicRoomEnabled,
-                       Boolean marketingEnabled) {
+                       Boolean marketingEnabled,
+                       Boolean operationPolicyEnabled) {
         if (likeFeedEnabled != null) this.likeFeedEnabled = likeFeedEnabled;
         if (likeReviewEnabled != null) this.likeReviewEnabled = likeReviewEnabled;
         if (likeCommentEnabled != null) this.likeCommentEnabled = likeCommentEnabled;
@@ -81,9 +87,10 @@ public class NotificationSetting extends BaseTimeEntity {
         if (todayFeedEnabled != null) this.todayFeedEnabled = todayFeedEnabled;
         if (hotTopicRoomEnabled != null) this.hotTopicRoomEnabled = hotTopicRoomEnabled;
         if (marketingEnabled != null) this.marketingEnabled = marketingEnabled;
+        if (operationPolicyEnabled != null) this.operationPolicyEnabled = operationPolicyEnabled;
     }
 
-    // 알림 타입별 수신 여부
+    // 알림 타입별 수신 여부 — 푸시 발송 동의 판정용 (인앱 저장은 토글 무관)
     public boolean acceptsType(NotificationType type) {
         return switch (type) {
             // 서비스 알림 — 타입별 토글
@@ -96,10 +103,10 @@ public class NotificationSetting extends BaseTimeEntity {
             case HOT_TOPIC_ROOM     -> hotTopicRoomEnabled;
             // 마케팅/광고
             case MARKETING          -> marketingEnabled;
-            // 운영 정책상 알림 — 수신 동의 무관, 항상 발송
+            // 운영/정책
             case REPORT_RECEIVED, REPORT_PROCESSED,
                  RESTRICTION_7D, RESTRICTION_30D,
-                 TOS_UPDATE, PRIVACY_UPDATE, FEATURE_UPDATE -> true;
+                 TOS_UPDATE, PRIVACY_UPDATE, FEATURE_UPDATE -> operationPolicyEnabled;
         };
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationType.java
@@ -1,12 +1,58 @@
 package com.storix.domain.domains.notification.domain;
 
-import lombok.Getter;
-
-@Getter
+/**
+ * 알림 타입
+ * - '마케팅/광고': 마케팅 수신 동의가 있어야 발송 가능
+ * */
 public enum NotificationType {
 
-    NEW_FOLLOWER,
-    NEW_LIKE,
-    NEW_COMMENT,
-    SYSTEM
+    /* ─────────── 서비스 ─────────── */
+    LIKE_FEED,         // 내 피드에 좋아요
+    LIKE_REVIEW,       // 내 리뷰에 좋아요
+    LIKE_COMMENT,      // 내 피드 댓글에 좋아요
+    COMMENT_ON_FEED,   // 내 피드에 댓글
+    REPLY_ON_COMMENT,  // 내 댓글에 답댓글
+
+    TODAY_FEED,        // 내 피드가 오늘의 피드로 선정
+    HOT_TOPIC_ROOM,    // 내가 참여한 토픽룸이 HOT으로 선정
+
+    /* ─────────── 마케팅/광고 ─────────── */
+    MARKETING,         // 운영자 발송 이벤트/광고
+
+    /* ─────────── 운영 정책 ─────────── */
+    REPORT_RECEIVED,   // 신고 접수 완료
+    REPORT_PROCESSED,  // 신고 처리 완료
+    RESTRICTION_7D,    // 서비스 이용 제한 안내 (7일)
+    RESTRICTION_30D,   // 서비스 이용 제한 안내 (30일)
+    TOS_UPDATE,        // 서비스 이용약관 업데이트
+    PRIVACY_UPDATE,    // 개인정보 처리방침 업데이트
+    FEATURE_UPDATE;    // 신기능 업데이트
+
+
+    // 일시 정지(SUSPENDED) 유저에게도 푸시를 발송할지 여부 — 서비스 이용 제한 안내만
+    public boolean deliverableToSuspendedUser() {
+        return switch (this) {
+            case RESTRICTION_7D, RESTRICTION_30D -> true;
+            default -> false;
+        };
+    }
+
+    // FE 아이콘 분기용 카테고리 (13개 type -> 6개 category)
+    public NotificationCategory category() {
+        return switch (this) {
+            case LIKE_FEED, LIKE_COMMENT, COMMENT_ON_FEED, REPLY_ON_COMMENT, TODAY_FEED
+                    -> NotificationCategory.FEED;
+            case LIKE_REVIEW
+                    -> NotificationCategory.REVIEW;
+            case HOT_TOPIC_ROOM
+                    -> NotificationCategory.TOPIC_ROOM;
+            case MARKETING
+                    -> NotificationCategory.MARKETING;
+            case REPORT_RECEIVED, REPORT_PROCESSED, RESTRICTION_7D, RESTRICTION_30D
+                    -> NotificationCategory.REPORT;
+            case TOS_UPDATE, PRIVACY_UPDATE, FEATURE_UPDATE
+                    -> NotificationCategory.POLICY;
+        };
+    }
+
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationType.java
@@ -29,10 +29,12 @@ public enum NotificationType {
     FEATURE_UPDATE;    // 신기능 업데이트
 
 
-    // 일시 정지(SUSPENDED) 유저에게도 푸시를 발송할지 여부 — 서비스 이용 제한 안내만
+    // 일시 정지(SUSPENDED) 유저에게도 푸시 알림을 발송할지 여부 (운영/정책 알림만 발송)
     public boolean deliverableToSuspendedUser() {
         return switch (this) {
-            case RESTRICTION_7D, RESTRICTION_30D -> true;
+            case REPORT_RECEIVED, REPORT_PROCESSED,
+                 RESTRICTION_7D, RESTRICTION_30D,
+                 TOS_UPDATE, PRIVACY_UPDATE, FEATURE_UPDATE -> true;
             default -> false;
         };
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/TargetType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/TargetType.java
@@ -1,0 +1,10 @@
+package com.storix.domain.domains.notification.domain;
+
+// 알림이 가리키는 타겟의 종류. 알림 탭 시 FE 라우팅 분기 + targetId 의 해석 기준.
+public enum TargetType {
+    FEED,
+    REVIEW,
+    COMMENT,
+    TOPIC_ROOM,
+    NONE         // 운영자/약관 등 타겟 없는 알림
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/DispatchResult.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/DispatchResult.java
@@ -1,0 +1,25 @@
+package com.storix.domain.domains.notification.dto;
+
+import java.util.List;
+
+// 알림 디스패치 결과 — 푸시 발송 여부와 대상 토큰을 Infra 단(Listener)에 전달
+public record DispatchResult(
+        Long notificationId,
+        List<String> tokens,
+        boolean shouldSendPush
+) {
+    // 전부 skip — DELETED 유저거나 타입 토글 OFF
+    public static DispatchResult skip() {
+        return new DispatchResult(null, List.of(), false);
+    }
+
+    // 인앱 알림만 저장, 푸시는 skip — SUSPENDED 유저의 일반 알림
+    public static DispatchResult inAppOnly(Long notificationId) {
+        return new DispatchResult(notificationId, List.of(), false);
+    }
+
+    // 인앱 + 푸시 발송
+    public static DispatchResult pushTo(Long notificationId, List<String> tokens) {
+        return new DispatchResult(notificationId, tokens, !tokens.isEmpty());
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationResponseDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationResponseDto.java
@@ -2,6 +2,7 @@ package com.storix.domain.domains.notification.dto;
 
 import com.storix.domain.domains.notification.domain.Notification;
 import com.storix.domain.domains.notification.domain.NotificationType;
+import com.storix.domain.domains.notification.domain.TargetType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,20 +14,23 @@ public class NotificationResponseDto {
 
     private Long id;
     private NotificationType notificationType;
-    private String content;
+    private TargetType targetType;
     private Long targetId;
+    private Long parentTargetId;
+    private String content;
     private boolean isRead;
     private LocalDateTime createdAt;
 
-    // Entity -> DTO 변환 정적 팩토리 메서드
     public static NotificationResponseDto from(Notification notification) {
         return NotificationResponseDto.builder()
                 .id(notification.getId())
                 .notificationType(notification.getNotificationType())
-                .content(notification.getContent())
+                .targetType(notification.getTargetType())
                 .targetId(notification.getTargetId())
+                .parentTargetId(notification.getParentTargetId())
+                .content(notification.getContent())
                 .isRead(notification.isRead())
-                .createdAt(notification.getCreatedAt()) // BaseEntity의 getter
+                .createdAt(notification.getCreatedAt())
                 .build();
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationResponseDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationResponseDto.java
@@ -17,6 +17,7 @@ public class NotificationResponseDto {
     private TargetType targetType;
     private Long targetId;
     private Long parentTargetId;
+    private String title;
     private String content;
     private boolean isRead;
     private LocalDateTime createdAt;
@@ -28,6 +29,7 @@ public class NotificationResponseDto {
                 .targetType(notification.getTargetType())
                 .targetId(notification.getTargetId())
                 .parentTargetId(notification.getParentTargetId())
+                .title(notification.getTitle())
                 .content(notification.getContent())
                 .isRead(notification.isRead())
                 .createdAt(notification.getCreatedAt())

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationSettingResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationSettingResponse.java
@@ -1,0 +1,27 @@
+package com.storix.domain.domains.notification.dto;
+
+import com.storix.domain.domains.notification.domain.NotificationSetting;
+
+public record NotificationSettingResponse(
+        boolean likeFeedEnabled,
+        boolean likeReviewEnabled,
+        boolean likeCommentEnabled,
+        boolean commentOnFeedEnabled,
+        boolean replyOnCommentEnabled,
+        boolean todayFeedEnabled,
+        boolean hotTopicRoomEnabled,
+        boolean marketingEnabled
+) {
+    public static NotificationSettingResponse from(NotificationSetting s) {
+        return new NotificationSettingResponse(
+                s.isLikeFeedEnabled(),
+                s.isLikeReviewEnabled(),
+                s.isLikeCommentEnabled(),
+                s.isCommentOnFeedEnabled(),
+                s.isReplyOnCommentEnabled(),
+                s.isTodayFeedEnabled(),
+                s.isHotTopicRoomEnabled(),
+                s.isMarketingEnabled()
+        );
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationSettingResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationSettingResponse.java
@@ -2,26 +2,20 @@ package com.storix.domain.domains.notification.dto;
 
 import com.storix.domain.domains.notification.domain.NotificationSetting;
 
+// 추후 알림 뎁스 세분화를 위한 테이블 컬럼 유지 (9개 -> 4개 상위 분류)
 public record NotificationSettingResponse(
-        boolean likeFeedEnabled,
-        boolean likeReviewEnabled,
-        boolean likeCommentEnabled,
-        boolean commentOnFeedEnabled,
-        boolean replyOnCommentEnabled,
-        boolean todayFeedEnabled,
-        boolean hotTopicRoomEnabled,
-        boolean marketingEnabled
+        boolean myActivityEnabled,
+        boolean contentCommunityEnabled,
+        boolean eventBenefitEnabled,
+        boolean operationPolicyEnabled
 ) {
     public static NotificationSettingResponse from(NotificationSetting s) {
         return new NotificationSettingResponse(
-                s.isLikeFeedEnabled(),
-                s.isLikeReviewEnabled(),
-                s.isLikeCommentEnabled(),
-                s.isCommentOnFeedEnabled(),
-                s.isReplyOnCommentEnabled(),
-                s.isTodayFeedEnabled(),
-                s.isHotTopicRoomEnabled(),
-                s.isMarketingEnabled()
+                s.isLikeFeedEnabled() && s.isLikeReviewEnabled() && s.isLikeCommentEnabled()
+                        && s.isCommentOnFeedEnabled() && s.isReplyOnCommentEnabled(),
+                s.isTodayFeedEnabled() && s.isHotTopicRoomEnabled(),
+                s.isMarketingEnabled(),
+                s.isOperationPolicyEnabled()
         );
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingCommand.java
@@ -8,6 +8,7 @@ public record UpdateNotificationSettingCommand(
         Boolean replyOnCommentEnabled,
         Boolean todayFeedEnabled,
         Boolean hotTopicRoomEnabled,
-        Boolean marketingEnabled
+        Boolean marketingEnabled,
+        Boolean operationPolicyEnabled
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingCommand.java
@@ -1,0 +1,13 @@
+package com.storix.domain.domains.notification.dto;
+
+public record UpdateNotificationSettingCommand(
+        Boolean likeFeedEnabled,
+        Boolean likeReviewEnabled,
+        Boolean likeCommentEnabled,
+        Boolean commentOnFeedEnabled,
+        Boolean replyOnCommentEnabled,
+        Boolean todayFeedEnabled,
+        Boolean hotTopicRoomEnabled,
+        Boolean marketingEnabled
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingRequest.java
@@ -1,0 +1,33 @@
+package com.storix.domain.domains.notification.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpdateNotificationSettingRequest(
+
+        /* ─────────── 서비스 알림 ─────────── */
+        @Schema(description = "내 피드에 좋아요", example = "true")
+        Boolean likeFeedEnabled,
+
+        @Schema(description = "내 리뷰에 좋아요", example = "true")
+        Boolean likeReviewEnabled,
+
+        @Schema(description = "내 피드 댓글에 좋아요", example = "true")
+        Boolean likeCommentEnabled,
+
+        @Schema(description = "내 피드에 댓글", example = "true")
+        Boolean commentOnFeedEnabled,
+
+        @Schema(description = "내 댓글에 답댓글", example = "true")
+        Boolean replyOnCommentEnabled,
+
+        @Schema(description = "내 피드가 오늘의 피드로 선정", example = "true")
+        Boolean todayFeedEnabled,
+
+        @Schema(description = "내가 참여한 토픽룸이 HOT으로 선정", example = "true")
+        Boolean hotTopicRoomEnabled,
+
+        /* ─────────── 마케팅/광고 ─────────── */
+        @Schema(description = "운영자 발송 이벤트/광고", example = "false")
+        Boolean marketingEnabled
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingRequest.java
@@ -30,4 +30,16 @@ public record UpdateNotificationSettingRequest(
         @Schema(description = "운영자 발송 이벤트/광고", example = "false")
         Boolean marketingEnabled
 ) {
+    public UpdateNotificationSettingCommand toCommand() {
+        return new UpdateNotificationSettingCommand(
+                likeFeedEnabled,
+                likeReviewEnabled,
+                likeCommentEnabled,
+                commentOnFeedEnabled,
+                replyOnCommentEnabled,
+                todayFeedEnabled,
+                hotTopicRoomEnabled,
+                marketingEnabled
+        );
+    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingRequest.java
@@ -2,44 +2,32 @@ package com.storix.domain.domains.notification.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+// 추후 알림 뎁스 세분화를 위한 테이블 컬럼 유지 (9개 -> 4개 상위 분류)
 public record UpdateNotificationSettingRequest(
 
-        /* ─────────── 서비스 알림 ─────────── */
-        @Schema(description = "내 피드에 좋아요", example = "true")
-        Boolean likeFeedEnabled,
+        @Schema(description = "내 활동 알림 — 피드/리뷰/댓글/답댓글/댓글 좋아요", example = "true")
+        Boolean myActivityEnabled,
 
-        @Schema(description = "내 리뷰에 좋아요", example = "true")
-        Boolean likeReviewEnabled,
+        @Schema(description = "콘텐츠/커뮤니티 알림 — 오늘의 피드/HOT 토픽룸 선정", example = "true")
+        Boolean contentCommunityEnabled,
 
-        @Schema(description = "내 피드 댓글에 좋아요", example = "true")
-        Boolean likeCommentEnabled,
+        @Schema(description = "이벤트/혜택 알림 — 운영자 발송 이벤트/광고", example = "false")
+        Boolean eventBenefitEnabled,
 
-        @Schema(description = "내 피드에 댓글", example = "true")
-        Boolean commentOnFeedEnabled,
-
-        @Schema(description = "내 댓글에 답댓글", example = "true")
-        Boolean replyOnCommentEnabled,
-
-        @Schema(description = "내 피드가 오늘의 피드로 선정", example = "true")
-        Boolean todayFeedEnabled,
-
-        @Schema(description = "내가 참여한 토픽룸이 HOT으로 선정", example = "true")
-        Boolean hotTopicRoomEnabled,
-
-        /* ─────────── 마케팅/광고 ─────────── */
-        @Schema(description = "운영자 발송 이벤트/광고", example = "false")
-        Boolean marketingEnabled
+        @Schema(description = "운영/정책 알림 — 신고 처리/이용 제한/약관 업데이트 등", example = "true")
+        Boolean operationPolicyEnabled
 ) {
     public UpdateNotificationSettingCommand toCommand() {
         return new UpdateNotificationSettingCommand(
-                likeFeedEnabled,
-                likeReviewEnabled,
-                likeCommentEnabled,
-                commentOnFeedEnabled,
-                replyOnCommentEnabled,
-                todayFeedEnabled,
-                hotTopicRoomEnabled,
-                marketingEnabled
+                myActivityEnabled,
+                myActivityEnabled,
+                myActivityEnabled,
+                myActivityEnabled,
+                myActivityEnabled,
+                contentCommunityEnabled,
+                contentCommunityEnabled,
+                eventBenefitEnabled,
+                operationPolicyEnabled
         );
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/event/NotificationEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/event/NotificationEvent.java
@@ -1,0 +1,200 @@
+package com.storix.domain.domains.notification.event;
+
+import com.storix.common.utils.STORIXStatic;
+import com.storix.domain.domains.notification.domain.NotificationType;
+import com.storix.domain.domains.notification.domain.TargetType;
+
+// 알림 발송 트리거 이벤트.
+// 발행 지점(Service) 은 정적 팩토리로 만들어 publisher.publish() 만 호출.
+// AFTER_COMMIT 시점에 NotificationEventListener 가 인앱 저장 + FCM 발송 수행.
+public record NotificationEvent(
+        Long recipientUserId,
+        NotificationType notificationType,
+        TargetType targetType,
+        Long targetId,
+        Long parentTargetId,
+        String title,
+        String content
+) {
+
+    /** 좋아요 */
+    // 1. 내 피드에 좋아요
+    public static NotificationEvent likeFeed(Long recipientUserId, Long feedId, String actorNickname) {
+        return new NotificationEvent(
+                recipientUserId,
+                NotificationType.LIKE_FEED,
+                TargetType.FEED,
+                feedId,
+                null,
+                STORIXStatic.Notification.TITLE_FEED,
+                String.format(STORIXStatic.Notification.TPL_LIKE_FEED, actorNickname)
+        );
+    }
+
+    // 2. 내 리뷰에 좋아요
+    public static NotificationEvent likeReview(Long recipientUserId, Long reviewId, String actorNickname) {
+        return new NotificationEvent(
+                recipientUserId,
+                NotificationType.LIKE_REVIEW,
+                TargetType.REVIEW,
+                reviewId,
+                null,
+                STORIXStatic.Notification.TITLE_REVIEW,
+                String.format(STORIXStatic.Notification.TPL_LIKE_REVIEW, actorNickname)
+        );
+    }
+
+    // 3. 내 피드 댓글에 좋아요 — parentTargetId 로 부모 피드 ID 전달
+    public static NotificationEvent likeComment(Long recipientUserId, Long commentId, Long feedId,
+                                                String actorNickname) {
+        return new NotificationEvent(
+                recipientUserId,
+                NotificationType.LIKE_COMMENT,
+                TargetType.COMMENT,
+                commentId,
+                feedId,
+                STORIXStatic.Notification.TITLE_FEED,
+                String.format(STORIXStatic.Notification.TPL_LIKE_COMMENT, actorNickname)
+        );
+    }
+
+
+    /** 댓글 / 답댓글 */
+    // 1. 내 피드에 댓글
+    public static NotificationEvent commentOnFeed(Long recipientUserId, Long feedId,
+                                                  String actorNickname, String commentContent) {
+        return new NotificationEvent(
+                recipientUserId,
+                NotificationType.COMMENT_ON_FEED,
+                TargetType.FEED,
+                feedId,
+                null,
+                STORIXStatic.Notification.TITLE_FEED,
+                String.format(STORIXStatic.Notification.TPL_COMMENT_ON_FEED, actorNickname, preview(commentContent))
+        );
+    }
+
+    // 2. 내 댓글에 답댓글 — parentTargetId 로 부모 피드 ID 전달
+    public static NotificationEvent replyOnComment(Long recipientUserId, Long parentCommentId, Long feedId,
+                                                   String actorNickname, String replyContent) {
+        return new NotificationEvent(
+                recipientUserId,
+                NotificationType.REPLY_ON_COMMENT,
+                TargetType.COMMENT,
+                parentCommentId,
+                feedId,
+                STORIXStatic.Notification.TITLE_FEED,
+                String.format(STORIXStatic.Notification.TPL_REPLY_ON_COMMENT, actorNickname, preview(replyContent))
+        );
+    }
+
+
+    /** 선정 알림 */
+    // 1. 내 피드가 오늘의 피드로 선정
+    public static NotificationEvent todayFeed(Long recipientUserId, Long feedId) {
+        return new NotificationEvent(
+                recipientUserId,
+                NotificationType.TODAY_FEED,
+                TargetType.FEED,
+                feedId,
+                null,
+                STORIXStatic.Notification.TITLE_FEED,
+                STORIXStatic.Notification.TPL_TODAY_FEED
+        );
+    }
+
+    // 2. 내가 참여한 토픽룸이 HOT 으로 선정
+    public static NotificationEvent hotTopicRoom(Long recipientUserId, Long topicRoomId, String topicRoomTitle) {
+        return new NotificationEvent(
+                recipientUserId,
+                NotificationType.HOT_TOPIC_ROOM,
+                TargetType.TOPIC_ROOM,
+                topicRoomId,
+                null,
+                STORIXStatic.Notification.TITLE_TOPIC_ROOM,
+                String.format(STORIXStatic.Notification.TPL_HOT_TOPIC_ROOM, topicRoomTitle)
+        );
+    }
+
+
+    /** 마케팅/광고 (운영자 발송) */
+    // 운영자가 입력한 타이틀/본문에 고정 prefix '(광고) ' + suffix '(수신거부 : 설정)' 자동 부착
+    public static NotificationEvent marketing(Long recipientUserId, String adTitle, String adBody) {
+        return new NotificationEvent(
+                recipientUserId,
+                NotificationType.MARKETING,
+                TargetType.NONE,
+                null,
+                null,
+                String.format(STORIXStatic.Notification.TITLE_MARKETING, adTitle),
+                String.format(STORIXStatic.Notification.TPL_MARKETING, adBody)
+        );
+    }
+
+
+    /** 운영 정책 */
+    // 1. 신고 접수 완료
+    public static NotificationEvent reportReceived(Long recipientUserId) {
+        return policyEvent(recipientUserId, NotificationType.REPORT_RECEIVED,
+                STORIXStatic.Notification.TITLE_REPORT_RECEIVED,
+                STORIXStatic.Notification.TPL_REPORT_RECEIVED);
+    }
+
+    // 2. 신고 처리 완료
+    public static NotificationEvent reportProcessed(Long recipientUserId) {
+        return policyEvent(recipientUserId, NotificationType.REPORT_PROCESSED,
+                STORIXStatic.Notification.TITLE_REPORT_PROCESSED,
+                STORIXStatic.Notification.TPL_REPORT_PROCESSED);
+    }
+
+    // 3. 서비스 이용 제한 (7일)
+    public static NotificationEvent restriction7d(Long recipientUserId) {
+        return policyEvent(recipientUserId, NotificationType.RESTRICTION_7D,
+                STORIXStatic.Notification.TITLE_RESTRICTION,
+                STORIXStatic.Notification.TPL_RESTRICTION_7D);
+    }
+
+    // 4. 서비스 이용 제한 (30일)
+    public static NotificationEvent restriction30d(Long recipientUserId) {
+        return policyEvent(recipientUserId, NotificationType.RESTRICTION_30D,
+                STORIXStatic.Notification.TITLE_RESTRICTION,
+                STORIXStatic.Notification.TPL_RESTRICTION_30D);
+    }
+
+    // 5. 서비스 이용약관 업데이트
+    public static NotificationEvent tosUpdate(Long recipientUserId) {
+        return policyEvent(recipientUserId, NotificationType.TOS_UPDATE,
+                STORIXStatic.Notification.TITLE_TOS_UPDATE,
+                STORIXStatic.Notification.TPL_TOS_UPDATE);
+    }
+
+    // 6. 개인정보 처리방침 업데이트
+    public static NotificationEvent privacyUpdate(Long recipientUserId) {
+        return policyEvent(recipientUserId, NotificationType.PRIVACY_UPDATE,
+                STORIXStatic.Notification.TITLE_PRIVACY_UPDATE,
+                STORIXStatic.Notification.TPL_PRIVACY_UPDATE);
+    }
+
+    // 7. 신기능 업데이트
+    public static NotificationEvent featureUpdate(Long recipientUserId) {
+        return policyEvent(recipientUserId, NotificationType.FEATURE_UPDATE,
+                STORIXStatic.Notification.TITLE_FEATURE_UPDATE,
+                STORIXStatic.Notification.TPL_FEATURE_UPDATE);
+    }
+
+    // 운영 정책 알림 공통 빌더 (타겟 없음, 고정 title/body)
+    private static NotificationEvent policyEvent(Long recipientUserId, NotificationType type,
+                                                 String title, String body) {
+        return new NotificationEvent(recipientUserId, type, TargetType.NONE, null, null, title, body);
+    }
+
+
+    // 본문 미리보기 — 10자 초과 시 잘라서 '…' 부가
+    private static String preview(String text) {
+        if (text == null) return "";
+        int max = STORIXStatic.Notification.CONTENT_PREVIEW_MAX;
+        return text.length() > max
+                ? text.substring(0, max) + STORIXStatic.Notification.CONTENT_PREVIEW_SUFFIX
+                : text;
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/exception/FcmSendFailedException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/exception/FcmSendFailedException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.notification.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class FcmSendFailedException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new FcmSendFailedException();
+
+    private FcmSendFailedException() { super(ErrorCode.FCM_SEND_FAILED); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/exception/UnknownNotificationSettingException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/exception/UnknownNotificationSettingException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.notification.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class UnknownNotificationSettingException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new UnknownNotificationSettingException();
+
+    private UnknownNotificationSettingException() { super(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/publisher/NotificationPublisher.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/publisher/NotificationPublisher.java
@@ -1,0 +1,41 @@
+package com.storix.domain.domains.notification.publisher;
+
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+/**
+ * 도메인 서비스(피드/리뷰/댓글)에서 알림 이벤트 발행
+ * */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 알림 이벤트 발행
+    public void publish(NotificationEvent event) {
+        if (event == null || event.recipientUserId() == null) {
+            log.warn(">>> [Notification] invalid event dropped: {}", event);
+            return;
+        }
+        try {
+            eventPublisher.publishEvent(event);
+        } catch (Exception e) {
+            log.warn(">>> [Notification] publish failed recipient={}, type={}, cause={}",
+                    event.recipientUserId(), event.notificationType(), e.getMessage());
+        }
+    }
+
+    // 본인 글에 본인이 좋아요/댓글을 달 경우 알림 발행 X (actorUserId == recipientUserId)
+    public void publishUnlessSelf(Long actorUserId, NotificationEvent event) {
+        if (actorUserId != null && event != null
+                && actorUserId.equals(event.recipientUserId())) {
+            return;
+        }
+        publish(event);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/repository/NotificationSettingRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/repository/NotificationSettingRepository.java
@@ -1,0 +1,7 @@
+package com.storix.domain.domains.notification.repository;
+
+import com.storix.domain.domains.notification.domain.NotificationSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
@@ -1,0 +1,74 @@
+package com.storix.domain.domains.notification.service;
+
+import com.storix.domain.domains.notification.adaptor.NotificationAdaptor;
+import com.storix.domain.domains.notification.adaptor.NotificationSettingAdaptor;
+import com.storix.domain.domains.notification.domain.Notification;
+import com.storix.domain.domains.notification.domain.NotificationSetting;
+import com.storix.domain.domains.notification.dto.DispatchResult;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
+import com.storix.domain.domains.user.adaptor.UserAdaptor;
+import com.storix.domain.domains.user.domain.AccountState;
+import com.storix.domain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationDispatchService {
+
+    private final UserAdaptor userAdaptor;
+    private final NotificationAdaptor notificationAdaptor;
+    private final NotificationSettingAdaptor notificationSettingAdaptor;
+
+    private final PushDeviceAdaptor pushDeviceAdaptor;
+
+    @Transactional
+    public DispatchResult dispatch(NotificationEvent event) {
+        // 1. 탈퇴 유저는 전부 skip
+        User user = userAdaptor.findUserById(event.recipientUserId());
+        if (user.getAccountState() == AccountState.DELETED) {
+            log.debug(">>> [Notification] skipped (user deleted) userId={}", event.recipientUserId());
+            return DispatchResult.skip();
+        }
+
+        // 2. 타입별 수신 동의 체크
+        NotificationSetting setting = notificationSettingAdaptor.getByUserId(event.recipientUserId());
+        if (!setting.acceptsType(event.notificationType())) {
+            log.debug(">>> [Notification] skipped (type disabled) userId={}, type={}",
+                    event.recipientUserId(), event.notificationType());
+            return DispatchResult.skip();
+        }
+
+        // 3. 인앱 알림 저장
+        Notification saved = notificationAdaptor.save(Notification.builder()
+                .userId(event.recipientUserId())
+                .notificationType(event.notificationType())
+                .targetType(event.targetType())
+                .targetId(event.targetId())
+                .parentTargetId(event.parentTargetId())
+                .content(event.content())
+                .build());
+
+        // 4. SUSPENDED 유저는 제재/신고 안내만 푸시 발송
+        if (user.getAccountState() == AccountState.SUSPENDED
+                && !event.notificationType().deliverableToSuspendedUser()) {
+            log.debug(">>> [Notification] push skipped (user suspended) userId={}, type={}",
+                    event.recipientUserId(), event.notificationType());
+            return DispatchResult.inAppOnly(saved.getId());
+        }
+
+        // 5. 푸시 발송 대상 디바이스 토큰 조회
+        List<String> tokens = pushDeviceAdaptor.findActiveFcmTokensByUserId(event.recipientUserId());
+        if (tokens.isEmpty()) {
+            log.debug(">>> [Notification] no active device for userId={}", event.recipientUserId());
+            return DispatchResult.inAppOnly(saved.getId());
+        }
+        return DispatchResult.pushTo(saved.getId(), tokens);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
@@ -52,6 +52,7 @@ public class NotificationDispatchService {
                 .targetType(event.targetType())
                 .targetId(event.targetId())
                 .parentTargetId(event.parentTargetId())
+                .title(event.title())
                 .content(event.content())
                 .build());
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
@@ -37,15 +37,7 @@ public class NotificationDispatchService {
             return DispatchResult.skip();
         }
 
-        // 2. 타입별 수신 동의 체크
-        NotificationSetting setting = notificationSettingAdaptor.getByUserId(event.recipientUserId());
-        if (!setting.acceptsType(event.notificationType())) {
-            log.debug(">>> [Notification] skipped (type disabled) userId={}, type={}",
-                    event.recipientUserId(), event.notificationType());
-            return DispatchResult.skip();
-        }
-
-        // 3. 인앱 알림 저장
+        // 2. 인앱 알림함 저장 > 수신 동의와 무관, 항상 저장
         Notification saved = notificationAdaptor.save(Notification.builder()
                 .userId(event.recipientUserId())
                 .notificationType(event.notificationType())
@@ -56,7 +48,14 @@ public class NotificationDispatchService {
                 .content(event.content())
                 .build());
 
-        // 4. SUSPENDED 유저는 제재/신고 안내만 푸시 발송
+        // 3. 푸시 발송 가능한 활성 디바이스 토큰 조회 > 없으면 인앱만
+        List<String> tokens = pushDeviceAdaptor.findActiveFcmTokensByUserId(event.recipientUserId());
+        if (tokens.isEmpty()) {
+            log.debug(">>> [Notification] no active device for userId={}", event.recipientUserId());
+            return DispatchResult.inAppOnly(saved.getId());
+        }
+
+        // 4-1. [SUSPENDED 유저] 제재/신고 안내만 푸시 발송
         if (user.getAccountState() == AccountState.SUSPENDED
                 && !event.notificationType().deliverableToSuspendedUser()) {
             log.debug(">>> [Notification] push skipped (user suspended) userId={}, type={}",
@@ -64,12 +63,14 @@ public class NotificationDispatchService {
             return DispatchResult.inAppOnly(saved.getId());
         }
 
-        // 5. 푸시 발송 대상 디바이스 토큰 조회
-        List<String> tokens = pushDeviceAdaptor.findActiveFcmTokensByUserId(event.recipientUserId());
-        if (tokens.isEmpty()) {
-            log.debug(">>> [Notification] no active device for userId={}", event.recipientUserId());
+        // 4-2. [NORMAL 유저] 푸시 알림 수신 동의 체크
+        NotificationSetting setting = notificationSettingAdaptor.getByUserId(event.recipientUserId());
+        if (!setting.acceptsType(event.notificationType())) {
+            log.debug(">>> [Notification] push skipped (type disabled) userId={}, type={}",
+                    event.recipientUserId(), event.notificationType());
             return DispatchResult.inAppOnly(saved.getId());
         }
+
         return DispatchResult.pushTo(saved.getId(), tokens);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationService.java
@@ -1,10 +1,9 @@
 package com.storix.domain.domains.notification.service;
 
+import com.storix.domain.domains.notification.adaptor.NotificationAdaptor;
 import com.storix.domain.domains.notification.domain.Notification;
 import com.storix.domain.domains.notification.dto.NotificationResponseDto;
-import com.storix.domain.domains.notification.repository.NotificationRepository;
 import com.storix.domain.domains.notification.exception.UnauthorizedNotificationException;
-import com.storix.domain.domains.notification.exception.UnknownNotificationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -15,54 +14,37 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class NotificationService {
 
-    private final NotificationRepository notificationRepository;
+    private final NotificationAdaptor notificationAdaptor;
 
-    /**
-     * 전체 알림 목록 조회
-     * */
+    // 1. 전체 알림 목록 조회 (커서 기반)
     @Transactional(readOnly = true)
     public Slice<NotificationResponseDto> getNotifications(Long userId, Long cursorId, Pageable pageable) {
-        Slice<Notification> notifications;
-
-        if (cursorId == null) {
-            // 커서가 없으면 가장 최신 데이터 조회
-            notifications = notificationRepository.findAllByUserIdOrderByIdDesc(userId, pageable);
-        } else {
-            // 커서가 있으면 그보다 과거 데이터 조회
-            notifications = notificationRepository.findAllByUserIdAndIdLessThanOrderByIdDesc(userId, cursorId, pageable);
-        }
+        Slice<Notification> notifications = (cursorId == null)
+                ? notificationAdaptor.findRecentByUserId(userId, pageable)
+                : notificationAdaptor.findOlderByUserId(userId, cursorId, pageable);
 
         return notifications.map(NotificationResponseDto::from);
     }
 
-    /**
-     * 안 읽은 알림 개수 조회
-     * */
+    // 2. 안 읽은 알림 개수 조회
     @Transactional(readOnly = true)
     public int getUnreadCount(Long userId) {
-        return notificationRepository.countByUserIdAndIsReadFalse(userId);
+        return notificationAdaptor.countUnreadByUserId(userId);
     }
 
-    /**
-     * 단건 알림 읽음 처리
-     */
+    // 3. 단건 알림 읽음 처리
     @Transactional
     public void readNotification(Long userId, Long notificationId) {
-        Notification notification = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> UnknownNotificationException.EXCEPTION);
-
+        Notification notification = notificationAdaptor.findById(notificationId);
         if (!notification.getUserId().equals(userId)) {
             throw UnauthorizedNotificationException.EXCEPTION;
         }
-
         notification.read();
     }
 
-    /**
-     * 전체 알림 읽음 처리
-     * */
+    // 4. 전체 알림 읽음 처리
     @Transactional
     public void readAllNotifications(Long userId) {
-        notificationRepository.bulkMarkAsRead(userId);
+        notificationAdaptor.bulkMarkAsRead(userId);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationSettingService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationSettingService.java
@@ -1,0 +1,39 @@
+package com.storix.domain.domains.notification.service;
+
+import com.storix.domain.domains.notification.adaptor.NotificationSettingAdaptor;
+import com.storix.domain.domains.notification.domain.NotificationSetting;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingService {
+
+    private final NotificationSettingAdaptor notificationSettingAdaptor;
+
+    // 유저 알림 설정 조회
+    @Transactional(readOnly = true)
+    public NotificationSetting get(Long userId) {
+        return notificationSettingAdaptor.getByUserId(userId);
+    }
+
+    // 부분 갱신 — 알림 설정 화면 전체 갱신
+    @Transactional
+    public NotificationSetting update(Long userId,
+                                      Boolean likeFeedEnabled,
+                                      Boolean likeReviewEnabled,
+                                      Boolean likeCommentEnabled,
+                                      Boolean commentOnFeedEnabled,
+                                      Boolean replyOnCommentEnabled,
+                                      Boolean todayFeedEnabled,
+                                      Boolean hotTopicRoomEnabled,
+                                      Boolean marketingEnabled) {
+        NotificationSetting setting = notificationSettingAdaptor.getByUserId(userId);
+        setting.update(likeFeedEnabled, likeReviewEnabled, likeCommentEnabled,
+                commentOnFeedEnabled, replyOnCommentEnabled,
+                todayFeedEnabled, hotTopicRoomEnabled,
+                marketingEnabled);
+        return setting;
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationSettingService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationSettingService.java
@@ -31,7 +31,8 @@ public class NotificationSettingService {
                 cmd.replyOnCommentEnabled(),
                 cmd.todayFeedEnabled(),
                 cmd.hotTopicRoomEnabled(),
-                cmd.marketingEnabled()
+                cmd.marketingEnabled(),
+                cmd.operationPolicyEnabled()
         );
         return setting;
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationSettingService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationSettingService.java
@@ -2,6 +2,7 @@ package com.storix.domain.domains.notification.service;
 
 import com.storix.domain.domains.notification.adaptor.NotificationSettingAdaptor;
 import com.storix.domain.domains.notification.domain.NotificationSetting;
+import com.storix.domain.domains.notification.dto.UpdateNotificationSettingCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,20 +21,18 @@ public class NotificationSettingService {
 
     // 부분 갱신 — 알림 설정 화면 전체 갱신
     @Transactional
-    public NotificationSetting update(Long userId,
-                                      Boolean likeFeedEnabled,
-                                      Boolean likeReviewEnabled,
-                                      Boolean likeCommentEnabled,
-                                      Boolean commentOnFeedEnabled,
-                                      Boolean replyOnCommentEnabled,
-                                      Boolean todayFeedEnabled,
-                                      Boolean hotTopicRoomEnabled,
-                                      Boolean marketingEnabled) {
+    public NotificationSetting update(Long userId, UpdateNotificationSettingCommand cmd) {
         NotificationSetting setting = notificationSettingAdaptor.getByUserId(userId);
-        setting.update(likeFeedEnabled, likeReviewEnabled, likeCommentEnabled,
-                commentOnFeedEnabled, replyOnCommentEnabled,
-                todayFeedEnabled, hotTopicRoomEnabled,
-                marketingEnabled);
+        setting.update(
+                cmd.likeFeedEnabled(),
+                cmd.likeReviewEnabled(),
+                cmd.likeCommentEnabled(),
+                cmd.commentOnFeedEnabled(),
+                cmd.replyOnCommentEnabled(),
+                cmd.todayFeedEnabled(),
+                cmd.hotTopicRoomEnabled(),
+                cmd.marketingEnabled()
+        );
         return setting;
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/repository/ReaderBoardRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/repository/ReaderBoardRepository.java
@@ -11,8 +11,13 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ReaderBoardRepository extends JpaRepository<ReaderBoard, Long>, ReaderBoardRankingRepository {
+
+    // 작성자 userId 단건 조회
+    @Query("SELECT rb.userId FROM ReaderBoard rb WHERE rb.id = :boardId")
+    Optional<Long> findUserIdById(@Param("boardId") Long boardId);
 
     // 프로필 관련
     @Query("SELECT rb " +
@@ -55,7 +60,7 @@ public interface ReaderBoardRepository extends JpaRepository<ReaderBoard, Long>,
 
     Slice<ReaderBoard> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
-    // 피드 - 댓글
+    // 피드 댓글
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE ReaderBoard r " +
             "SET r.replyCount = r.replyCount + 1 " +
@@ -68,7 +73,7 @@ public interface ReaderBoardRepository extends JpaRepository<ReaderBoard, Long>,
             "WHERE r.id = :id AND r.replyCount > 0")
     void decrementReplyCount(@Param("id") Long id);
 
-    // 피드 - 좋아요
+    // 피드 좋아요
     @Query("SELECT r.likeCount " +
             "FROM ReaderBoard r " +
             "WHERE r.id = :boardId")

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -22,6 +24,11 @@ public class PushDeviceAdaptor {
         // (userId, installationId) 기존 row 없을 경우 예외 처리
         return pushDeviceRepository.findByUserIdAndInstallationId(userId, installationId)
                 .orElseThrow(() -> UnknownPushDeviceException.EXCEPTION);
+    }
+
+    // [PushDispatch] 한 유저의 활성 디바이스 FCM 토큰 일괄 조회
+    public List<String> findActiveFcmTokensByUserId(Long userId) {
+        return pushDeviceRepository.findActiveFcmTokensByUserId(userId);
     }
 
     /** 쓰기 작업 관련 메서드 */
@@ -50,5 +57,15 @@ public class PushDeviceAdaptor {
     // [PushDevice] 유저 탈퇴 시 모든 디바이스 일괄 비활성화
     public int deactivateAllByUserId(Long userId) {
         return pushDeviceRepository.deactivateAllByUserId(userId);
+    }
+
+    // [PushDispatch] FCM invalid 토큰 일괄 비활성화
+    public int deactivateByFcmTokens(List<String> tokens) {
+        return pushDeviceRepository.deactivateByFcmTokens(tokens);
+    }
+
+    // [PushDispatch] 발송 성공한 토큰들의 lastSuccessAt 일괄 갱신
+    public void markFcmTokensSuccess(List<String> tokens, LocalDateTime now) {
+        pushDeviceRepository.markFcmTokensSuccess(tokens, now);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
@@ -13,14 +15,28 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     // 단일 디바이스 조회
     Optional<PushDevice> findByUserIdAndInstallationId(Long userId, String installationId);
 
+    // 한 유저의 활성 디바이스 FCM 토큰 일괄 조회
+    @Query("SELECT d.fcmToken FROM PushDevice d WHERE d.userId = :userId AND d.isActive = true")
+    List<String> findActiveFcmTokensByUserId(@Param("userId") Long userId);
+
     // 단일 디바이스 비활성화
     @Modifying(clearAutomatically = true)
     @Query("UPDATE PushDevice d SET d.isActive = false WHERE d.userId = :userId AND d.installationId = :installationId")
     int deactivateByUserIdAndInstallationId(@Param("userId") Long userId,
                                             @Param("installationId") String installationId);
 
+    // FCM invalid 토큰 일괄 비활성화
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PushDevice d SET d.isActive = false WHERE d.fcmToken IN :tokens")
+    int deactivateByFcmTokens(@Param("tokens") List<String> tokens);
+
     // 유저 탈퇴 시 해당 유저의 모든 활성 디바이스 일괄 비활성화
     @Modifying(clearAutomatically = true)
     @Query("UPDATE PushDevice d SET d.isActive = false WHERE d.userId = :userId AND d.isActive = true")
     int deactivateAllByUserId(@Param("userId") Long userId);
+
+    // 발송 성공한 토큰들의 lastSuccessAt 갱신
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PushDevice d SET d.lastSuccessAt = :now WHERE d.fcmToken IN :tokens AND d.isActive = true")
+    void markFcmTokensSuccess(@Param("tokens") List<String> tokens, @Param("now") LocalDateTime now);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/service/PushDispatchService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/service/PushDispatchService.java
@@ -1,0 +1,36 @@
+package com.storix.domain.domains.pushdevice.service;
+
+import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * FCM 발송 관련 서비스
+ * */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PushDispatchService {
+
+    private final PushDeviceAdaptor pushDeviceAdaptor;
+
+    // FCM invalid 토큰 일괄 비활성화
+    @Transactional
+    public void deactivateTokens(List<String> tokens) {
+        if (tokens == null || tokens.isEmpty()) return;
+        int affected = pushDeviceAdaptor.deactivateByFcmTokens(tokens);
+        log.info(">>>> [PushDispatch] deactivate invalid tokens count={}, affected={}", tokens.size(), affected);
+    }
+
+    // 발송 성공한 토큰들의 lastSuccessAt 갱신
+    @Transactional
+    public void markTokensSuccess(List<String> tokens) {
+        if (tokens == null || tokens.isEmpty()) return;
+        pushDeviceAdaptor.markFcmTokensSuccess(tokens, LocalDateTime.now());
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/review/adaptor/ReviewLikeAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/review/adaptor/ReviewLikeAdaptor.java
@@ -1,7 +1,12 @@
 package com.storix.domain.domains.review.adaptor;
 
+import com.storix.domain.domains.plus.domain.Review;
+import com.storix.domain.domains.plus.repository.ReviewRepository;
+import com.storix.domain.domains.review.domain.ReviewLike;
+import com.storix.domain.domains.review.dto.ReviewLikeToggleResponse;
 import com.storix.domain.domains.review.repository.ReviewLikeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -9,11 +14,31 @@ import org.springframework.stereotype.Component;
 public class ReviewLikeAdaptor {
 
     private final ReviewLikeRepository reviewLikeRepository;
+    private final ReviewRepository reviewRepository;
 
     public boolean isAlreadyLiked(Long userId, Long reviewId) {
         return reviewLikeRepository.existsByUserIdAndReview_Id(userId, reviewId);
     }
 
+    public int isReviewLikeDeleted(Long userId, Long reviewId) {
+        return reviewLikeRepository.deleteLike(userId, reviewId);
+    }
+
+    public ReviewLikeToggleResponse deleteReviewLike(Long reviewId) {
+        reviewRepository.decrementLikeCount(reviewId);
+        return new ReviewLikeToggleResponse(false, reviewRepository.findLikeCountById(reviewId));
+    }
+
+    public ReviewLikeToggleResponse insertReviewLike(Long userId, Long reviewId) {
+        try {
+            Review reviewRef = reviewRepository.getReferenceById(reviewId);
+            reviewLikeRepository.saveAndFlush(ReviewLike.of(userId, reviewRef));
+            reviewRepository.incrementLikeCount(reviewId);
+        } catch (DataIntegrityViolationException ignored) {
+            // 이미 좋아요 상태로 간주
+        }
+        return new ReviewLikeToggleResponse(true, reviewRepository.findLikeCountById(reviewId));
+    }
 
     // 리뷰와 연관관계 맺은 좋아요 삭제
     public void deleteAllRelatedReviewLike(Long reviewId) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/review/service/WorksDetailReactionService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/review/service/WorksDetailReactionService.java
@@ -1,12 +1,13 @@
 package com.storix.domain.domains.review.service;
 
-import com.storix.domain.domains.plus.domain.Review;
-import com.storix.domain.domains.plus.repository.ReviewRepository;
-import com.storix.domain.domains.review.domain.ReviewLike;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
+import com.storix.domain.domains.plus.adaptor.ReviewAdaptor;
+import com.storix.domain.domains.review.adaptor.ReviewLikeAdaptor;
 import com.storix.domain.domains.review.dto.ReviewLikeToggleResponse;
-import com.storix.domain.domains.review.repository.ReviewLikeRepository;
+import com.storix.domain.domains.user.adaptor.UserAdaptor;
+import com.storix.domain.domains.user.dto.StandardProfileInfo;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,37 +15,32 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class WorksDetailReactionService {
 
-    private final ReviewRepository reviewRepository;
-    private final ReviewLikeRepository reviewLikeRepository;
+    private final ReviewAdaptor reviewAdaptor;
+    private final ReviewLikeAdaptor reviewLikeAdaptor;
+    private final UserAdaptor userAdaptor;
+    private final NotificationPublisher notificationPublisher;
 
     @Transactional
     public ReviewLikeToggleResponse toggleReviewLike(Long userId, Long reviewId) {
 
-        int isDeleted = reviewLikeRepository.deleteLike(userId, reviewId);
+        // 리뷰 작성자 조회
+        Long reviewAuthorUserId = reviewAdaptor.findReviewerIdById(reviewId);
+
+        int isDeleted = reviewLikeAdaptor.isReviewLikeDeleted(userId, reviewId);
         if (isDeleted == 1) {
-            reviewRepository.decrementLikeCount(reviewId);
-
-            int likeCount = reviewRepository.findLikeCountById(reviewId);
-            return new ReviewLikeToggleResponse(false, likeCount);
+            return reviewLikeAdaptor.deleteReviewLike(reviewId);
         }
 
-        try {
-            Review reviewRef = reviewRepository.getReferenceById(reviewId);
-
-            ReviewLike like = ReviewLike.of(userId, reviewRef);
-            reviewLikeRepository.saveAndFlush(like);
-
-            reviewRepository.incrementLikeCount(reviewId);
-
-            int likeCount = reviewRepository.findLikeCountById(reviewId);
-            return new ReviewLikeToggleResponse(true, likeCount);
-
-        } catch (DataIntegrityViolationException e) {
-
-            int likeCount = reviewRepository.findLikeCountById(reviewId);
-            return new ReviewLikeToggleResponse(true, likeCount);
-        }
-
+        ReviewLikeToggleResponse response = reviewLikeAdaptor.insertReviewLike(userId, reviewId);
+        publishReviewLikeNotification(userId, reviewId, reviewAuthorUserId);
+        return response;
     }
 
+    private void publishReviewLikeNotification(Long actorUserId, Long reviewId, Long reviewAuthorUserId) {
+        StandardProfileInfo actor = userAdaptor.findStandardProfileInfoByUserId(actorUserId);
+        notificationPublisher.publishUnlessSelf(
+                actorUserId,
+                NotificationEvent.likeReview(reviewAuthorUserId, reviewId, actor.nickName())
+        );
+    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/review/service/WorksDetailReactionService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/review/service/WorksDetailReactionService.java
@@ -23,14 +23,14 @@ public class WorksDetailReactionService {
     @Transactional
     public ReviewLikeToggleResponse toggleReviewLike(Long userId, Long reviewId) {
 
-        // 리뷰 작성자 조회
-        Long reviewAuthorUserId = reviewAdaptor.findReviewerIdById(reviewId);
-
+        // unlike > 작성자 조회 불필요
         int isDeleted = reviewLikeAdaptor.isReviewLikeDeleted(userId, reviewId);
         if (isDeleted == 1) {
             return reviewLikeAdaptor.deleteReviewLike(reviewId);
         }
 
+        // like > 알림 발행을 위해 리뷰 작성자 조회
+        Long reviewAuthorUserId = reviewAdaptor.findReviewerIdById(reviewId);
         ReviewLikeToggleResponse response = reviewLikeAdaptor.insertReviewLike(userId, reviewId);
         publishReviewLikeNotification(userId, reviewId, reviewAuthorUserId);
         return response;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
@@ -60,8 +60,9 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private int point = 0;
 
-    @Column(name = "market_agree")
-    private Boolean marketingAgree;
+    // 이용약관 동의 여부
+    @Column(name = "terms_agree")
+    private Boolean termsAgree;
 
     @Column(name = "is_adult_verified")
     private Boolean isAdultVerified = false;
@@ -97,8 +98,8 @@ public class User extends BaseTimeEntity {
     protected User() {}
 
     @Builder
-    public User(boolean marketingAgree, OAuthInfo oauthInfo, String nickName, Set<Genre> favoriteGenreList, String profileDescription, Role role) {
-        this.marketingAgree = marketingAgree;
+    public User(Boolean termsAgree, OAuthInfo oauthInfo, String nickName, Set<Genre> favoriteGenreList, String profileDescription, Role role) {
+        this.termsAgree = termsAgree;
         this.oauthInfo = oauthInfo;
         this.nickName = nickName;
         this.favoriteGenreList = favoriteGenreList;
@@ -152,7 +153,7 @@ public class User extends BaseTimeEntity {
         profileObjectKey = null;
         nickName = "탈퇴한 유저";
         oauthInfo = oauthInfo.withDrawOauthInfo();
-        marketingAgree = null;
+        termsAgree = null;
         isAdultVerified = null;
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateDeveloperUserCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateDeveloperUserCommand.java
@@ -21,7 +21,7 @@ public record CreateDeveloperUserCommand(
                 Collections.emptySet() : new LinkedHashSet<>(favoriteGenreList);
 
         return User.builder()
-                .marketingAgree(true)
+                .termsAgree(true)
                 .oauthInfo(oauthInfo)
                 .nickName(nickName)
                 .favoriteGenreList(genres)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateReaderUserCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateReaderUserCommand.java
@@ -10,7 +10,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 public record CreateReaderUserCommand(
-        Boolean marketingAgree,
+        Boolean termsAgree,
         OAuthProvider provider,
         String oid,
         String nickName,
@@ -23,7 +23,7 @@ public record CreateReaderUserCommand(
                         Collections.emptySet() : new LinkedHashSet<>(favoriteGenreList);
 
         return User.builder()
-                .marketingAgree(marketingAgree)
+                .termsAgree(termsAgree)
                 .oauthInfo(oauthInfo)
                 .nickName(nickName)
                 .favoriteGenreList(genres)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ReaderSignUpData.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ReaderSignUpData.java
@@ -1,0 +1,15 @@
+package com.storix.domain.domains.user.dto;
+
+import com.storix.domain.domains.works.domain.Genre;
+
+import java.util.Set;
+
+// 회원가입 내부 명령 (v1/v2 API DTO -> 공통 변환 후 AuthService 에 전달)
+public record ReaderSignUpData(
+        Boolean termsAgree,
+        String nickName,
+        String profileDescription,
+        Set<Genre> favoriteGenreList,
+        Set<Long> favoriteWorksIdList
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -4,6 +4,8 @@ import com.storix.domain.domains.favorite.adaptor.FavoriteWorksAdaptor;
 import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
 import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
+import com.storix.domain.domains.notification.adaptor.NotificationSettingAdaptor;
+import com.storix.domain.domains.notification.domain.NotificationSetting;
 import com.storix.domain.domains.onboarding.service.OnboardingWorksHelper;
 import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
 import com.storix.domain.domains.user.dto.CreateReaderUserCommand;
@@ -32,6 +34,7 @@ public class AuthService {
     private final FavoriteWorksAdaptor favoriteWorksAdaptor;
 
     private final PushDeviceAdaptor pushDeviceAdaptor;
+    private final NotificationSettingAdaptor notificationSettingAdaptor;
 
     private final OnboardingWorksHelper onboardingWorksHelper; // -> usecase 리팩토링 필요
     private final GenreScorePublisher genreScorePublisher;
@@ -95,6 +98,9 @@ public class AuthService {
         }
         libraryAdaptor.initLibrary(authUserDetails.getUserId());
 
+        // 알림 설정 기본값 생성 (마케팅만 OFF, 나머지 ON)
+        notificationSettingAdaptor.save(authUserDetails.getUserId());
+
         return authUserDetails;
     }
 
@@ -133,7 +139,10 @@ public class AuthService {
         favoriteWorksAdaptor.deleteFavoriteWorks(userId);
         libraryAdaptor.deleteLibrary(userId);
 
-        // 3. 푸시 알림 디바아스 일괄 비활성화
+        // 3. 푸시 알림 디바이스 일괄 비활성화
         pushDeviceAdaptor.deactivateAllByUserId(userId);
+
+        // 4. 알림 설정 삭제 (재가입 시 새 row 생성됨)
+        notificationSettingAdaptor.deleteByUserId(userId);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -8,7 +8,7 @@ import com.storix.domain.domains.onboarding.service.OnboardingWorksHelper;
 import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
 import com.storix.domain.domains.user.dto.CreateReaderUserCommand;
 import com.storix.domain.domains.user.dto.OnboardingPrincipal;
-import com.storix.domain.domains.user.dto.ReaderSignupRequest;
+import com.storix.domain.domains.user.dto.ReaderSignUpData;
 import com.storix.domain.domains.user.dto.ValidAuthDTO;
 import com.storix.domain.domains.user.exception.me.DuplicateUserException;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
@@ -60,7 +60,7 @@ public class AuthService {
 
     // 독자 회원 가입 (소셜 로그인)
     @Transactional
-    public AuthUserDetails signUpReaderUser(ReaderSignupRequest cmd, String jti) {
+    public AuthUserDetails signUpReaderUser(ReaderSignUpData cmd, String jti) {
 
         OnboardingPrincipal principal = tokenAdaptor.findOnboardingPrincipalByJti(jti);
         OAuthProvider provider = principal.provider(); String oid = principal.oid();
@@ -75,7 +75,7 @@ public class AuthService {
         userAdaptor.checkNicknameDuplicate(cmd.nickName());
 
         CreateReaderUserCommand m = new CreateReaderUserCommand(
-                cmd.marketingAgree(),
+                cmd.termsAgree(),
                 provider,
                 oid,
                 cmd.nickName(),

--- a/STORIX-Infrastructure/build.gradle
+++ b/STORIX-Infrastructure/build.gradle
@@ -16,4 +16,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation "software.amazon.awssdk:s3"
+
+    // FCM
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
 }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/AsyncConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/AsyncConfig.java
@@ -47,4 +47,15 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "notificationTaskExecutor")
+    public Executor notificationTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(16);
+        executor.setQueueCapacity(1000);
+        executor.setThreadNamePrefix("NotiAsync-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/AsyncConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/AsyncConfig.java
@@ -1,5 +1,6 @@
 package com.storix.infrastructure.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -7,6 +8,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
 
+@Slf4j
 @Configuration
 @EnableAsync
 public class AsyncConfig {
@@ -55,6 +57,15 @@ public class AsyncConfig {
         executor.setMaxPoolSize(16);
         executor.setQueueCapacity(1000);
         executor.setThreadNamePrefix("NotiAsync-");
+
+        // TODO: 재시도 로직 + traceId 로깅 필요
+        executor.setRejectedExecutionHandler((r, exec) -> {
+            log.warn(">>> [Notification] queue overflow — running on caller thread (pool={}, queue={}/{})",
+                    exec.getPoolSize(), exec.getQueue().size(), exec.getQueue().remainingCapacity());
+            if (!exec.isShutdown()) {
+                r.run();
+            }
+        });
         executor.initialize();
         return executor;
     }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
@@ -123,6 +123,9 @@ public class SecurityConfig {
                                 // [TopicRoom]
                                 .requestMatchers("/ws-stomp/**").permitAll()
 
+                                // [Notification] 테스트 엔드포인트는 ADMIN 만
+                                .requestMatchers("/api/v1/notifications/admin/**").hasRole("ADMIN")
+
                                 .anyRequest().hasRole("READER")
                 )
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/FcmSender.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/FcmSender.java
@@ -1,0 +1,107 @@
+package com.storix.infrastructure.external.fcm;
+
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.MulticastMessage;
+import com.storix.domain.domains.notification.exception.FcmSendFailedException;
+import com.storix.infrastructure.external.fcm.dto.MulticastResult;
+import com.storix.infrastructure.external.fcm.dto.SingleSendResult;
+import com.storix.infrastructure.external.fcm.dto.TokenClassification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FcmSender {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final FcmSenderHelper fcmSenderHelper;
+
+    // 단일 토큰 푸시 발송
+    public SingleSendResult sendToToken(String token, Map<String, String> data) {
+        // 1. data-only 메시지 빌드
+        Message.Builder builder = Message.builder()
+                .setToken(token)
+                .setAndroidConfig(highPriorityAndroid())
+                .setApnsConfig(backgroundWakeApns());
+        fcmSenderHelper.putData(builder::putData, data);
+
+        try {
+            // 2. 전송 성공
+            String messageId = firebaseMessaging.send(builder.build());
+            log.info(">>>> [FCM] send 성공. messageId={}, token={}", messageId, fcmSenderHelper.maskToken(token));
+            return SingleSendResult.success(messageId);
+        } catch (FirebaseMessagingException e) {
+            MessagingErrorCode code = e.getMessagingErrorCode();
+            // 3. 영구 invalid 토큰 -> caller 가 deactivate 처리하도록 invalid 반환
+            if (fcmSenderHelper.isPermanentInvalid(code)) {
+                log.warn(">>>> [FCM] permanent invalid token. token={}, errorCode={}", fcmSenderHelper.maskToken(token), code);
+                return SingleSendResult.invalid(token);
+            }
+            // 4. 일시 오류 / 그 외 실패 -> throw
+            log.error(">>>> [FCM] send 실패. token={}, errorCode={}, msg={}", fcmSenderHelper.maskToken(token), code, e.getMessage());
+            throw FcmSendFailedException.EXCEPTION;
+        }
+    }
+
+    // 멀티캐스트 발송 (한 유저의 여러 디바이스 동시 발송)
+    public MulticastResult sendMulticast(List<String> tokens, Map<String, String> data) {
+        // 1. 빈 토큰 short-circuit
+        if (tokens == null || tokens.isEmpty()) {
+            return MulticastResult.empty();
+        }
+
+        // 2. data-only + background wake 메시지 빌드
+        MulticastMessage.Builder builder = MulticastMessage.builder()
+                .addAllTokens(tokens)
+                .setAndroidConfig(highPriorityAndroid())
+                .setApnsConfig(backgroundWakeApns());
+        fcmSenderHelper.putData(builder::putData, data);
+
+        try {
+            // 3. 발송 + 응답을 invalid / success 로 분류
+            BatchResponse response = firebaseMessaging.sendEachForMulticast(builder.build());
+            TokenClassification classified = fcmSenderHelper.classifyTokens(tokens, response);
+            log.info(">>>> [FCM] multicast 결과 success={}, failure={}, invalid={}",
+                    response.getSuccessCount(), response.getFailureCount(), classified.invalidTokens().size());
+            return new MulticastResult(
+                    response.getSuccessCount(),
+                    response.getFailureCount(),
+                    classified.invalidTokens(),
+                    classified.successTokens()
+            );
+        } catch (FirebaseMessagingException e) {
+            // 4. batch 자체 실패 -> throw
+            log.error(">>>> [FCM] multicast 실패. tokenCount={}, errorCode={}, msg={}",
+                    tokens.size(), e.getMessagingErrorCode(), e.getMessage());
+            throw FcmSendFailedException.EXCEPTION;
+        }
+    }
+
+    // Android HIGH 우선순위 (data-only 메시지 즉시 배달)
+    private AndroidConfig highPriorityAndroid() {
+        return AndroidConfig.builder()
+                .setPriority(AndroidConfig.Priority.HIGH)
+                .build();
+    }
+
+    // iOS background wake (data-only 메시지로 background 상태 앱을 깨우기 위한 헤더 조합)
+    private ApnsConfig backgroundWakeApns() {
+        return ApnsConfig.builder()
+                .putHeader("apns-priority", "5")
+                .putHeader("apns-push-type", "background")
+                .setAps(Aps.builder().setContentAvailable(true).build())
+                .build();
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/FcmSenderHelper.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/FcmSenderHelper.java
@@ -1,0 +1,59 @@
+package com.storix.infrastructure.external.fcm;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.SendResponse;
+import com.storix.infrastructure.external.fcm.dto.TokenClassification;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+@Component
+public class FcmSenderHelper {
+
+    // data payload put
+    public void putData(BiConsumer<String, String> putter, Map<String, String> data) {
+        if (data == null) return;
+        data.forEach((k, v) -> {
+            // null value entry 는 skip
+            if (v != null) putter.accept(k, v);
+        });
+    }
+
+    // 응답 토큰 분류 (일시 오류는 어디에도 포함 X)
+    public TokenClassification classifyTokens(List<String> tokens, BatchResponse response) {
+        List<SendResponse> responses = response.getResponses();
+        List<String> invalid = new ArrayList<>();
+        List<String> success = new ArrayList<>();
+        for (int i = 0; i < responses.size(); i++) {
+            SendResponse r = responses.get(i);
+            // 1. 성공
+            if (r.isSuccessful()) {
+                success.add(tokens.get(i));
+                continue;
+            }
+            // 2. 영구 invalid 만 invalid 그룹으로 (일시 오류는 둘 다 X)
+            MessagingErrorCode code = r.getException() != null ? r.getException().getMessagingErrorCode() : null;
+            if (isPermanentInvalid(code)) {
+                invalid.add(tokens.get(i));
+            }
+        }
+        return new TokenClassification(invalid, success);
+    }
+
+    // 영구 invalid 판별 (Firebase 공식 가이드 기준)
+    public boolean isPermanentInvalid(MessagingErrorCode code) {
+        return code == MessagingErrorCode.UNREGISTERED
+                || code == MessagingErrorCode.INVALID_ARGUMENT
+                || code == MessagingErrorCode.SENDER_ID_MISMATCH;
+    }
+
+    // 로깅용 토큰 마스킹
+    public String maskToken(String token) {
+        if (token == null || token.length() < 12) return "***";
+        return token.substring(0, 6) + "..." + token.substring(token.length() - 4);
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/FcmSenderHelper.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/FcmSenderHelper.java
@@ -47,7 +47,6 @@ public class FcmSenderHelper {
     // 영구 invalid 판별 (Firebase 공식 가이드 기준)
     public boolean isPermanentInvalid(MessagingErrorCode code) {
         return code == MessagingErrorCode.UNREGISTERED
-                || code == MessagingErrorCode.INVALID_ARGUMENT
                 || code == MessagingErrorCode.SENDER_ID_MISMATCH;
     }
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/FirebaseAppConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/FirebaseAppConfig.java
@@ -1,0 +1,56 @@
+package com.storix.infrastructure.external.fcm;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.storix.common.property.FirebaseProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "firebase", name = "credentials-base64")
+public class FirebaseAppConfig {
+
+    private static final String FIREBASE_APP_NAME = "storix-fcm";
+
+    private final FirebaseProperties firebaseProperties;
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        // 1. 동일 이름의 FirebaseApp 이 이미 초기화되어 있으면 재사용
+        for (FirebaseApp existing : FirebaseApp.getApps()) {
+            if (FIREBASE_APP_NAME.equals(existing.getName())) {
+                return existing;
+            }
+        }
+
+        // 2. credentials base64 디코딩 후 FirebaseOptions 빌드
+        byte[] decoded = Base64.getDecoder().decode(firebaseProperties.getCredentialsBase64());
+        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(decoded));
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(credentials)
+                .setProjectId(firebaseProperties.getProjectId())
+                .build();
+
+        // 3. 신규 FirebaseApp 초기화
+        FirebaseApp app = FirebaseApp.initializeApp(options, FIREBASE_APP_NAME);
+        log.info(">>>> [FCM] FirebaseApp 초기화 완료 (projectId={})", firebaseProperties.getProjectId());
+        return app;
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/NotificationEventListener.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/NotificationEventListener.java
@@ -1,0 +1,72 @@
+package com.storix.infrastructure.external.fcm;
+
+import com.storix.domain.domains.notification.dto.DispatchResult;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.service.NotificationDispatchService;
+import com.storix.domain.domains.pushdevice.service.PushDispatchService;
+import com.storix.infrastructure.external.fcm.dto.MulticastResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final FcmSender fcmSender;
+
+    private final NotificationDispatchService notificationDispatchService;
+    private final PushDispatchService pushDispatchService;
+
+    @Async("notificationTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onEvent(NotificationEvent event) {
+        try {
+            // 1. Domain 비즈니스 로직 위임 (인앱 저장 + 푸시 발송 대상 결정)
+            DispatchResult result = notificationDispatchService.dispatch(event);
+
+            // 2. 푸시 발송 대상 없으면 종료
+            if (!result.shouldSendPush()) return;
+
+            // 3. FCM 멀티캐스트 발송
+            MulticastResult mc = fcmSender.sendMulticast(
+                    result.tokens(),
+                    buildData(event, result.notificationId()));
+
+            // 4. 토큰 후처리 (invalid 비활성화 + success lastSuccessAt 갱신)
+            if (!mc.invalidTokens().isEmpty()) {
+                pushDispatchService.deactivateTokens(mc.invalidTokens());
+            }
+            if (!mc.successTokens().isEmpty()) {
+                pushDispatchService.markTokensSuccess(mc.successTokens());
+            }
+        } catch (Exception e) {
+            log.error(">>> [Notification] dispatch failed event={}, cause={}", event, e.getMessage(), e);
+        }
+    }
+
+    // FCM data payload 빌드
+    private Map<String, String> buildData(NotificationEvent event, Long notificationId) {
+        Map<String, String> data = new HashMap<>();
+        data.put("notificationId", String.valueOf(notificationId));
+        data.put("type", event.notificationType().name());
+        data.put("category", event.notificationType().category().name());
+        data.put("targetType", event.targetType().name());
+        data.put("title", event.title());
+        data.put("body", event.content());
+        if (event.targetId() != null) {
+            data.put("targetId", String.valueOf(event.targetId()));
+        }
+        if (event.parentTargetId() != null) {
+            data.put("parentTargetId", String.valueOf(event.parentTargetId()));
+        }
+        return data;
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/dto/MulticastResult.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/dto/MulticastResult.java
@@ -1,0 +1,18 @@
+package com.storix.infrastructure.external.fcm.dto;
+
+import java.util.Collections;
+import java.util.List;
+
+// 멀티캐스트 전송 결과.
+// invalidTokens 는 영구 invalid 로 분류된 토큰, successTokens 는 성공 토큰.
+// 일시 오류 토큰은 어느 쪽에도 포함되지 않음.
+public record MulticastResult(
+        int successCount,
+        int failureCount,
+        List<String> invalidTokens,
+        List<String> successTokens
+) {
+    public static MulticastResult empty() {
+        return new MulticastResult(0, 0, Collections.emptyList(), Collections.emptyList());
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/dto/SingleSendResult.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/dto/SingleSendResult.java
@@ -1,0 +1,14 @@
+package com.storix.infrastructure.external.fcm.dto;
+
+// 단일 토큰 전송 결과.
+// invalidToken != null 이면 영구 invalid 로 판별되어 caller 가 deactivate 해야 함.
+public record SingleSendResult(String messageId, String invalidToken) {
+
+    public static SingleSendResult success(String messageId) {
+        return new SingleSendResult(messageId, null);
+    }
+
+    public static SingleSendResult invalid(String token) {
+        return new SingleSendResult(null, token);
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/dto/TokenClassification.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/fcm/dto/TokenClassification.java
@@ -1,0 +1,10 @@
+package com.storix.infrastructure.external.fcm.dto;
+
+import java.util.List;
+
+// FCM multicast 응답에서 무효 토큰 / 성공 토큰 분류 결과
+public record TokenClassification(
+        List<String> invalidTokens,
+        List<String> successTokens
+) {
+}


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. FCM 인프라 구축
- Firebase Admin SDK, FirebaseProperties 로 환경변수 바인딩 + FirebaseApp / FirebaseMessaging Bean
초기화해두었습니다.
- FCM 발송 래퍼 (FcmSender) 구현
  - payload : title/body/data 만 전송합니다. (알림 아이콘 -> 프론트에 위임)
  - background/quit 상태에서도 깨우기 위해 Android HIGH priority + iOS apns-priority=5, content-available=1
 헤더를 함께 전송합니다.
- 응답 분류: Firebase 공식 가이드 기준 영구 invalid 토큰(UNREGISTERED / INVALID_ARGUMENT /
SENDER_ID_MISMATCH) 만 invalid 그룹으로 분리. 일시 오류는 자동 비활성화 대상에서 제외합니다.
- 비동기 처리: 알림 발송 전용 notificationTaskExecutor 분리 (core 4, max 16, queue 1000)


 ### 2. 알림 설정 API 구현
**[알림 설정 도메인]**
푸시 알림 / 인앱 알림함에 동일하게 수신 여부가 적용됩니다. 푸시 알림은 pushDevice의 isActive=true인 경우에 한해서 전송 가능합니다.
- 유저별 타입별 수신 여부 (피드/리뷰/댓글/답댓글/오늘의 피드/토픽룸/마케팅 )
   - 기본값: 마케팅만 OFF, 나머지 ON (NotificationSetting.defaultFor).
- 회원가입 시 기본 row 생성, 회원탈퇴 시 row 삭제합니다.
+ acceptsType(NotificationType) 에 운영 정책상 알림(신고 접수/처리, 이용 제한, 약관/정책/기능 업데이트)은 우선 수신 여부 필드 없이 항상 발송되도록 하였습니다. (기획 재질의 필요)

**[API 스펙]**
- `[GET /api/v1/notifications/settings]` 알림 설정 조회.
- `[PATCH /api/v1/notifications/settings]` 알림 설정 부분 갱신 


### 3. 알림 이벤트 / Publisher / Listener 정의
알림 시스템 구조 >
```
Service ──publish──▶ NotificationPublisher (Domain)
                          │  (Spring) ApplicationEventPublisher -> 구현체 변경 가능합니다
                          ▼  
                    NotificationEvent (AFTER_COMMIT)  
                          │
                          ▼
NotificationEventListener (Infra)
   ├─▶ NotificationDispatchService (Domain) -> 알림 발송 가능 여부 검증 / 푸시 발송 대상 FCM 토큰 조회
   ├─▶ FcmSender (Infra) -> FCM 알림 발송 후, FCM의 응답 코드에 따라 토큰 상태 체크
   └─▶ PushDispatchService (Domain)-> 토큰 후처리 (invalid / success)
```

**[알림 이벤트]**
- [Domain] NotificationEvent > 정적 팩토리 (likeFeed, commentOnFeed marketing, reportRecevied, 등)
- 푸시 알림 템플릿 : STORIXStatic 파일에서 관리합니다.
   - NotificationCategory (FEED/REVIEW/TOPIC_ROOM/MARKETING/REPORT/POLICY) -> 알림 아이콘 카테고리
   - 마케팅/광고 > 타이틀 (광고) %s, 본문 %s (수신거부 : 설정)
   - 신고 접수/처리, 이용 제한(7일/30일), 약관/개인정보/기능 업데이트 > 모두 사전 정의된 타이틀/본문 사용.

**[알림 이벤트 Publisher]**
- [Domain] NotificationPublisher > Spring event publisher (ApplicationEventPublisher) 사용 -> NotificationEvent 발행
- 발행 지점(Service)은 팩토리 호출 + publisher.publishUnlessSelf(actorUserId, event)
   - 본인 행동에 본인 알림 차단: publishUnlessSelf 가 actorUserId == recipientUserId 이면 무시.
   - AFTER_COMMIT + @ Async 리스너 분리 — 트리거 트랜잭션이 커밋된 후에만 발송, 알림 실패가 원본 트랜잭션에 영향 X

**[알림 이벤트 Listener]**
- [Infra] NotificationEventListener > 
   1)[Domain] NotificationDispatchService 호출 -> 2)[Infra] FcmSender FCM 푸시 알림 발송 -> 3)토큰 후처리(invalid 비활성화, success lastSuccessAt 갱신)
         - [Domain] NotificationDispatchService — 비즈니스 로직 (유저 상태 검사, 타입 토글 검사, 인앱 저장, SUSPENDED 게이트, 토큰 조회).
              - SUSPENDED 게이트: 정지 유저는 인앱은 저장(정지 풀리면 확인 가능)하되, 푸시는 신고/제재 안내만 발송. (기획 재질의 필요)


### 4. 알림 테스트 API (ADMIN only)
- `[POST /api/v1/notifications/admin/test-push]` 단일 토큰 직접 발송 — FCM 환경변수 세팅 검증용. invalid
토큰이면 자동 비활성화.
- `[POST /api/v1/notifications/admin/test-dispatch]` NotificationEvent.publish E2E 검증 — 인앱 저장 + 활성
디바이스에 멀티캐스트 발송까지 전 흐름 확인.


### 5. 알림 트리거 로직 + 조회 개편
- [알림 트리거] 피드/리뷰 좋아요·댓글·답댓글 지점에서 NotificationPublisher.publishUnlessSelf(...) 호출
   - "오늘의 피드 / HOT 토픽룸 / 운영 정책상 알림" 추후 작업
- [조회 개편] FeedReactionService, WorksDetailReactionService의 책임 분리 일관성을 맞추었습니다.


### 6. 기타
- [GlobalExceptionHandle] InvalidFormatException 처리 추가 -> enum 필드에 잘못된 값 보내면 어느 필드가
어떤 값으로 거부됐는지 + 허용값 enum 목록을 응답에 포함합니다.


## 📸 작업 화면 (스크린샷)
FCM 푸시 알림 테스트용 RN 앱을 생성하여 테스트 진행하였습니다.
- 10자 이상인 경우 ... 처리
<img width="1080" height="1099" alt="알림 테스트 화면" src="https://github.com/user-attachments/assets/d1a88ebc-dc12-4727-9122-7759513786ad" />


## 💬 리뷰 요구사항(선택)


## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #61 

## 🖇️ 기타
[서버 DB 변경건]
- NotificationSetting 테이블은 User 엔티티 생성 시 userId를 PK값으로 하여 row가 추가되도록 하였습니다. (트랜잭션 처리) 테스트용으로 이미 만들어진 user 데이터에 대하여 notification_setting 테이블을 별도로 생성하는 쿼리를 날려 정합성을 맞추는 작업이 필요합니다. 
- Notification 엔티티 ddl 옵션 중 변경한 것이 많으나, enum 필드의 경우 hibernate update 옵션 만으로 제대로 반영되지 않을 수 있습니다. 이또한 직접 쿼리를 날려 맞추는 작업이 필요합니다.

[서버 환경변수 추가건]
- FCM 세팅하면서 Firebase Console의 Admin 키를 base64로 전환한 값을 서버 환경변수로 등록하는 작업이 필요합니다.

-> 위 사항들은 작업 배포 시 제가 사전에 작업을 진행하도록 하겠습니다.
