### PR TITLE
Refactor: [프로필] 취향 분석 장르 스코어링 정책 변경

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/profile/usecase/ProfileFavoriteUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/profile/usecase/ProfileFavoriteUseCase.java
@@ -51,10 +51,10 @@ public class ProfileFavoriteUseCase {
         return CustomResponse.onSuccess(SuccessCode.PROFILE_FAVORITE_HASHTAGS_LOAD_SUCCESS, result);
     }
 
-    // 선호 장르 통계 조회 (비율 정규화)
+    // 선호 장르 통계 조회
     public CustomResponse<List<GenreScoreInfo>> getGenreStats(Long userId) {
 
-        List<GenreScoreInfo> result = genreScoreQueryService.getRatioNormalized(userId);
+        List<GenreScoreInfo> result = genreScoreQueryService.getRawScores(userId);
         return CustomResponse.onSuccess(SuccessCode.PROFILE_GENRE_STATS_LOAD_SUCCESS, result);
     }
 }

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
@@ -22,8 +22,8 @@ public class GenreScoreAggregationScheduler {
     private final GenreScoreAggregationService aggregationService;
 
 
-    // 매일 자정, 미처리 로그 청크 단위로 집계
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    // 매 시간 정각, 미처리 로그 청크 단위로 집계
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
     public void run() {
         long started = System.currentTimeMillis();
         Set<Long> touchedUsers = new HashSet<>();

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreResetScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreResetScheduler.java
@@ -1,0 +1,24 @@
+package com.storix.batch.scheduler;
+
+import com.storix.domain.domains.genrescore.service.GenreScoreAggregationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GenreScoreResetScheduler {
+
+    private final GenreScoreAggregationService aggregationService;
+
+    // 유저 장르 점수 주기별 초기화
+    @Scheduled(cron = "0 0 4 1 1 *", zone = "Asia/Seoul")
+    public void resetAll() {
+        long started = System.currentTimeMillis();
+        log.info(">>> [GenreScoreReset] start");
+        aggregationService.resetAllRawScores();
+        log.info(">>> [GenreScoreReset] done. took={}ms", System.currentTimeMillis() - started);
+    }
+}

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreResetScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreResetScheduler.java
@@ -13,8 +13,8 @@ public class GenreScoreResetScheduler {
 
     private final GenreScoreAggregationService aggregationService;
 
-    // 유저 장르 점수 주기별 초기화
-    @Scheduled(cron = "0 0 4 1 1 *", zone = "Asia/Seoul")
+    // 유저 장르 점수 주기별 초기화 (집계 배치와 시각 분리)
+    @Scheduled(cron = "0 30 3 1 1 *", zone = "Asia/Seoul")
     public void resetAll() {
         long started = System.currentTimeMillis();
         log.info(">>> [GenreScoreReset] start");

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/favorite/service/FavoriteService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/favorite/service/FavoriteService.java
@@ -35,6 +35,7 @@ public class FavoriteService {
     @Transactional
     public void deleteFavoriteWorks(Long userId, Long worksId) {
         favoriteWorksAdaptor.deleteSingleFavoriteWorks(userId, worksId);
+        genreScorePublisher.publish(userId, worksId, GenreScoreEventType.FAVORITE_WORKS_REMOVE);
     }
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/event/GenreScoreEventType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/event/GenreScoreEventType.java
@@ -11,7 +11,8 @@ public enum GenreScoreEventType {
     TOPIC_ROOM_JOIN(4),
     REVIEW_WRITE_POSITIVE(4),
     BOARD_WRITE(3),
-    FAVORITE_WORKS_ADD(3);
+    FAVORITE_WORKS_ADD(3),
+    FAVORITE_WORKS_REMOVE(-3);
 
     private final int weight;
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreAggregationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreAggregationService.java
@@ -60,6 +60,12 @@ public class GenreScoreAggregationService {
         return logRepository.deleteProcessedBefore(LocalDateTime.now().minusDays(LOG_RETENTION_DAYS));
     }
 
+    // 주기별 raw_score 테이블 전체 초기화
+    @Transactional
+    public void resetAllRawScores() {
+        rawScoreRepository.deleteAllInBatch();
+    }
+
     public record ChunkResult(int processedLogs, int groups, Set<Long> users) {
         public static ChunkResult empty() {
             return new ChunkResult(0, 0, Collections.emptySet());

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
@@ -17,28 +17,20 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class GenreScoreQueryService {
 
-    private static final double PERCENT_SCALE = 100.0;
-
     private final UserGenreRawScoreRepository rawScoreRepository;
 
-    // 장르별 raw_score 비율 정규화 (전체 합 대비 백분율 0~100, 정수 반올림 변환)
-    public List<GenreScoreInfo> getRatioNormalized(Long userId) {
+    // 장르별 raw_score 반환
+    public List<GenreScoreInfo> getRawScores(Long userId) {
         List<UserGenreRawScore> scores = rawScoreRepository.findAllByIdUserId(userId);
-        return normalize(scores);
-    }
-
-    private List<GenreScoreInfo> normalize(List<UserGenreRawScore> scores) {
-        long total = scores.stream().mapToLong(UserGenreRawScore::getRawScore).sum();
 
         Map<Genre, Long> rawByGenre = scores.stream()
                 .collect(Collectors.toMap(UserGenreRawScore::getGenre, UserGenreRawScore::getRawScore));
 
         return Arrays.stream(Genre.values())
-                .map(g -> {
-                    long raw = rawByGenre.getOrDefault(g, 0L);
-                    double score = total == 0 ? 0.0 : Math.round(raw / (double) total * PERCENT_SCALE);
-                    return new GenreScoreInfo(g.getDbValue(), score);
-                })
+                .map(g -> new GenreScoreInfo(
+                        g.getDbValue(),
+                        (double) rawByGenre.getOrDefault(g, 0L)
+                ))
                 .sorted(Comparator.comparing(GenreScoreInfo::score).reversed())
                 .toList();
     }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 취향 분석 장르 스코어링 정책 변경
26.05.12 회의 내용을 기준으로 내부 로직 변경하였습니다.

1. 장르 점수 이벤트 발행 기준
(기존) 장르 스코어링 구조 -> 관심 작품 : 등록에 대한 가중치(+3)만 있었음
    - 장르 스코어링 관련 이벤트 발생 > `user_genre_score_log` 저장 > 주기별로(자정) 청크 단위(1000건)마다 `user_genre_raw_score `풀링
    - 만약 관심 작품 등록 후 해제를 여러 번 반복할 경우 : 등록에 대한 가중치가 계속 반영 -> 장르에 대한 관심이라고 보기 어려운 값이 지속적으로 반영됨
       - case) 기존 user_genre_score_log에 쌓인 컬럼을 조회하여 등록 해제시 row를 삭제하거나 등록 전 기존 row 존재 여부를 파악하여 가중치를 반영한다면, 선형적으로 접근/쓰기 작업을 수행하던 기존 로직의 결에 맞지 않다고 생각 (주기별 scheduler로 인해 db 값이 갈아치워지는 경우도 생각해야함)
       => (신규) 관심 작품 : 등록 해제에 대한 가중치(-3)을 두어 (최종적으로) +- = 0 로 처리하자고 제안하였고, 반영했습니다.

2. 선호 장르 통계 반환값
(기존) raw_score -> 정규화 로직을 거쳐서 반환
(신규) 정규화 로직 제거

### 2. 기타
- 1-2. 선호 장르 통계 반환값을 raw_score로 보여줄 시, 행동 데이터가 많을 수록 UX가 깨질 수 있는 수준의 점수값이 노출될 수 있겠다 판단 -> 주기별로 user_genre_raw_score 테이블을 초기화하는 스케줄러를 추가하였습니다. (현재는 매년 1/1 초기화 -> 추후 모니터링을 통해 적절히 주기를 변경할 예정)
- 장르 점수 집계 주기 : 자정 -> 1시간 으로 변경


## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #57 

## 🖇️ 기타