### PR TITLE
Feat: [약관] 이용약관 등록 및 동의 이력 관리

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthV2Controller.java
@@ -34,7 +34,7 @@ public class AuthV2Controller {
 
     @Operation(summary = "[v2] 독자 계정 회원가입", description = "유저 정보를 최종적으로 등록하는 api 입니다.   \n" +
             "- 온보딩 토큰을 헤더로 보내주세요.  \n" +
-            "- v1 의 marketingAgree 필드 대신 termsAgree(서비스 이용약관 동의) 필드를 받습니다.  \n" +
+            "- 필수 동의 3가지를 각각 받습니다: serviceTermsAgree(서비스 이용약관), privacyPolicyAgree(개인정보 수집·이용), ageOver14(만 14세 이상). 모두 true 여야 합니다.  \n" +
             "- 마케팅 알림 수신 동의 여부는 가입 후 별도 모달에서 받습니다.")
     @PostMapping("/users/reader/signup")
     public ResponseEntity<CustomResponse<AuthorizationResponse>> readerUserSignup(

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/TermsController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/TermsController.java
@@ -1,0 +1,35 @@
+package com.storix.api.domain.user.controller;
+
+import com.storix.api.domain.user.controller.dto.TermsRegisterRequest;
+import com.storix.api.domain.user.controller.dto.TermsRegisterResponse;
+import com.storix.api.domain.user.usecase.TermsUseCase;
+import com.storix.common.payload.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/terms")
+@RequiredArgsConstructor
+@Tag(name = "약관", description = "약관 관리 API")
+public class TermsController {
+
+    private final TermsUseCase termsUseCase;
+
+    @Operation(summary = "[관리자] 약관 등록", description = "버전별로 약관을 등록합니다.  \n" +
+            "- termsType: 약관 종류(SERVICE/PRIVACY)  \n" +
+            "- 같은 termsType 으로 새 version 을 등록하면, 시행일(effectiveFrom) 기준 가장 최근 버전이 현재 약관으로 사용됩니다.  \n" +
+            "- ADMIN 권한 전용입니다.")
+    @PostMapping
+    public ResponseEntity<CustomResponse<TermsRegisterResponse>> registerTerms(
+            @Valid @RequestBody TermsRegisterRequest req
+    ) {
+        return termsUseCase.registerTerms(req);
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderSignupRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderSignupRequest.java
@@ -30,8 +30,8 @@ public record ReaderSignupRequest(
     Set<Long> favoriteWorksIdList
 
 ) {
-    // [v1] marketingAgree 를 termsAgree 로 매핑
+    // [v1-deprecated]
     public ReaderSignUpData toData() {
-        return new ReaderSignUpData(marketingAgree, nickName, profileDescription, favoriteGenreList, favoriteWorksIdList);
+        return new ReaderSignUpData(null, null, null, nickName, profileDescription, favoriteGenreList, favoriteWorksIdList);
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderSignupRequestV2.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/ReaderSignupRequestV2.java
@@ -10,7 +10,15 @@ public record ReaderSignupRequestV2(
 
     @NotNull(message = "서비스 이용약관 동의는 필수입니다.")
     @AssertTrue(message = "서비스 이용약관 동의는 필수입니다.")
-    Boolean termsAgree,
+    Boolean serviceTermsAgree,
+
+    @NotNull(message = "개인정보 수집·이용 동의는 필수입니다.")
+    @AssertTrue(message = "개인정보 수집·이용 동의는 필수입니다.")
+    Boolean privacyPolicyAgree,
+
+    @NotNull(message = "만 14세 이상 동의는 필수입니다.")
+    @AssertTrue(message = "만 14세 이상만 가입할 수 있습니다.")
+    Boolean ageOver14,
 
     @NotBlank(message = "닉네임은 필수입니다.")
     @Size(min = 2, max = 10, message = "닉네임은 2~10자까지 가능합니다.")
@@ -32,6 +40,14 @@ public record ReaderSignupRequestV2(
 
 ) {
     public ReaderSignUpData toData() {
-        return new ReaderSignUpData(termsAgree, nickName, profileDescription, favoriteGenreList, favoriteWorksIdList);
+        return new ReaderSignUpData(
+                serviceTermsAgree,
+                privacyPolicyAgree,
+                ageOver14,
+                nickName,
+                profileDescription,
+                favoriteGenreList,
+                favoriteWorksIdList
+        );
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/TermsRegisterRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/TermsRegisterRequest.java
@@ -2,39 +2,46 @@ package com.storix.api.domain.user.controller.dto;
 
 import com.storix.domain.domains.user.domain.TermsType;
 import com.storix.domain.domains.user.dto.CreateTermsCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public record TermsRegisterRequest(
 
+        @Schema(description = "약관 종류", example = "SERVICE")
         @NotNull(message = "약관 종류는 필수입니다.")
         TermsType termsType,
 
+        @Schema(description = "약관명", example = "서비스 이용약관")
         @NotBlank(message = "약관명은 필수입니다.")
         @Size(max = 255, message = "약관명은 255자까지 가능합니다.")
         String title,
 
+        @Schema(description = "약관 버전", example = "1.0")
         @NotBlank(message = "약관 버전은 필수입니다.")
         @Size(max = 50, message = "약관 버전은 50자까지 가능합니다.")
         String version,
 
+        @Schema(description = "약관 원문", example = "제1조(목적) 본 약관은 ...")
         @NotBlank(message = "약관 원문은 필수입니다.")
         String content,
 
+        @Schema(description = "필수 약관 여부", example = "true")
         @NotNull(message = "필수 약관 여부는 필수입니다.")
         Boolean isRequired,
 
-        // 고지(공지) 일자 - 선택
-        LocalDateTime announcedAt,
+        @Schema(description = "고지 일자", example = "2026-06-04", format = "date")
+        LocalDate announcedAt,
 
+        @Schema(description = "시행 시작일", example = "2026-06-04", format = "date")
         @NotNull(message = "시행 시작일은 필수입니다.")
-        LocalDateTime effectiveFrom,
+        LocalDate effectiveFrom,
 
-        // 적용 종료일 - 선택(null=무기한)
-        LocalDateTime effectiveTo
+        @Schema(description = "적용 종료일 (null=무기한)", example = "2026-12-31", format = "date")
+        LocalDate effectiveTo
 
 ) {
     public CreateTermsCommand toCommand() {

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/TermsRegisterRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/TermsRegisterRequest.java
@@ -3,6 +3,7 @@ package com.storix.api.domain.user.controller.dto;
 import com.storix.domain.domains.user.domain.TermsType;
 import com.storix.domain.domains.user.dto.CreateTermsCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -34,6 +35,7 @@ public record TermsRegisterRequest(
         Boolean isRequired,
 
         @Schema(description = "고지 일자", example = "2026-06-04", format = "date")
+        @NotNull(message = "고지 일자는 필수입니다.")
         LocalDate announcedAt,
 
         @Schema(description = "시행 시작일", example = "2026-06-04", format = "date")
@@ -44,6 +46,14 @@ public record TermsRegisterRequest(
         LocalDate effectiveTo
 
 ) {
+    // 날짜 범위 검증: 고지일 <= 시행일, 종료일(있다면) >= 시행일
+    @AssertTrue(message = "약관 날짜 범위가 올바르지 않습니다.")
+    private boolean isDateRangeValid() {
+        if (announcedAt == null || effectiveFrom == null) return true;
+        if (announcedAt.isAfter(effectiveFrom)) return false;
+        return effectiveTo == null || !effectiveTo.isBefore(effectiveFrom);
+    }
+
     public CreateTermsCommand toCommand() {
         return new CreateTermsCommand(
                 termsType,

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/TermsRegisterRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/TermsRegisterRequest.java
@@ -1,0 +1,52 @@
+package com.storix.api.domain.user.controller.dto;
+
+import com.storix.domain.domains.user.domain.TermsType;
+import com.storix.domain.domains.user.dto.CreateTermsCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record TermsRegisterRequest(
+
+        @NotNull(message = "약관 종류는 필수입니다.")
+        TermsType termsType,
+
+        @NotBlank(message = "약관명은 필수입니다.")
+        @Size(max = 255, message = "약관명은 255자까지 가능합니다.")
+        String title,
+
+        @NotBlank(message = "약관 버전은 필수입니다.")
+        @Size(max = 50, message = "약관 버전은 50자까지 가능합니다.")
+        String version,
+
+        @NotBlank(message = "약관 원문은 필수입니다.")
+        String content,
+
+        @NotNull(message = "필수 약관 여부는 필수입니다.")
+        Boolean isRequired,
+
+        // 고지(공지) 일자 - 선택
+        LocalDateTime announcedAt,
+
+        @NotNull(message = "시행 시작일은 필수입니다.")
+        LocalDateTime effectiveFrom,
+
+        // 적용 종료일 - 선택(null=무기한)
+        LocalDateTime effectiveTo
+
+) {
+    public CreateTermsCommand toCommand() {
+        return new CreateTermsCommand(
+                termsType,
+                title,
+                version,
+                content,
+                isRequired,
+                announcedAt,
+                effectiveFrom,
+                effectiveTo
+        );
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/TermsRegisterResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/TermsRegisterResponse.java
@@ -1,0 +1,20 @@
+package com.storix.api.domain.user.controller.dto;
+
+import com.storix.domain.domains.user.domain.Terms;
+import com.storix.domain.domains.user.domain.TermsType;
+
+public record TermsRegisterResponse(
+        Long id,
+        TermsType termsType,
+        String title,
+        String version
+) {
+    public static TermsRegisterResponse from(Terms terms) {
+        return new TermsRegisterResponse(
+                terms.getId(),
+                terms.getTermsType(),
+                terms.getTitle(),
+                terms.getVersion()
+        );
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/TermsUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/TermsUseCase.java
@@ -1,0 +1,26 @@
+package com.storix.api.domain.user.usecase;
+
+import com.storix.api.domain.user.controller.dto.TermsRegisterRequest;
+import com.storix.api.domain.user.controller.dto.TermsRegisterResponse;
+import com.storix.common.annotation.UseCase;
+import com.storix.common.code.SuccessCode;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.user.domain.Terms;
+import com.storix.domain.domains.user.service.TermsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@UseCase
+@RequiredArgsConstructor
+public class TermsUseCase {
+
+    private final TermsService termsService;
+
+    // 약관 등록
+    public ResponseEntity<CustomResponse<TermsRegisterResponse>> registerTerms(TermsRegisterRequest req) {
+        Terms saved = termsService.register(req.toCommand());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CustomResponse.onSuccess(SuccessCode.CREATED, TermsRegisterResponse.from(saved)));
+    }
+}

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -162,7 +162,8 @@ public enum ErrorCode {
     PREFERENCE_ALREADY_DONE_TODAY(HttpStatus.BAD_REQUEST, "PREFERENCE_ERROR_001", "취향 탐색 기능은 하루에 한 번만 가능합니다."),
 
     // Terms error
-    DUPLICATE_TERMS_VERSION(HttpStatus.CONFLICT, "TERMS_ERROR_001", "이미 등록된 약관 종류/버전입니다.");
+    DUPLICATE_TERMS_VERSION(HttpStatus.CONFLICT, "TERMS_ERROR_001", "이미 등록된 약관 종류/버전입니다."),
+    CURRENT_TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "TERMS_ERROR_002", "현재 시행 중인 약관이 없습니다. 약관 등록 여부를 확인해주세요.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -159,7 +159,10 @@ public enum ErrorCode {
     SPOILER_SCRIPT_REQUIRED(HttpStatus.BAD_REQUEST, "SPOILER_ERROR_001", "스포일러 설정 시 스포일러 문구를 입력해주세요."),
 
     // Preference error
-    PREFERENCE_ALREADY_DONE_TODAY(HttpStatus.BAD_REQUEST, "PREFERENCE_ERROR_001", "취향 탐색 기능은 하루에 한 번만 가능합니다.");
+    PREFERENCE_ALREADY_DONE_TODAY(HttpStatus.BAD_REQUEST, "PREFERENCE_ERROR_001", "취향 탐색 기능은 하루에 한 번만 가능합니다."),
+
+    // Terms error
+    DUPLICATE_TERMS_VERSION(HttpStatus.CONFLICT, "TERMS_ERROR_001", "이미 등록된 약관 종류/버전입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/TermsAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/TermsAdaptor.java
@@ -3,10 +3,14 @@ package com.storix.domain.domains.user.adaptor;
 import com.storix.domain.domains.user.domain.Terms;
 import com.storix.domain.domains.user.domain.TermsType;
 import com.storix.domain.domains.user.dto.CreateTermsCommand;
+import com.storix.domain.domains.user.exception.terms.CurrentTermsNotFoundException;
 import com.storix.domain.domains.user.exception.terms.DuplicateTermsVersionException;
 import com.storix.domain.domains.user.repository.TermsRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
 
 @Component
 @RequiredArgsConstructor
@@ -22,8 +26,11 @@ public class TermsAdaptor {
         return termsRepository.save(cmd.toEntity());
     }
 
-    // 해당 종류의 최신 버전 약관 조회
+    // 해당 종류의 현재 시행 중인 약관 조회 (없으면 예외)
     public Terms findCurrentByType(TermsType termsType) {
-        return termsRepository.findFirstByTermsTypeOrderByEffectiveFromDesc(termsType).orElseThrow();
+        return termsRepository
+                .findCurrentlyEffective(termsType, LocalDate.now(), PageRequest.of(0, 1))
+                .stream().findFirst()
+                .orElseThrow(() -> CurrentTermsNotFoundException.EXCEPTION);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/TermsAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/TermsAdaptor.java
@@ -1,0 +1,29 @@
+package com.storix.domain.domains.user.adaptor;
+
+import com.storix.domain.domains.user.domain.Terms;
+import com.storix.domain.domains.user.domain.TermsType;
+import com.storix.domain.domains.user.dto.CreateTermsCommand;
+import com.storix.domain.domains.user.exception.terms.DuplicateTermsVersionException;
+import com.storix.domain.domains.user.repository.TermsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TermsAdaptor {
+
+    private final TermsRepository termsRepository;
+
+    // 약관 등록
+    public Terms register(CreateTermsCommand cmd) {
+        if (termsRepository.existsByTermsTypeAndVersion(cmd.termsType(), cmd.version())) {
+            throw DuplicateTermsVersionException.EXCEPTION;
+        }
+        return termsRepository.save(cmd.toEntity());
+    }
+
+    // 해당 종류의 최신 버전 약관 조회
+    public Terms findCurrentByType(TermsType termsType) {
+        return termsRepository.findFirstByTermsTypeOrderByEffectiveFromDesc(termsType).orElseThrow();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserHistoryAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserHistoryAdaptor.java
@@ -1,7 +1,9 @@
 package com.storix.domain.domains.user.adaptor;
 
 import com.storix.domain.domains.user.domain.UserHistory;
+import com.storix.domain.domains.user.domain.UserTermHistory;
 import com.storix.domain.domains.user.repository.UserHistoryRepository;
+import com.storix.domain.domains.user.repository.UserTermHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -10,9 +12,15 @@ import org.springframework.stereotype.Component;
 public class UserHistoryAdaptor {
 
     private final UserHistoryRepository userHistoryRepository;
+    private final UserTermHistoryRepository userTermHistoryRepository;
 
     // 사용자 이력 저장
     public UserHistory save(UserHistory userHistory) {
         return userHistoryRepository.save(userHistory);
+    }
+
+    // 사용자 약관 동의/철회 이력 저장
+    public UserTermHistory saveUserTermHistory(UserTermHistory userTermHistory) {
+        return userTermHistoryRepository.save(userTermHistory);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/Terms.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/Terms.java
@@ -1,0 +1,76 @@
+package com.storix.domain.domains.user.domain;
+
+import com.storix.common.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "terms",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_terms_type_version", columnNames = {"terms_type", "version"})
+        },
+        indexes = {
+                @Index(name = "idx_terms_type_effective", columnList = "terms_type, effective_from")
+        }
+)
+public class Terms extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 약관 종류
+    @Enumerated(EnumType.STRING)
+    @Column(name = "terms_type", nullable = false, length = 50)
+    private TermsType termsType;
+
+    // 약관 명
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    // 약관 버전
+    @Column(name = "version", nullable = false, length = 50)
+    private String version;
+
+    // 약관 원문
+    @Column(name = "content", columnDefinition = "MEDIUMTEXT")
+    private String content;
+
+    // 필수 약관 여부
+    @Column(name = "is_required", nullable = false)
+    private boolean isRequired;
+
+    // 고지 일자
+    @Column(name = "announced_at")
+    private LocalDateTime announcedAt;
+
+    // 시행 시작일
+    @Column(name = "effective_from", nullable = false)
+    private LocalDateTime effectiveFrom;
+
+    // 적용 종료일
+    @Column(name = "effective_to")
+    private LocalDateTime effectiveTo;
+
+    @Builder
+    private Terms(TermsType termsType, String title, String version, String content,
+                  boolean isRequired, LocalDateTime announcedAt,
+                  LocalDateTime effectiveFrom, LocalDateTime effectiveTo) {
+        this.termsType = termsType;
+        this.title = title;
+        this.version = version;
+        this.content = content;
+        this.isRequired = isRequired;
+        this.announcedAt = announcedAt;
+        this.effectiveFrom = effectiveFrom;
+        this.effectiveTo = effectiveTo;
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/Terms.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/Terms.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 
 @Entity
@@ -50,20 +50,20 @@ public class Terms extends BaseTimeEntity {
 
     // 고지 일자
     @Column(name = "announced_at")
-    private LocalDateTime announcedAt;
+    private LocalDate announcedAt;
 
     // 시행 시작일
     @Column(name = "effective_from", nullable = false)
-    private LocalDateTime effectiveFrom;
+    private LocalDate effectiveFrom;
 
     // 적용 종료일
     @Column(name = "effective_to")
-    private LocalDateTime effectiveTo;
+    private LocalDate effectiveTo;
 
     @Builder
     private Terms(TermsType termsType, String title, String version, String content,
-                  boolean isRequired, LocalDateTime announcedAt,
-                  LocalDateTime effectiveFrom, LocalDateTime effectiveTo) {
+                  boolean isRequired, LocalDate announcedAt,
+                  LocalDate effectiveFrom, LocalDate effectiveTo) {
         this.termsType = termsType;
         this.title = title;
         this.version = version;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/TermsType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/TermsType.java
@@ -1,0 +1,14 @@
+package com.storix.domain.domains.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermsType {
+
+    SERVICE("서비스 이용약관"),
+    PRIVACY("개인정보 처리 방침");
+
+    private final String description;
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
@@ -60,9 +60,9 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private int point = 0;
 
-    // 이용약관 동의 여부
-    @Column(name = "terms_agree")
-    private Boolean termsAgree;
+    // 만 14세 이상 동의 여부
+    @Column(name = "age_over_14")
+    private Boolean ageOver14;
 
     @Column(name = "is_adult_verified")
     private Boolean isAdultVerified = false;
@@ -98,8 +98,8 @@ public class User extends BaseTimeEntity {
     protected User() {}
 
     @Builder
-    public User(Boolean termsAgree, OAuthInfo oauthInfo, String nickName, Set<Genre> favoriteGenreList, String profileDescription, Role role) {
-        this.termsAgree = termsAgree;
+    public User(Boolean ageOver14, OAuthInfo oauthInfo, String nickName, Set<Genre> favoriteGenreList, String profileDescription, Role role) {
+        this.ageOver14 = ageOver14;
         this.oauthInfo = oauthInfo;
         this.nickName = nickName;
         this.favoriteGenreList = favoriteGenreList;
@@ -153,7 +153,7 @@ public class User extends BaseTimeEntity {
         profileObjectKey = null;
         nickName = "탈퇴한 유저";
         oauthInfo = oauthInfo.withDrawOauthInfo();
-        termsAgree = null;
+        ageOver14 = null;
         isAdultVerified = null;
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserTermHistory.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserTermHistory.java
@@ -1,0 +1,61 @@
+package com.storix.domain.domains.user.domain;
+
+import com.storix.common.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_term_history",
+        indexes = {
+                @Index(name = "idx_user_term_user", columnList = "user_id"),
+                @Index(name = "idx_user_term_terms", columnList = "terms_id")
+        }
+)
+public class UserTermHistory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    // 동의한 약관 ID
+    @Column(name = "terms_id", nullable = false)
+    private Long termsId;
+
+    // 동의 여부
+    @Column(name = "is_agreed", nullable = false)
+    private boolean isAgreed;
+
+    // 동의 시각
+    @Column(name = "agreed_at")
+    private LocalDateTime agreedAt;
+
+    // 철회 시각
+    @Column(name = "withdrawn_at")
+    private LocalDateTime withdrawnAt;
+
+    @Builder
+    private UserTermHistory(Long userId, Long termsId, boolean isAgreed,
+                            LocalDateTime agreedAt, LocalDateTime withdrawnAt) {
+        this.userId = userId;
+        this.termsId = termsId;
+        this.isAgreed = isAgreed;
+        this.agreedAt = agreedAt;
+        this.withdrawnAt = withdrawnAt;
+    }
+
+    // 동의 철회
+    public void withdraw(LocalDateTime withdrawnAt) {
+        this.isAgreed = false;
+        this.withdrawnAt = withdrawnAt;
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserTermHistory.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserTermHistory.java
@@ -27,9 +27,10 @@ public class UserTermHistory extends BaseTimeEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    // 동의한 약관 ID
-    @Column(name = "terms_id", nullable = false)
-    private Long termsId;
+    // 동의한 약관
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "terms_id", nullable = false, foreignKey = @ForeignKey(name = "fk_user_term_history_terms"))
+    private Terms terms;
 
     // 동의 여부
     @Column(name = "is_agreed", nullable = false)
@@ -44,10 +45,10 @@ public class UserTermHistory extends BaseTimeEntity {
     private LocalDateTime withdrawnAt;
 
     @Builder
-    private UserTermHistory(Long userId, Long termsId, boolean isAgreed,
+    private UserTermHistory(Long userId, Terms terms, boolean isAgreed,
                             LocalDateTime agreedAt, LocalDateTime withdrawnAt) {
         this.userId = userId;
-        this.termsId = termsId;
+        this.terms = terms;
         this.isAgreed = isAgreed;
         this.agreedAt = agreedAt;
         this.withdrawnAt = withdrawnAt;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateDeveloperUserCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateDeveloperUserCommand.java
@@ -21,7 +21,6 @@ public record CreateDeveloperUserCommand(
                 Collections.emptySet() : new LinkedHashSet<>(favoriteGenreList);
 
         return User.builder()
-                .termsAgree(true)
                 .oauthInfo(oauthInfo)
                 .nickName(nickName)
                 .favoriteGenreList(genres)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateReaderUserCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateReaderUserCommand.java
@@ -10,7 +10,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 public record CreateReaderUserCommand(
-        Boolean termsAgree,
+        Boolean ageOver14,
         OAuthProvider provider,
         String oid,
         String nickName,
@@ -23,7 +23,7 @@ public record CreateReaderUserCommand(
                         Collections.emptySet() : new LinkedHashSet<>(favoriteGenreList);
 
         return User.builder()
-                .termsAgree(termsAgree)
+                .ageOver14(ageOver14)
                 .oauthInfo(oauthInfo)
                 .nickName(nickName)
                 .favoriteGenreList(genres)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateTermsCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateTermsCommand.java
@@ -1,0 +1,30 @@
+package com.storix.domain.domains.user.dto;
+
+import com.storix.domain.domains.user.domain.Terms;
+import com.storix.domain.domains.user.domain.TermsType;
+
+import java.time.LocalDateTime;
+
+public record CreateTermsCommand(
+        TermsType termsType,
+        String title,
+        String version,
+        String content,
+        boolean isRequired,
+        LocalDateTime announcedAt,
+        LocalDateTime effectiveFrom,
+        LocalDateTime effectiveTo
+) {
+    public Terms toEntity() {
+        return Terms.builder()
+                .termsType(termsType)
+                .title(title)
+                .version(version)
+                .content(content)
+                .isRequired(isRequired)
+                .announcedAt(announcedAt)
+                .effectiveFrom(effectiveFrom)
+                .effectiveTo(effectiveTo)
+                .build();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateTermsCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateTermsCommand.java
@@ -3,7 +3,7 @@ package com.storix.domain.domains.user.dto;
 import com.storix.domain.domains.user.domain.Terms;
 import com.storix.domain.domains.user.domain.TermsType;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public record CreateTermsCommand(
         TermsType termsType,
@@ -11,9 +11,9 @@ public record CreateTermsCommand(
         String version,
         String content,
         boolean isRequired,
-        LocalDateTime announcedAt,
-        LocalDateTime effectiveFrom,
-        LocalDateTime effectiveTo
+        LocalDate announcedAt,
+        LocalDate effectiveFrom,
+        LocalDate effectiveTo
 ) {
     public Terms toEntity() {
         return Terms.builder()

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ReaderSignUpData.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ReaderSignUpData.java
@@ -4,9 +4,12 @@ import com.storix.domain.domains.works.domain.Genre;
 
 import java.util.Set;
 
-// 회원가입 내부 명령 (v1/v2 API DTO -> 공통 변환 후 AuthService 에 전달)
+// v2: 약관별 동의(서비스 이용약관/개인정보 수집·이용) + 만 14세 이상 동의를 개별로 수신
+// v1(deprecated): 약관/연령 동의 필드 사용 X
 public record ReaderSignUpData(
-        Boolean termsAgree,
+        Boolean serviceTermsAgree,
+        Boolean privacyPolicyAgree,
+        Boolean ageOver14,
         String nickName,
         String profileDescription,
         Set<Genre> favoriteGenreList,

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/exception/terms/CurrentTermsNotFoundException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/exception/terms/CurrentTermsNotFoundException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.user.exception.terms;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class CurrentTermsNotFoundException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new CurrentTermsNotFoundException();
+
+    private CurrentTermsNotFoundException() { super(ErrorCode.CURRENT_TERMS_NOT_FOUND); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/exception/terms/DuplicateTermsVersionException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/exception/terms/DuplicateTermsVersionException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.user.exception.terms;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class DuplicateTermsVersionException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new DuplicateTermsVersionException();
+
+    private DuplicateTermsVersionException() { super(ErrorCode.DUPLICATE_TERMS_VERSION); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/TermsRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/TermsRepository.java
@@ -2,14 +2,27 @@ package com.storix.domain.domains.user.repository;
 
 import com.storix.domain.domains.user.domain.Terms;
 import com.storix.domain.domains.user.domain.TermsType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import java.time.LocalDate;
+import java.util.List;
 
 public interface TermsRepository extends JpaRepository<Terms, Long> {
 
-    // 해당 종류의 최신 버전(시행일 기준) 약관 조회
-    Optional<Terms> findFirstByTermsTypeOrderByEffectiveFromDesc(TermsType termsType);
+    // 해당 종류의 현재 시행 중인 약관(시행일 <= 오늘 <= 종료일(또는 무기한), 시행일 기준 최신) 조회
+    @Query("""
+            SELECT t FROM Terms t
+            WHERE t.termsType = :termsType
+              AND t.effectiveFrom <= :today
+              AND (t.effectiveTo IS NULL OR t.effectiveTo >= :today)
+            ORDER BY t.effectiveFrom DESC
+    """)
+    List<Terms> findCurrentlyEffective(@Param("termsType") TermsType termsType,
+                                       @Param("today") LocalDate today,
+                                       Pageable pageable);
 
     // 같은 종류 + 버전 중복 여부
     boolean existsByTermsTypeAndVersion(TermsType termsType, String version);

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/TermsRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/TermsRepository.java
@@ -1,0 +1,16 @@
+package com.storix.domain.domains.user.repository;
+
+import com.storix.domain.domains.user.domain.Terms;
+import com.storix.domain.domains.user.domain.TermsType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+
+    // 해당 종류의 최신 버전(시행일 기준) 약관 조회
+    Optional<Terms> findFirstByTermsTypeOrderByEffectiveFromDesc(TermsType termsType);
+
+    // 같은 종류 + 버전 중복 여부
+    boolean existsByTermsTypeAndVersion(TermsType termsType, String version);
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserTermHistoryRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserTermHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.storix.domain.domains.user.repository;
+
+import com.storix.domain.domains.user.domain.UserTermHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTermHistoryRepository extends JpaRepository<UserTermHistory, Long> {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -184,7 +184,7 @@ public class AuthService {
         Terms terms = termsAdaptor.findCurrentByType(termsType);
         userHistoryAdaptor.saveUserTermHistory(UserTermHistory.builder()
                 .userId(userId)
-                .termsId(terms.getId())
+                .terms(terms)
                 .isAgreed(true)
                 .agreedAt(LocalDateTime.now())
                 .build());

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -7,6 +7,10 @@ import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
 import com.storix.domain.domains.notification.adaptor.NotificationSettingAdaptor;
 import com.storix.domain.domains.onboarding.service.OnboardingWorksHelper;
 import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
+import com.storix.domain.domains.user.adaptor.TermsAdaptor;
+import com.storix.domain.domains.user.domain.Terms;
+import com.storix.domain.domains.user.domain.TermsType;
+import com.storix.domain.domains.user.domain.UserTermHistory;
 import com.storix.domain.domains.user.dto.CreateReaderUserCommand;
 import com.storix.domain.domains.user.dto.OnboardingPrincipal;
 import com.storix.domain.domains.user.dto.ReaderSignUpData;
@@ -43,6 +47,7 @@ public class AuthService {
     private final PushDeviceAdaptor pushDeviceAdaptor;
     private final NotificationSettingAdaptor notificationSettingAdaptor;
     private final UserHistoryAdaptor userHistoryAdaptor;
+    private final TermsAdaptor termsAdaptor;
 
     private final OnboardingWorksHelper onboardingWorksHelper; // -> usecase 리팩토링 필요
     private final GenreScorePublisher genreScorePublisher;
@@ -73,9 +78,11 @@ public class AuthService {
     @Transactional
     public AuthUserDetails signUpReaderUser(ReaderSignUpData cmd, String jti) {
 
+        // 1. 온보딩 토큰 정보 조회
         OnboardingPrincipal principal = tokenAdaptor.findOnboardingPrincipalByJti(jti);
         OAuthProvider provider = principal.provider(); String oid = principal.oid();
 
+        // 2. 회원 가입 관련 검증
         boolean isUserPresent = userAdaptor.isUserPresentWithProviderAndOid(provider, oid);
         if (isUserPresent) throw DuplicateUserException.EXCEPTION;
 
@@ -85,17 +92,20 @@ public class AuthService {
 
         userAdaptor.checkNicknameDuplicate(cmd.nickName());
 
+        // 3. 회원 가입 정보 DB 저장
         CreateReaderUserCommand m = new CreateReaderUserCommand(
-                cmd.termsAgree(),
+                cmd.ageOver14(),
                 provider,
                 oid,
                 cmd.nickName(),
                 cmd.favoriteGenreList(),
                 cmd.profileDescription()
         );
-
         AuthUserDetails authUserDetails = userAdaptor.saveReaderUser(m);
+
         tokenAdaptor.deleteOnboardingTokenByJti(jti);
+
+        saveSignupTermsAgreements(authUserDetails.getUserId(), cmd);
 
         if (cmd.favoriteWorksIdList() != null && !cmd.favoriteWorksIdList().isEmpty()) {
             favoriteWorksAdaptor.saveFavoriteWorks(authUserDetails.getUserId(), cmd.favoriteWorksIdList());
@@ -104,6 +114,7 @@ public class AuthService {
                     cmd.favoriteWorksIdList(),
                     GenreScoreEventType.ONBOARDING_SELECT);
         }
+
         libraryAdaptor.initLibrary(authUserDetails.getUserId());
 
         // 알림 설정 기본값 생성 (마케팅만 OFF, 나머지 ON)
@@ -157,6 +168,29 @@ public class AuthService {
         saveWithdrawHistory(userId, reasons, detail);
     }
 
+
+    // 회원 가입 시 필수 약관(서비스 이용약관/개인정보 수집·이용) 동의 이력 저장
+    private void saveSignupTermsAgreements(Long userId, ReaderSignUpData cmd) {
+        if (Boolean.TRUE.equals(cmd.serviceTermsAgree())) {
+            recordTermAgreement(userId, TermsType.SERVICE);
+        }
+        if (Boolean.TRUE.equals(cmd.privacyPolicyAgree())) {
+            recordTermAgreement(userId, TermsType.PRIVACY);
+        }
+    }
+
+    // 해당 종류의 현재 약관에 대한 동의 이력 저장
+    private void recordTermAgreement(Long userId, TermsType termsType) {
+        Terms terms = termsAdaptor.findCurrentByType(termsType);
+        userHistoryAdaptor.saveUserTermHistory(UserTermHistory.builder()
+                .userId(userId)
+                .termsId(terms.getId())
+                .isAgreed(true)
+                .agreedAt(LocalDateTime.now())
+                .build());
+    }
+
+    // 회원탈퇴 사유 저장
     private void saveWithdrawHistory(Long userId, Set<WithdrawReason> reasons, String detail) {
         String otherDetail = (detail == null) ? null : detail.trim();
         LocalDateTime processedAt = LocalDateTime.now();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/TermsService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/TermsService.java
@@ -1,0 +1,21 @@
+package com.storix.domain.domains.user.service;
+
+import com.storix.domain.domains.user.adaptor.TermsAdaptor;
+import com.storix.domain.domains.user.domain.Terms;
+import com.storix.domain.domains.user.dto.CreateTermsCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TermsService {
+
+    private final TermsAdaptor termsAdaptor;
+
+    // 약관 등록
+    @Transactional
+    public Terms register(CreateTermsCommand cmd) {
+        return termsAdaptor.register(cmd);
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
@@ -113,6 +113,7 @@ public class SecurityConfig {
                                 // [Auth]
                                 .requestMatchers("/api/v1/auth/oauth/**").permitAll()
                                 .requestMatchers("/api/v1/auth/users/reader/signup").hasRole("ONBOARDING")
+                                .requestMatchers("/api/v2/auth/users/reader/signup").hasRole("ONBOARDING")
                                 .requestMatchers("/api/v1/auth/nickname/valid").permitAll()
                                 .requestMatchers("/api/v1/auth/tokens/refresh").permitAll()
                                 .requestMatchers("/api/v1/auth/developer/signup").permitAll()
@@ -125,6 +126,9 @@ public class SecurityConfig {
 
                                 // [Notification] 테스트 엔드포인트는 ADMIN 만
                                 .requestMatchers("/api/v1/notifications/admin/**").hasRole("ADMIN")
+
+                                // [Terms] 약관 등록/관리는 ADMIN 만
+                                .requestMatchers("/api/v1/terms/**").hasRole("ADMIN")
 
                                 .anyRequest().hasRole("READER")
                 )

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/JwtAuthenticationFilter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/JwtAuthenticationFilter.java
@@ -34,6 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return uri.startsWith("/api/v1/auth/oauth/")
                 || uri.equals("/api/v1/auth/nickname/valid")
                 || uri.equals("/api/v1/auth/users/reader/signup")
+                || uri.equals("/api/v2/auth/users/reader/signup")
                 || uri.equals("/api/v1/auth/tokens/refresh")
                 || uri.equals("/api/v1/auth/developer/signup")
                 || uri.equals("/api/v1/auth/developer/login")

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/OnboardingAuthenticationFilter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/OnboardingAuthenticationFilter.java
@@ -32,7 +32,9 @@ public class OnboardingAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return !("/api/v1/auth/users/reader/signup".equals(request.getRequestURI()));
+        String uri = request.getRequestURI();
+        return !(uri.equals("/api/v1/auth/users/reader/signup")
+                || uri.equals("/api/v2/auth/users/reader/signup"));
     }
 
     @Override


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 이용약관 등록 API 개발
- '서비스 이용약관'과 '개인정보처리방침'을 DB화하여 버전별로 고지일, 시행일, 적용 종료일을 관리합니다.
- 개발자 계정 토큰을 필요로 합니다.
   -> 관리자 페이지에서 사용할 것을 고려하였습니다.

### 2. 이용약관 동의 이력 관리
회원가입 시 1) 서비스 이용약관, 2) 개인정보 수집·이용, 3) 만 14세 이상임을 필수로 동의&확인 받습니다. 
[기존]
- [v1] marketingAgree -> termsAgree 로 한 필드로 저장하고 있었습니다.

[변경 후]
- 1), 2)의 경우는 약관에 해당하므로, `user_terms_history` 테이블에 약관 동의 여부를 따로 저장합니다.
   -> 추후 약관 개정 시 유저 재동의가 필요한 경우, termsId로 트래킹이 가능합니다. 
- 3)은 `user `테이블에서 ageOver14 컬럼을 추가하여 함께 저장합니다. 

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #80 

## 🖇️ 기타
~~ddl 옵션이 update이므로, 
서버 DB User 테이블에서 termsAgree 컬럼 삭제 및 기존 user row에 대하여 ageOver14 컬럼 추가시 기본값 null > true update가 필요합니다.~~
처리완