### PR TITLE
Fix: 회원탈퇴 이슈 수정

### DIFF
--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
@@ -20,23 +20,23 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     List<String> findActiveFcmTokensByUserId(@Param("userId") Long userId);
 
     // 단일 디바이스 비활성화
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PushDevice d SET d.isActive = false WHERE d.userId = :userId AND d.installationId = :installationId")
     int deactivateByUserIdAndInstallationId(@Param("userId") Long userId,
                                             @Param("installationId") String installationId);
 
     // FCM invalid 토큰 일괄 비활성화
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PushDevice d SET d.isActive = false WHERE d.fcmToken IN :tokens")
     int deactivateByFcmTokens(@Param("tokens") List<String> tokens);
 
     // 유저 탈퇴 시 해당 유저의 모든 활성 디바이스 일괄 비활성화
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PushDevice d SET d.isActive = false WHERE d.userId = :userId AND d.isActive = true")
     int deactivateAllByUserId(@Param("userId") Long userId);
 
     // 발송 성공한 토큰들의 lastSuccessAt 갱신
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PushDevice d SET d.lastSuccessAt = :now WHERE d.fcmToken IN :tokens AND d.isActive = true")
     void markFcmTokensSuccess(@Param("tokens") List<String> tokens, @Param("now") LocalDateTime now);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/TokenAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/TokenAdaptor.java
@@ -6,6 +6,7 @@ import com.storix.domain.domains.user.dto.OnboardingPrincipal;
 import com.storix.domain.domains.user.repository.OnboardingTokenRepository;
 import com.storix.domain.domains.user.repository.RefreshTokenRepository;
 import com.storix.domain.domains.user.exception.auth.InvalidLogoutException;
+import com.storix.domain.domains.user.exception.auth.InvalidWithdrawException;
 import com.storix.domain.domains.user.exception.token.InvalidTokenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,14 @@ public class TokenAdaptor {
         Optional<RefreshToken> refreshTokenInfo = refreshTokenRepository.findById(userId);
         if (refreshTokenInfo.isEmpty()) {
             throw InvalidLogoutException.EXCEPTION;
+        }
+        refreshTokenRepository.deleteById(userId);
+    }
+
+    public void deleteRefreshTokenForWithdrawByUserId(Long userId) {
+        Optional<RefreshToken> refreshTokenInfo = refreshTokenRepository.findById(userId);
+        if (refreshTokenInfo.isEmpty()) {
+            throw InvalidWithdrawException.EXCEPTION;
         }
         refreshTokenRepository.deleteById(userId);
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/exception/auth/InvalidWithdrawException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/exception/auth/InvalidWithdrawException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.user.exception.auth;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class InvalidWithdrawException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new InvalidWithdrawException();
+
+    private InvalidWithdrawException() { super(ErrorCode.INVALID_USER_WITHDRAW); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -143,7 +143,7 @@ public class AuthService {
         user.withdraw();
 
         // 2. 유저 관련 정보 (refresh 토큰, 관심 작품, 서재) 삭제
-        tokenAdaptor.deleteRefreshTokenByUserId(userId);
+        tokenAdaptor.deleteRefreshTokenForWithdrawByUserId(userId);
         favoriteWorksAdaptor.deleteFavoriteWorks(userId);
         libraryAdaptor.deleteLibrary(userId);
 


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
[문제]
회원 탈퇴를 진행하였을 시, user 테이블에 회원탈퇴 상태가 반영되지 않음
이외의 모든 회원탈퇴 관련 메서드는 정상 동작 및 정상 응답

[이슈 원인]
User 엔티티를 영속성 컨텍스트에 올린 후 user.withdraw() 실행으로 필드 변경
-> dirty checking으로 반영 대기 상태
-> 이후 한 Transaction에서 묶인 push device bulk update가 영속성 컨텍스트를 바로 비워서, dirty checking으로 반영 대기 중인 user 엔티티 변경사항이 반영되지 않음

[해결]
push device bulk update 이후 flush


## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #73 

## 🖇️ 기타