### PR TITLE
Feat: [프로필-설정] 회원 탈퇴 사유 수집 및 프로필 응답 추가 반환

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/search/SearchController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/search/SearchController.java
@@ -29,7 +29,7 @@ public class SearchController {
     private final SearchHistoryService searchHistoryService;
 
     @GetMapping("/works")
-    @Operation(summary = "작품 검색", description = "작품명 검색합니다. 결과값은 무한 스크롤로 구성됩니다.")
+    @Operation(summary = "작품 검색", description = "작품명 검색합니다. 결과값은 무한 스크롤로 구성됩니다.", deprecated = true)
     public CustomResponse<SearchResponseWrapperDto<WorksSearchResponseDto>> searchWorks(
             @RequestParam String keyword,
             @AuthenticationPrincipal AuthUserDetails authUser,

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -5,7 +5,6 @@ import com.storix.api.domain.user.controller.dto.KakaoNativeLoginRequest;
 import com.storix.api.domain.user.controller.dto.NaverNativeLoginRequest;
 import com.storix.api.domain.user.controller.dto.ReaderSocialLoginResponse;
 import com.storix.api.domain.user.controller.dto.RefreshTokenRequest;
-import com.storix.api.domain.user.controller.dto.WithdrawRequest;
 import com.storix.api.domain.user.usecase.*;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.domain.domains.user.adaptor.OnboardingUserDetails;
@@ -143,15 +142,13 @@ public class AuthController {
         return logoutUseCase.execute(authUserDetails.getUserId(), null);
     }
 
-    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴용 api 입니다.   \n" +
-            "회원 계정과 관련된 Refresh 토큰과 모든 디바이스의 FCM 토큰을 비활성화합니다.   \n" +
-            "탈퇴 사유(reason)는 필수이며, reason=OTHER 인 경우에만 detail(직접 입력)을 함께 보내주세요.")
+    @Operation(summary = "[v1] 회원 탈퇴", description = "[v1 > v2 마이그레이션 필요] 회원 탈퇴용 api 입니다.   \n" +
+            "회원 계정과 관련된 Refresh 토큰과 모든 디바이스의 FCM 토큰을 비활성화합니다.")
     @DeleteMapping("/user/withdraw")
     public ResponseEntity<CustomResponse<Void>> withdraw(
-            @AuthenticationPrincipal AuthUserDetails authUserDetails,
-            @Valid @RequestBody WithdrawRequest req
+            @AuthenticationPrincipal AuthUserDetails authUserDetails
     ) {
-        return withDrawUseCase.execute(authUserDetails.getUserId(), req.reason(), req.detail());
+        return withDrawUseCase.execute(authUserDetails.getUserId(), null, null);
     }
 
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.storix.api.domain.user.controller.dto.KakaoNativeLoginRequest;
 import com.storix.api.domain.user.controller.dto.NaverNativeLoginRequest;
 import com.storix.api.domain.user.controller.dto.ReaderSocialLoginResponse;
 import com.storix.api.domain.user.controller.dto.RefreshTokenRequest;
+import com.storix.api.domain.user.controller.dto.WithdrawRequest;
 import com.storix.api.domain.user.usecase.*;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.domain.domains.user.adaptor.OnboardingUserDetails;
@@ -143,12 +144,14 @@ public class AuthController {
     }
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴용 api 입니다.   \n" +
-            "회원 계정과 관련된 Refresh 토큰과 모든 디바이스의 FCM 토큰을 비활성화합니다.")
+            "회원 계정과 관련된 Refresh 토큰과 모든 디바이스의 FCM 토큰을 비활성화합니다.   \n" +
+            "탈퇴 사유(reason)는 필수이며, reason=OTHER 인 경우에만 detail(직접 입력)을 함께 보내주세요.")
     @DeleteMapping("/user/withdraw")
     public ResponseEntity<CustomResponse<Void>> withdraw(
-            @AuthenticationPrincipal AuthUserDetails authUserDetails
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @Valid @RequestBody WithdrawRequest req
     ) {
-        return withDrawUseCase.execute(authUserDetails.getUserId());
+        return withDrawUseCase.execute(authUserDetails.getUserId(), req.reason(), req.detail());
     }
 
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -94,7 +94,7 @@ public class AuthController {
     }
 
     @Operation(summary = "[v1] 독자 계정 회원가입", description = "[v1 > v2 마이그레이션 필요] 유저 정보를 최종적으로 등록하는 api 입니다.   \n" +
-            "온보딩 토큰을 보내주세요.")
+            "온보딩 토큰을 보내주세요.", deprecated = true)
     @PostMapping("/users/reader/signup")
     public ResponseEntity<CustomResponse<AuthorizationResponse>> readerUserSignup(
             @AuthenticationPrincipal OnboardingUserDetails onboardingUser,
@@ -134,7 +134,7 @@ public class AuthController {
     }
 
     @Operation(summary = "[v1] 로그아웃", description = "[v1 > v2 마이그레이션 필요] 로그아웃용 api 입니다.   \n" +
-            "액세스 토큰을 보내주세요.")
+            "액세스 토큰을 보내주세요.", deprecated = true)
     @PostMapping("/user/logout")
     public ResponseEntity<CustomResponse<Void>> logout(
             @AuthenticationPrincipal AuthUserDetails authUserDetails
@@ -143,7 +143,7 @@ public class AuthController {
     }
 
     @Operation(summary = "[v1] 회원 탈퇴", description = "[v1 > v2 마이그레이션 필요] 회원 탈퇴용 api 입니다.   \n" +
-            "회원 계정과 관련된 Refresh 토큰과 모든 디바이스의 FCM 토큰을 비활성화합니다.")
+            "회원 계정과 관련된 Refresh 토큰과 모든 디바이스의 FCM 토큰을 비활성화합니다.", deprecated = true)
     @DeleteMapping("/user/withdraw")
     public ResponseEntity<CustomResponse<Void>> withdraw(
             @AuthenticationPrincipal AuthUserDetails authUserDetails

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
@@ -2,8 +2,10 @@ package com.storix.api.domain.user.controller;
 
 import com.storix.api.domain.user.controller.dto.AuthorizationResponse;
 import com.storix.api.domain.user.controller.dto.LogoutRequest;
+import com.storix.api.domain.user.controller.dto.WithdrawRequest;
 import com.storix.api.domain.user.usecase.AuthUseCase;
 import com.storix.api.domain.user.usecase.LogoutUseCase;
+import com.storix.api.domain.user.usecase.WithDrawUseCase;
 import com.storix.common.payload.CustomResponse;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.domain.domains.user.adaptor.OnboardingUserDetails;
@@ -14,6 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +30,7 @@ public class AuthV2Controller {
 
     private final AuthUseCase authUseCase;
     private final LogoutUseCase logoutUseCase;
+    private final WithDrawUseCase withDrawUseCase;
 
     @Operation(summary = "[v2] 독자 계정 회원가입", description = "유저 정보를 최종적으로 등록하는 api 입니다.   \n" +
             "- 온보딩 토큰을 헤더로 보내주세요.  \n" +
@@ -50,5 +54,17 @@ public class AuthV2Controller {
     ) {
         String installationId = body != null ? body.installationId() : null;
         return logoutUseCase.execute(authUserDetails.getUserId(), installationId);
+    }
+
+    @Operation(summary = "[v2] 회원 탈퇴", description = "회원 탈퇴용 api 입니다.   \n" +
+            "회원 계정과 관련된 Refresh 토큰과 모든 디바이스의 FCM 토큰을 비활성화합니다.   \n" +
+            "- 탈퇴 사유(reason)는 필수이며, user_history 에 기록됩니다.  \n" +
+            "- reason=OTHER 인 경우에만 detail(직접 입력, 200자 이내)을 함께 보내주세요.")
+    @DeleteMapping("/user/withdraw")
+    public ResponseEntity<CustomResponse<Void>> withdraw(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @Valid @RequestBody WithdrawRequest req
+    ) {
+        return withDrawUseCase.execute(authUserDetails.getUserId(), req.reason(), req.detail());
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
@@ -58,13 +58,12 @@ public class AuthV2Controller {
 
     @Operation(summary = "[v2] 회원 탈퇴", description = "회원 탈퇴용 api 입니다.   \n" +
             "회원 계정과 관련된 Refresh 토큰과 모든 디바이스의 FCM 토큰을 비활성화합니다.   \n" +
-            "- 탈퇴 사유(reason)는 필수이며, user_history 에 기록됩니다.  \n" +
-            "- reason=OTHER 인 경우에만 detail(직접 입력, 200자 이내)을 함께 보내주세요.")
+            "- 탈퇴 사유(reasons)는 1개 이상 선택해야 하며, reasons 에 OTHER 가 포함된 경우에만 detail(직접 입력, 100자 이내)을 함께 보내주세요.")
     @DeleteMapping("/user/withdraw")
     public ResponseEntity<CustomResponse<Void>> withdraw(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
             @Valid @RequestBody WithdrawRequest req
     ) {
-        return withDrawUseCase.execute(authUserDetails.getUserId(), req.reason(), req.detail());
+        return withDrawUseCase.execute(authUserDetails.getUserId(), req.reasons(), req.detail());
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/WithdrawRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/WithdrawRequest.java
@@ -1,0 +1,15 @@
+package com.storix.api.domain.user.controller.dto;
+
+import com.storix.domain.domains.user.domain.WithdrawReason;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record WithdrawRequest(
+        @NotNull(message = "탈퇴 사유는 필수입니다.")
+        WithdrawReason reason,
+
+        // reason == OTHER 일 때만 사용 (200자 이내)
+        @Size(max = 200, message = "직접 입력 사유는 200자 이내여야 합니다.")
+        String detail
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/WithdrawRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/WithdrawRequest.java
@@ -1,15 +1,24 @@
 package com.storix.api.domain.user.controller.dto;
 
 import com.storix.domain.domains.user.domain.WithdrawReason;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
-public record WithdrawRequest(
-        @NotNull(message = "탈퇴 사유는 필수입니다.")
-        WithdrawReason reason,
+import java.util.Set;
 
-        // reason == OTHER 일 때만 사용 (200자 이내)
-        @Size(max = 200, message = "직접 입력 사유는 200자 이내여야 합니다.")
+public record WithdrawRequest(
+        @NotEmpty(message = "탈퇴 사유를 1개 이상 선택해야 합니다.")
+        Set<WithdrawReason> reasons,
+
+        // reasons 에 OTHER 가 포함된 경우에만 사용 (100자 이내)
+        @Size(max = 100, message = "직접 입력 사유는 100자 이내여야 합니다.")
         String detail
 ) {
+    @AssertTrue(message = "OTHER 사유 선택 시 detail 은 필수이며, 그 외 사유에서는 detail 을 보낼 수 없습니다.")
+    private boolean isDetailConsistent() {
+        boolean otherSelected = reasons != null && reasons.contains(WithdrawReason.OTHER);
+        boolean detailPresent = detail != null && !detail.isBlank();
+        return otherSelected == detailPresent;
+    }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
@@ -2,6 +2,7 @@ package com.storix.api.domain.user.usecase;
 
 import com.storix.common.annotation.UseCase;
 import com.storix.domain.domains.user.domain.OAuthInfo;
+import com.storix.domain.domains.user.domain.WithdrawReason;
 import com.storix.domain.domains.user.service.AuthService;
 import com.storix.api.domain.user.helper.OAuthHelper;
 import com.storix.api.domain.user.helper.CookieHelper;
@@ -21,7 +22,7 @@ public class WithDrawUseCase {
     private final OAuthHelper oauthHelper;
     private final CookieHelper cookieHelper;
 
-    public ResponseEntity<CustomResponse<Void>> execute(Long userId) {
+    public ResponseEntity<CustomResponse<Void>> execute(Long userId, WithdrawReason reason, String detail) {
 
         // 1. OAuth 연결 해제
         OAuthInfo oauthInfo = authService.findOAuthInfoByUserId(userId);
@@ -40,8 +41,8 @@ public class WithDrawUseCase {
         }
 
 
-        // 2. 유저 탈퇴 처리 (RefreshToken / 관심작품 / 서재 삭제 + 푸시 알림 발송 대상 제외)
-        authService.withDrawUser(userId);
+        // 2. 유저 탈퇴 처리 (RefreshToken / 관심작품 / 서재 삭제 + 푸시 알림 발송 대상 제외 + 탈퇴 사유 로그)
+        authService.withDrawUser(userId, reason, detail);
 
         return ResponseEntity.ok()
                 .headers(cookieHelper.deleteCookie())

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 
+import java.util.Set;
+
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
@@ -22,7 +24,7 @@ public class WithDrawUseCase {
     private final OAuthHelper oauthHelper;
     private final CookieHelper cookieHelper;
 
-    public ResponseEntity<CustomResponse<Void>> execute(Long userId, WithdrawReason reason, String detail) {
+    public ResponseEntity<CustomResponse<Void>> execute(Long userId, Set<WithdrawReason> reasons, String detail) {
 
         // 1. OAuth 연결 해제
         OAuthInfo oauthInfo = authService.findOAuthInfoByUserId(userId);
@@ -42,7 +44,7 @@ public class WithDrawUseCase {
 
 
         // 2. 유저 탈퇴 처리 (RefreshToken / 관심작품 / 서재 삭제 + 푸시 알림 발송 대상 제외 + 탈퇴 사유 로그)
-        authService.withDrawUser(userId, reason, detail);
+        authService.withDrawUser(userId, reasons, detail);
 
         return ResponseEntity.ok()
                 .headers(cookieHelper.deleteCookie())

--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -72,8 +72,8 @@ public class STORIXStatic {
     // 사용자 이력 — 마케팅 동의/거부 모달 표시 문구
     public static class UserHistory {
 
-        // 발신자 (DB 컬럼에 저장되는 값 — 향후 변동 대비 컬럼 보관)
-        public static final String SENDER_TEAM_STORIX = "팀 스토릭스";
+        // 처리자
+        public static final String PROCESSOR_TEAM_STORIX = "팀 스토릭스";
 
         // 타이틀
         public static final String TITLE_MARKETING_AGREE  = "이벤트/혜택 알림 동의 안내";

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/MarketingConsentResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/MarketingConsentResponse.java
@@ -7,12 +7,12 @@ import java.time.LocalDateTime;
 // 마케팅 동의/거부 처리 결과 (모달 표시용)
 public record MarketingConsentResponse(
         String title,         // 이벤트/혜택 알림 동의/거부 안내
-        String sender,        // 팀 스토릭스
+        String sender,        // 팀 스토릭스 (응답 표기명 — 내부에서는 processor 로 관리)
         @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
         LocalDateTime processedAt,
         String description    // 알림 동의/거부 처리 완료
 ) {
     public static MarketingConsentResponse of(MarketingConsentResult result, String title, String description) {
-        return new MarketingConsentResponse(title, result.sender(), result.processedAt(), description);
+        return new MarketingConsentResponse(title, result.processor(), result.processedAt(), description);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/MarketingConsentResult.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/MarketingConsentResult.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 public record MarketingConsentResult(
         boolean agreed,
-        String sender,
+        String processor,
         LocalDateTime processedAt
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/MarketingConsentService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/MarketingConsentService.java
@@ -32,10 +32,10 @@ public class MarketingConsentService {
         UserHistory saved = userHistoryAdaptor.save(UserHistory.builder()
                 .userId(userId)
                 .historyType(agreed ? UserHistoryType.MARKETING_AGREE : UserHistoryType.MARKETING_REJECT)
-                .sender(STORIXStatic.UserHistory.SENDER_TEAM_STORIX)
+                .processor(STORIXStatic.UserHistory.PROCESSOR_TEAM_STORIX)
                 .processedAt(LocalDateTime.now())
                 .build());
 
-        return new MarketingConsentResult(agreed, saved.getSender(), saved.getProcessedAt());
+        return new MarketingConsentResult(agreed, saved.getProcessor(), saved.getProcessedAt());
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/dto/UserInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/dto/UserInfo.java
@@ -1,6 +1,7 @@
 package com.storix.domain.domains.profile.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.storix.domain.domains.user.domain.OAuthProvider;
 import lombok.Builder;
 
 @Builder
@@ -16,6 +17,9 @@ public record UserInfo(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     Integer point,
 
-    String profileDescription
+    String profileDescription,
+
+    // 소셜 로그인 방식 (설정 탭 표시용)
+    OAuthProvider oauthProvider
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/dto/UserInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/dto/UserInfo.java
@@ -1,7 +1,6 @@
 package com.storix.domain.domains.profile.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.storix.domain.domains.user.domain.OAuthProvider;
 import lombok.Builder;
 
 @Builder
@@ -19,7 +18,6 @@ public record UserInfo(
 
     String profileDescription,
 
-    // 소셜 로그인 방식 (설정 탭 표시용)
-    OAuthProvider oauthProvider
+    String oauthProvider
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileService.java
@@ -30,7 +30,8 @@ public class ProfileService {
                 .profileDescription(readerUser.getProfileDescription())
                 .profileImageUrl(readerUser.getProfileObjectKey() == null
                         ? null : baseUrl + "/" + readerUser.getProfileObjectKey())
-                .oauthProvider(readerUser.getOauthInfo().getProvider())
+                .oauthProvider(readerUser.getOauthInfo() == null
+                        ? null : readerUser.getOauthInfo().getProvider().getDbValue())
                 .build();
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileService.java
@@ -30,6 +30,7 @@ public class ProfileService {
                 .profileDescription(readerUser.getProfileDescription())
                 .profileImageUrl(readerUser.getProfileObjectKey() == null
                         ? null : baseUrl + "/" + readerUser.getProfileObjectKey())
+                .oauthProvider(readerUser.getOauthInfo().getProvider())
                 .build();
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OAuthProvider.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OAuthProvider.java
@@ -1,5 +1,16 @@
 package com.storix.domain.domains.user.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum OAuthProvider {
-    KAKAO, NAVER, APPLE, SLACK
+
+    KAKAO("카카오"),
+    NAVER("네이버"),
+    APPLE("애플"),
+    SLACK("슬랙");
+
+    private final String dbValue;
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserHistory.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserHistory.java
@@ -30,25 +30,32 @@ public class UserHistory extends BaseTimeEntity {
     @Column(name = "history_type", nullable = false, length = 32)
     private UserHistoryType historyType;
 
-    // 발신자
-    @Column(name = "sender", nullable = false, length = 50)
-    private String sender;
+    // 처리자
+    @Column(name = "processor", nullable = false, length = 50)
+    private String processor;
 
     // 처리 시점
     @Column(name = "processed_at", nullable = false)
     private LocalDateTime processedAt;
 
-    // 부가 정보 — 탈퇴 사유(enum)/직접 입력 등 유형별 컨텍스트 보관 (nullable)
+    // 탈퇴 사유
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason", length = 32)
+    private WithdrawReason reason;
+
+    // 사용자 자유 입력
     @Column(name = "detail", length = 255)
     private String detail;
 
 
     @Builder
-    private UserHistory(Long userId, UserHistoryType historyType, String sender, LocalDateTime processedAt, String detail) {
+    private UserHistory(Long userId, UserHistoryType historyType, String processor,
+                        LocalDateTime processedAt, WithdrawReason reason, String detail) {
         this.userId = userId;
         this.historyType = historyType;
-        this.sender = sender;
+        this.processor = processor;
         this.processedAt = processedAt;
+        this.reason = reason;
         this.detail = detail;
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserHistory.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserHistory.java
@@ -38,12 +38,17 @@ public class UserHistory extends BaseTimeEntity {
     @Column(name = "processed_at", nullable = false)
     private LocalDateTime processedAt;
 
+    // 부가 정보 — 탈퇴 사유(enum)/직접 입력 등 유형별 컨텍스트 보관 (nullable)
+    @Column(name = "detail", length = 255)
+    private String detail;
+
 
     @Builder
-    private UserHistory(Long userId, UserHistoryType historyType, String sender, LocalDateTime processedAt) {
+    private UserHistory(Long userId, UserHistoryType historyType, String sender, LocalDateTime processedAt, String detail) {
         this.userId = userId;
         this.historyType = historyType;
         this.sender = sender;
         this.processedAt = processedAt;
+        this.detail = detail;
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserHistoryType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserHistoryType.java
@@ -2,5 +2,6 @@ package com.storix.domain.domains.user.domain;
 
 public enum UserHistoryType {
     MARKETING_AGREE,
-    MARKETING_REJECT
+    MARKETING_REJECT,
+    WITHDRAW
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/WithdrawReason.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/WithdrawReason.java
@@ -1,0 +1,9 @@
+package com.storix.domain.domains.user.domain;
+
+public enum WithdrawReason {
+    LACK_OF_CONTENT,        // 원하는 작품/장르가 부족해서
+    NOT_SUITABLE_COMMUNITY, // 커뮤니티 활동이 맞지 않아서
+    HARD_TO_USE,            // 사용법이 어려워서
+    LOW_USAGE,              // 이용 빈도가 낮아서
+    OTHER                   // 기타 (직접 입력)
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -153,16 +153,18 @@ public class AuthService {
         // 4. 알림 설정 삭제 (재가입 시 새 row 생성됨)
         notificationSettingAdaptor.deleteByUserId(userId);
 
-        // 5. 탈퇴 사유 로그 — OTHER 일 때만 detail 보관, 그 외는 enum 값 자체를 detail 로 보관
-        String detailValue = (reason == WithdrawReason.OTHER)
-                ? (StringUtils.hasText(detail) ? detail.trim() : null)
-                : reason.name();
-        userHistoryAdaptor.save(UserHistory.builder()
-                .userId(userId)
-                .historyType(UserHistoryType.WITHDRAW)
-                .sender(STORIXStatic.UserHistory.SENDER_TEAM_STORIX)
-                .processedAt(LocalDateTime.now())
-                .detail(detailValue)
-                .build());
+        // 5. 탈퇴 사유 로그 — v2 에서만 reason 전달, OTHER 일 때만 detail 보관, 그 외는 enum 값 자체를 detail 로 보관
+        if (reason != null) {
+            String detailValue = (reason == WithdrawReason.OTHER)
+                    ? (StringUtils.hasText(detail) ? detail.trim() : null)
+                    : reason.name();
+            userHistoryAdaptor.save(UserHistory.builder()
+                    .userId(userId)
+                    .historyType(UserHistoryType.WITHDRAW)
+                    .sender(STORIXStatic.UserHistory.SENDER_TEAM_STORIX)
+                    .processedAt(LocalDateTime.now())
+                    .detail(detailValue)
+                    .build());
+        }
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -13,16 +13,23 @@ import com.storix.domain.domains.user.dto.OnboardingPrincipal;
 import com.storix.domain.domains.user.dto.ReaderSignUpData;
 import com.storix.domain.domains.user.dto.ValidAuthDTO;
 import com.storix.domain.domains.user.exception.me.DuplicateUserException;
+import com.storix.common.utils.STORIXStatic;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.domain.domains.user.adaptor.TokenAdaptor;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
+import com.storix.domain.domains.user.adaptor.UserHistoryAdaptor;
 import com.storix.domain.domains.user.domain.OAuthInfo;
 import com.storix.domain.domains.user.domain.OAuthProvider;
 import com.storix.domain.domains.user.domain.User;
+import com.storix.domain.domains.user.domain.UserHistory;
+import com.storix.domain.domains.user.domain.UserHistoryType;
+import com.storix.domain.domains.user.domain.WithdrawReason;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +42,7 @@ public class AuthService {
 
     private final PushDeviceAdaptor pushDeviceAdaptor;
     private final NotificationSettingAdaptor notificationSettingAdaptor;
+    private final UserHistoryAdaptor userHistoryAdaptor;
 
     private final OnboardingWorksHelper onboardingWorksHelper; // -> usecase 리팩토링 필요
     private final GenreScorePublisher genreScorePublisher;
@@ -129,7 +137,7 @@ public class AuthService {
 
     // 유저 회원 탈퇴
     @Transactional
-    public void withDrawUser(Long userId) {
+    public void withDrawUser(Long userId, WithdrawReason reason, String detail) {
         // 1. 유저 soft-delete
         User user = userAdaptor.findUserById(userId);
         user.withdraw();
@@ -144,5 +152,17 @@ public class AuthService {
 
         // 4. 알림 설정 삭제 (재가입 시 새 row 생성됨)
         notificationSettingAdaptor.deleteByUserId(userId);
+
+        // 5. 탈퇴 사유 로그 — OTHER 일 때만 detail 보관, 그 외는 enum 값 자체를 detail 로 보관
+        String detailValue = (reason == WithdrawReason.OTHER)
+                ? (StringUtils.hasText(detail) ? detail.trim() : null)
+                : reason.name();
+        userHistoryAdaptor.save(UserHistory.builder()
+                .userId(userId)
+                .historyType(UserHistoryType.WITHDRAW)
+                .sender(STORIXStatic.UserHistory.SENDER_TEAM_STORIX)
+                .processedAt(LocalDateTime.now())
+                .detail(detailValue)
+                .build());
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -5,7 +5,6 @@ import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
 import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
 import com.storix.domain.domains.notification.adaptor.NotificationSettingAdaptor;
-import com.storix.domain.domains.notification.domain.NotificationSetting;
 import com.storix.domain.domains.onboarding.service.OnboardingWorksHelper;
 import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
 import com.storix.domain.domains.user.dto.CreateReaderUserCommand;
@@ -30,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -137,7 +137,7 @@ public class AuthService {
 
     // 유저 회원 탈퇴
     @Transactional
-    public void withDrawUser(Long userId, WithdrawReason reason, String detail) {
+    public void withDrawUser(Long userId, Set<WithdrawReason> reasons, String detail) {
         // 1. 유저 soft-delete
         User user = userAdaptor.findUserById(userId);
         user.withdraw();
@@ -153,16 +153,22 @@ public class AuthService {
         // 4. 알림 설정 삭제 (재가입 시 새 row 생성됨)
         notificationSettingAdaptor.deleteByUserId(userId);
 
-        // 5. 탈퇴 사유 로그 — v2 에서만 reason 전달, OTHER 일 때만 detail 보관, 그 외는 enum 값 자체를 detail 로 보관
-        if (reason != null) {
-            String detailValue = (reason == WithdrawReason.OTHER)
-                    ? (StringUtils.hasText(detail) ? detail.trim() : null)
-                    : reason.name();
+        // 5. 탈퇴 사유 로그 저장
+        saveWithdrawHistory(userId, reasons, detail);
+    }
+
+    private void saveWithdrawHistory(Long userId, Set<WithdrawReason> reasons, String detail) {
+        String otherDetail = (detail == null) ? null : detail.trim();
+        LocalDateTime processedAt = LocalDateTime.now();
+
+        for (WithdrawReason reason : reasons) {
+            String detailValue = (reason == WithdrawReason.OTHER) ? otherDetail : null;
             userHistoryAdaptor.save(UserHistory.builder()
                     .userId(userId)
                     .historyType(UserHistoryType.WITHDRAW)
-                    .sender(STORIXStatic.UserHistory.SENDER_TEAM_STORIX)
-                    .processedAt(LocalDateTime.now())
+                    .processor(STORIXStatic.UserHistory.PROCESSOR_TEAM_STORIX)
+                    .processedAt(processedAt)
+                    .reason(reason)
                     .detail(detailValue)
                     .build());
         }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 회원탈퇴 v2 API 분리 + 탈퇴 사유 수집
- 5가지 사유 enum (`LACK_OF_CONTENT` / `NOT_SUITABLE_COMMUNITY` / `HARD_TO_USE` / `LOW_USAGE` / `OTHER`)
- `reason=OTHER` 일 때만 `detail` (직접 입력, 200자 이내) 함께 전송
- `user_history` 테이블에 `WITHDRAW` 이력 저장 (사유 · 처리 일시 · 발신자)
  -> enum 값은 그대로 `detail` 컬럼에 보관, `OTHER` 인 경우만 사용자 입력 그대로

### 2. 프로필 조회 응답에 소셜 로그인 방식 (oauthProvider) 추가
별도의 소셜 로그인 조회 API를 개발하지 않고, 기본 프로필 조회 응답 DTO에 추가하였습니다.
- 값: `KAKAO` / `NAVER` / `APPLE`

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #70 

## 🖇️ 기타