### PR TITLE
Feat: [알림 시스템] 마케팅 수신 동의 로그 저장 (+알림 카테고리 응답 추가)

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
@@ -1,7 +1,9 @@
 package com.storix.api.domain.notification.controller;
 
 import com.storix.api.domain.notification.controller.dto.FcmSendRequest;
+import com.storix.api.domain.notification.controller.dto.MarketingConsentRequest;
 import com.storix.api.domain.notification.controller.dto.NotificationDispatchTestRequest;
+import com.storix.api.domain.notification.usecase.MarketingConsentUseCase;
 import com.storix.api.domain.notification.usecase.NotificationSettingUseCase;
 import com.storix.api.domain.notification.usecase.NotificationTestUseCase;
 import com.storix.api.domain.notification.usecase.NotificationUseCase;
@@ -9,6 +11,7 @@ import com.storix.common.payload.CustomResponse;
 import com.storix.domain.domains.notification.dto.NotificationResponseDto;
 import com.storix.domain.domains.notification.dto.NotificationSettingResponse;
 import com.storix.domain.domains.notification.dto.UpdateNotificationSettingRequest;
+import com.storix.domain.domains.notification.dto.MarketingConsentResponse;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,6 +31,7 @@ public class NotificationController {
     private final NotificationUseCase notificationUseCase;
     private final NotificationSettingUseCase notificationSettingUseCase;
     private final NotificationTestUseCase notificationTestUseCase;
+    private final MarketingConsentUseCase marketingConsentUseCase;
 
     /** 사용자 알림함 */
     // 1. 전체 알림 목록 조회
@@ -89,6 +93,16 @@ public class NotificationController {
             @RequestBody UpdateNotificationSettingRequest request
     ) {
         return notificationSettingUseCase.updateNotificationSetting(authUser.getUserId(), request);
+    }
+
+    // 7. 마케팅 수신 동의/거부
+    @PutMapping("/marketing-consent")
+    @Operation(summary = "마케팅 수신 동의/거부", description = "이벤트/혜택 알림 동의 또는 거부를 처리하고 로그를 DB에 저장합니다.")
+    public CustomResponse<MarketingConsentResponse> updateMarketingConsent(
+            @AuthenticationPrincipal AuthUserDetails authUser,
+            @RequestBody @Valid MarketingConsentRequest request
+    ) {
+        return marketingConsentUseCase.updateMarketingConsent(authUser.getUserId(), request.agreed());
     }
 
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
@@ -102,7 +102,7 @@ public class NotificationController {
             @AuthenticationPrincipal AuthUserDetails authUser,
             @RequestBody @Valid MarketingConsentRequest request
     ) {
-        return marketingConsentUseCase.updateMarketingConsent(authUser.getUserId(), request.agreed());
+        return marketingConsentUseCase.updateMarketingConsent(authUser.getUserId(), request.marketingEnabled());
     }
 
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/MarketingConsentRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/MarketingConsentRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.NotNull;
 
 public record MarketingConsentRequest(
 
-        @Schema(description = "이벤트/혜택 알림 동의 여부 (true: 동의, false: 거부)", example = "true")
+        @Schema(description = "이벤트/혜택 알림 수신 동의 여부 (true: 동의, false: 거부)", example = "true")
         @NotNull(message = "동의 여부를 보내주세요.")
-        Boolean agreed
+        Boolean marketingEnabled
 ) {
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/MarketingConsentRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/MarketingConsentRequest.java
@@ -1,0 +1,12 @@
+package com.storix.api.domain.notification.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record MarketingConsentRequest(
+
+        @Schema(description = "이벤트/혜택 알림 동의 여부 (true: 동의, false: 거부)", example = "true")
+        @NotNull(message = "동의 여부를 보내주세요.")
+        Boolean agreed
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/MarketingConsentUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/MarketingConsentUseCase.java
@@ -1,0 +1,33 @@
+package com.storix.api.domain.notification.usecase;
+
+import com.storix.common.annotation.UseCase;
+import com.storix.common.code.SuccessCode;
+import com.storix.common.payload.CustomResponse;
+import com.storix.common.utils.STORIXStatic;
+import com.storix.domain.domains.notification.dto.MarketingConsentResponse;
+import com.storix.domain.domains.notification.dto.MarketingConsentResult;
+import com.storix.domain.domains.notification.service.MarketingConsentService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class MarketingConsentUseCase {
+
+    private final MarketingConsentService marketingConsentService;
+
+    // 마케팅 수신 동의/거부 처리
+    public CustomResponse<MarketingConsentResponse> updateMarketingConsent(Long userId, boolean agreed) {
+
+        MarketingConsentResult result = marketingConsentService.process(userId, agreed);
+
+        String title       = result.agreed() ? STORIXStatic.UserHistory.TITLE_MARKETING_AGREE
+                                             : STORIXStatic.UserHistory.TITLE_MARKETING_REJECT;
+        String description = result.agreed() ? STORIXStatic.UserHistory.DESC_MARKETING_AGREE
+                                             : STORIXStatic.UserHistory.DESC_MARKETING_REJECT;
+
+        return CustomResponse.onSuccess(
+                SuccessCode.NOTIFICATION_MARKETING_CONSENT_UPDATE_SUCCESS,
+                MarketingConsentResponse.of(result, title, description)
+        );
+    }
+}

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -19,6 +19,7 @@ public enum SuccessCode {
     NOTIFICATION_PREFERENCE_LOAD_SUCCESS(HttpStatus.OK, "NOTI2006", "알림 설정을 성공적으로 조회했습니다."),
     NOTIFICATION_PREFERENCE_UPDATE_SUCCESS(HttpStatus.OK, "NOTI2007", "알림 설정이 변경되었습니다."),
     NOTIFICATION_TEST_PUSH_SUCCESS(HttpStatus.OK, "NOTI2008", "테스트 푸시 알림 전송에 성공했습니다."),
+    NOTIFICATION_MARKETING_CONSENT_UPDATE_SUCCESS(HttpStatus.OK, "NOTI2009", "마케팅 알림 동의 상태가 변경되었습니다."),
 
     // PushDevice success
     DEVICE_SYNC_SUCCESS(HttpStatus.OK, "DEVICE2001", "디바이스 동기화에 성공했습니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -68,4 +68,19 @@ public class STORIXStatic {
         public static final int CONTENT_PREVIEW_MAX = 10;
         public static final String CONTENT_PREVIEW_SUFFIX = "...";
     }
+
+    // 사용자 이력 — 마케팅 동의/거부 모달 표시 문구
+    public static class UserHistory {
+
+        // 발신자 (DB 컬럼에 저장되는 값 — 향후 변동 대비 컬럼 보관)
+        public static final String SENDER_TEAM_STORIX = "팀 스토릭스";
+
+        // 타이틀
+        public static final String TITLE_MARKETING_AGREE  = "이벤트/혜택 알림 동의 안내";
+        public static final String TITLE_MARKETING_REJECT = "이벤트/혜택 알림 거부 안내";
+
+        // 처리 내용
+        public static final String DESC_MARKETING_AGREE   = "알림 동의 처리 완료";
+        public static final String DESC_MARKETING_REJECT  = "알림 거부 처리 완료";
+    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationSetting.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationSetting.java
@@ -69,7 +69,7 @@ public class NotificationSetting extends BaseTimeEntity {
 
 
     /** 비즈니스 메서드 */
-    // 부분 갱신 — null 인자는 변경하지 않음
+    // 부분 갱신 — null 인자는 변경하지 않음 (marketing 은 changeMarketing 으로 분리)
     public void update(Boolean likeFeedEnabled,
                        Boolean likeReviewEnabled,
                        Boolean likeCommentEnabled,
@@ -77,7 +77,6 @@ public class NotificationSetting extends BaseTimeEntity {
                        Boolean replyOnCommentEnabled,
                        Boolean todayFeedEnabled,
                        Boolean hotTopicRoomEnabled,
-                       Boolean marketingEnabled,
                        Boolean operationPolicyEnabled) {
         if (likeFeedEnabled != null) this.likeFeedEnabled = likeFeedEnabled;
         if (likeReviewEnabled != null) this.likeReviewEnabled = likeReviewEnabled;
@@ -86,8 +85,12 @@ public class NotificationSetting extends BaseTimeEntity {
         if (replyOnCommentEnabled != null) this.replyOnCommentEnabled = replyOnCommentEnabled;
         if (todayFeedEnabled != null) this.todayFeedEnabled = todayFeedEnabled;
         if (hotTopicRoomEnabled != null) this.hotTopicRoomEnabled = hotTopicRoomEnabled;
-        if (marketingEnabled != null) this.marketingEnabled = marketingEnabled;
         if (operationPolicyEnabled != null) this.operationPolicyEnabled = operationPolicyEnabled;
+    }
+
+    // 마케팅 수신 동의 단일 갱신 (회원가입 직후 모달 / 설정 페이지 분리 API 용)
+    public void changeMarketing(boolean enabled) {
+        this.marketingEnabled = enabled;
     }
 
     // 알림 타입별 수신 여부 — 푸시 발송 동의 판정용 (인앱 저장은 토글 무관)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/MarketingConsentResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/MarketingConsentResponse.java
@@ -1,0 +1,18 @@
+package com.storix.domain.domains.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+// 마케팅 동의/거부 처리 결과 (모달 표시용)
+public record MarketingConsentResponse(
+        String title,         // 이벤트/혜택 알림 동의/거부 안내
+        String sender,        // 팀 스토릭스
+        @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
+        LocalDateTime processedAt,
+        String description    // 알림 동의/거부 처리 완료
+) {
+    public static MarketingConsentResponse of(MarketingConsentResult result, String title, String description) {
+        return new MarketingConsentResponse(title, result.sender(), result.processedAt(), description);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/MarketingConsentResult.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/MarketingConsentResult.java
@@ -1,0 +1,10 @@
+package com.storix.domain.domains.notification.dto;
+
+import java.time.LocalDateTime;
+
+public record MarketingConsentResult(
+        boolean agreed,
+        String sender,
+        LocalDateTime processedAt
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationResponseDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationResponseDto.java
@@ -1,6 +1,7 @@
 package com.storix.domain.domains.notification.dto;
 
 import com.storix.domain.domains.notification.domain.Notification;
+import com.storix.domain.domains.notification.domain.NotificationCategory;
 import com.storix.domain.domains.notification.domain.NotificationType;
 import com.storix.domain.domains.notification.domain.TargetType;
 import lombok.Builder;
@@ -14,6 +15,7 @@ public class NotificationResponseDto {
 
     private Long id;
     private NotificationType notificationType;
+    private NotificationCategory category;
     private TargetType targetType;
     private Long targetId;
     private Long parentTargetId;
@@ -26,7 +28,8 @@ public class NotificationResponseDto {
         return NotificationResponseDto.builder()
                 .id(notification.getId())
                 .notificationType(notification.getNotificationType())
-                .targetType(notification.getTargetType())
+                .category(notification.getNotificationType().category()) // 알림 분류 라벨 (UI 아이콘 / 그룹)
+                .targetType(notification.getTargetType()) // 알림 클릭 시 라우팅 대상 (페이지 이동)
                 .targetId(notification.getTargetId())
                 .parentTargetId(notification.getParentTargetId())
                 .title(notification.getTitle())

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingCommand.java
@@ -8,7 +8,6 @@ public record UpdateNotificationSettingCommand(
         Boolean replyOnCommentEnabled,
         Boolean todayFeedEnabled,
         Boolean hotTopicRoomEnabled,
-        Boolean marketingEnabled,
         Boolean operationPolicyEnabled
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingRequest.java
@@ -2,7 +2,8 @@ package com.storix.domain.domains.notification.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-// 추후 알림 뎁스 세분화를 위한 테이블 컬럼 유지 (9개 -> 4개 상위 분류)
+// 추후 알림 뎁스 세분화를 위한 테이블 컬럼 유지 (8개 -> 3개 상위 분류)
+// 이벤트/혜택(마케팅) 동의는 법적 추적 대상 -> marketing-consent 별도 API 로 분리
 public record UpdateNotificationSettingRequest(
 
         @Schema(description = "내 활동 알림 — 피드/리뷰/댓글/답댓글/댓글 좋아요", example = "true")
@@ -10,9 +11,6 @@ public record UpdateNotificationSettingRequest(
 
         @Schema(description = "콘텐츠/커뮤니티 알림 — 오늘의 피드/HOT 토픽룸 선정", example = "true")
         Boolean contentCommunityEnabled,
-
-        @Schema(description = "이벤트/혜택 알림 — 운영자 발송 이벤트/광고", example = "false")
-        Boolean eventBenefitEnabled,
 
         @Schema(description = "운영/정책 알림 — 신고 처리/이용 제한/약관 업데이트 등", example = "true")
         Boolean operationPolicyEnabled
@@ -26,7 +24,6 @@ public record UpdateNotificationSettingRequest(
                 myActivityEnabled,
                 contentCommunityEnabled,
                 contentCommunityEnabled,
-                eventBenefitEnabled,
                 operationPolicyEnabled
         );
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/MarketingConsentService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/MarketingConsentService.java
@@ -1,0 +1,41 @@
+package com.storix.domain.domains.notification.service;
+
+import com.storix.common.utils.STORIXStatic;
+import com.storix.domain.domains.notification.adaptor.NotificationSettingAdaptor;
+import com.storix.domain.domains.notification.domain.NotificationSetting;
+import com.storix.domain.domains.notification.dto.MarketingConsentResult;
+import com.storix.domain.domains.user.adaptor.UserHistoryAdaptor;
+import com.storix.domain.domains.user.domain.UserHistory;
+import com.storix.domain.domains.user.domain.UserHistoryType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class MarketingConsentService {
+
+    private final NotificationSettingAdaptor notificationSettingAdaptor;
+    private final UserHistoryAdaptor userHistoryAdaptor;
+
+    // 마케팅 수신 동의/거부 처리
+    @Transactional
+    public MarketingConsentResult process(Long userId, boolean agreed) {
+
+        // 1. 알림 설정 갱신
+        NotificationSetting setting = notificationSettingAdaptor.getByUserId(userId);
+        setting.changeMarketing(agreed);
+
+        // 2. 유저 로그 저장
+        UserHistory saved = userHistoryAdaptor.save(UserHistory.builder()
+                .userId(userId)
+                .historyType(agreed ? UserHistoryType.MARKETING_AGREE : UserHistoryType.MARKETING_REJECT)
+                .sender(STORIXStatic.UserHistory.SENDER_TEAM_STORIX)
+                .processedAt(LocalDateTime.now())
+                .build());
+
+        return new MarketingConsentResult(agreed, saved.getSender(), saved.getProcessedAt());
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationSettingService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationSettingService.java
@@ -31,7 +31,6 @@ public class NotificationSettingService {
                 cmd.replyOnCommentEnabled(),
                 cmd.todayFeedEnabled(),
                 cmd.hotTopicRoomEnabled(),
-                cmd.marketingEnabled(),
                 cmd.operationPolicyEnabled()
         );
         return setting;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserHistoryAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserHistoryAdaptor.java
@@ -1,0 +1,18 @@
+package com.storix.domain.domains.user.adaptor;
+
+import com.storix.domain.domains.user.domain.UserHistory;
+import com.storix.domain.domains.user.repository.UserHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserHistoryAdaptor {
+
+    private final UserHistoryRepository userHistoryRepository;
+
+    // 사용자 이력 저장
+    public UserHistory save(UserHistory userHistory) {
+        return userHistoryRepository.save(userHistory);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserHistory.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserHistory.java
@@ -1,0 +1,49 @@
+package com.storix.domain.domains.user.domain;
+
+import com.storix.common.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_history",
+        indexes = {
+                @Index(name = "idx_user_created", columnList = "user_id, created_at DESC")
+        }
+)
+public class UserHistory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "history_type", nullable = false, length = 32)
+    private UserHistoryType historyType;
+
+    // 발신자
+    @Column(name = "sender", nullable = false, length = 50)
+    private String sender;
+
+    // 처리 시점
+    @Column(name = "processed_at", nullable = false)
+    private LocalDateTime processedAt;
+
+
+    @Builder
+    private UserHistory(Long userId, UserHistoryType historyType, String sender, LocalDateTime processedAt) {
+        this.userId = userId;
+        this.historyType = historyType;
+        this.sender = sender;
+        this.processedAt = processedAt;
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserHistoryType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserHistoryType.java
@@ -1,0 +1,6 @@
+package com.storix.domain.domains.user.domain;
+
+public enum UserHistoryType {
+    MARKETING_AGREE,
+    MARKETING_REJECT
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserHistoryRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.storix.domain.domains.user.repository;
+
+import com.storix.domain.domains.user.domain.UserHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserHistoryRepository extends JpaRepository<UserHistory, Long> {
+}


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 마케팅 수신 동의/거부 API 분리 + UserHistory 이력 저장
법적으로 광고성 정보 수신 동의 이후 처리 결과를 전달 및 관리해야 한다고 합니다. 이를 DB 테이블에 저장하도록 처리하였습니다.
  - 신규 API: `PUT /api/v1/notifications/marketing-consent`
  - 알림 설정 PATCH 에서 마케팅 필드 제거 (`eventBenefitEnabled`)
    → 마케팅 동의/거부는 마케팅 수신 동의/거부 API 호출로만 가능
  - `user_history` 테이블에 동의/거부 이력 저장 (발신자 · 처리 일시)

### 2. 알림 조회 응답에 category 필드 추가
  - `NotificationResponseDto` 에 `category` 추가
  - 6개 카테고리 (피드 / 리뷰 / 토픽룸 / 이벤트·광고 / 신고 / 약관·정책)


## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #61 

## 🖇️ 기타