### PR TITLE
Refactor: [취향 탐색] 리뷰한 작품 제외 및 DTO 수정

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/preference/PreferenceController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/preference/PreferenceController.java
@@ -49,7 +49,7 @@ public class PreferenceController {
         return CustomResponse.onSuccess(SuccessCode.SUCCESS);
     }
 
-    // 결과 페이지 조회 (오늘 진행한 15개)
+    // 결과 페이지 조회 (오늘 진행한 10개)
     @Operation(summary = "취향 분석 결과", description = "취향 분석 결과에 대해 조회합니다.")
     @GetMapping("/results")
     public CustomResponse<ExplorationResultResponseDto> getResults(

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/adaptor/ReviewAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/adaptor/ReviewAdaptor.java
@@ -50,6 +50,10 @@ public class ReviewAdaptor {
         return reviewRepository.findAllWorksIdsByUserId(userId);
     }
 
+    public List<Long> findAllReviewedWorksIdsByUserId(Long userId) {
+        return reviewRepository.findAllReviewedWorksIdsByUserId(userId);
+    }
+
     public List<ReviewedWorksIdAndRatingInfo> findAllReviewInfoByFavoriteWorks(Long userId, List<Long> worksIds) {
         if (worksIds == null || worksIds.isEmpty()) {
             return Collections.emptyList();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/repository/ReviewRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/repository/ReviewRepository.java
@@ -30,6 +30,11 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "WHERE r.libraryUserId = :userId")
     List<ReviewedWorksIdAndRatingInfo> findAllWorksIdsByUserId(@Param("userId") Long userId);
 
+    @Query("SELECT r.worksId " +
+            "FROM Review r " +
+            "WHERE r.libraryUserId = :userId")
+    List<Long> findAllReviewedWorksIdsByUserId(@Param("userId") Long userId);
+
     @Query("SELECT new com.storix.domain.domains.plus.dto.ReviewedWorksIdAndRatingInfo(r.worksId, r.id, r.rating) " +
             "FROM Review r " +
             "WHERE r.libraryUserId = :userId AND r.worksId IN :worksIds")

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationCacheHelper.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationCacheHelper.java
@@ -42,14 +42,14 @@ public class ExplorationCacheHelper {
                     "local q_len = redis.call('llen', KEYS[4]) " +
                     "if q_len > tonumber(ARGV[4]) then return -4 end " +
                     "local count = redis.call('incr', KEYS[2]) " +
-                    "if count > 15 then return -2 end " +
+                    "if count > tonumber(ARGV[5]) then return -2 end " +
                     "redis.call('rpush', KEYS[3], ARGV[1]) " +
                     "redis.call('rpush', KEYS[4], ARGV[1]) " +
                     "if count == 1 then redis.call('expire', KEYS[2], ARGV[2]) end " +
                     "redis.call('expire', KEYS[3], ARGV[3]) " +
                     "return count";
 
-    public Long submitWithLua(Long userId, PendingSwipeDto dto) {
+    public Long submitWithLua(Long userId, PendingSwipeDto dto, int dailyLimit) {
         try {
             String json = objectMapper.writeValueAsString(dto);
             String doneKey = DONE_KEY_PREFIX + userId;
@@ -65,7 +65,8 @@ public class ExplorationCacheHelper {
                     json,
                     "43200",
                     "43200",
-                    String.valueOf(MAX_QUEUE_SIZE)
+                    String.valueOf(MAX_QUEUE_SIZE),
+                    String.valueOf(dailyLimit)
             );
 
         } catch (Exception e) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
@@ -141,7 +141,8 @@ public class ExplorationService implements ExplorationUseCase {
                         w.getOriginalAuthor(),
                         w.getThumbnailUrl(),
                         w.getWorksType(),
-                        w.getGenre()
+                        w.getGenre(),
+                        w.getAvgRating()
                 ))
                 .toList();
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ExplorationService implements ExplorationUseCase {
 
+    public static final int DAILY_EXPLORATION_LIMIT = 10;
+
     private final ExplorationRepository explorationRepository;
     private final LoadWorksPort loadWorksPort;
     private final ExplorationCacheHelper cacheHelper;
@@ -47,7 +49,7 @@ public class ExplorationService implements ExplorationUseCase {
         int sessionCount = explorationRepository.countByUserIdAndCreatedAtAfter(userId, threshold)
                 + pendingIds.size();
 
-        int needed = 10 - sessionCount;
+        int needed = DAILY_EXPLORATION_LIMIT - sessionCount;
         if (needed <= 0) return Collections.emptyList();
 
         return loadWorksPort.findRandomWorksExcluding(new ArrayList<>(allHistoryIds), needed)
@@ -72,7 +74,7 @@ public class ExplorationService implements ExplorationUseCase {
                 .isLiked(request.isLiked())
                 .build();
 
-        Long result = cacheHelper.submitWithLua(userId, pendingDto);
+        Long result = cacheHelper.submitWithLua(userId, pendingDto, DAILY_EXPLORATION_LIMIT);
 
         if (result == -1 || result == -2) {
             cacheHelper.markAsParticipatedToday(userId);
@@ -87,7 +89,7 @@ public class ExplorationService implements ExplorationUseCase {
             throw new STORIXCodeException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        if (result == 15) {
+        if (result == DAILY_EXPLORATION_LIMIT) {
             cacheHelper.markAsParticipatedToday(userId);
             cacheHelper.deleteChartCache(userId);
         }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationService.java
@@ -3,6 +3,7 @@ package com.storix.domain.domains.preference.service;
 import com.storix.common.annotation.UseCase;
 import com.storix.common.code.ErrorCode;
 import com.storix.common.exception.STORIXCodeException;
+import com.storix.domain.domains.plus.adaptor.ReviewAdaptor;
 import com.storix.domain.domains.preference.application.ExplorationUseCase;
 import com.storix.domain.domains.preference.dto.*;
 import com.storix.domain.domains.favorite.adaptor.FavoriteWorksAdaptor;
@@ -28,6 +29,7 @@ public class ExplorationService implements ExplorationUseCase {
     private final LoadWorksPort loadWorksPort;
     private final ExplorationCacheHelper cacheHelper;
     private final FavoriteWorksAdaptor favoriteWorksAdaptor;
+    private final ReviewAdaptor reviewAdaptor;
 
     @Override
     @Transactional(readOnly = true)
@@ -41,10 +43,12 @@ public class ExplorationService implements ExplorationUseCase {
         List<Long> dbHistoryIds = explorationRepository.findRespondedWorksIdsByUserId(userId);
         Set<Long> pendingIds = cacheHelper.getPendingWorksIds(userId);
         List<Long> favoriteWorksIds = favoriteWorksAdaptor.findAllFavoriteWorksIdsByUserId(userId);
+        List<Long> reviewedWorksIds = reviewAdaptor.findAllReviewedWorksIdsByUserId(userId);
 
         Set<Long> allHistoryIds = new HashSet<>(dbHistoryIds);
         allHistoryIds.addAll(pendingIds);
         allHistoryIds.addAll(favoriteWorksIds);
+        allHistoryIds.addAll(reviewedWorksIds);
 
         int sessionCount = explorationRepository.countByUserIdAndCreatedAtAfter(userId, threshold)
                 + pendingIds.size();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/dto/LibraryWorksInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/dto/LibraryWorksInfo.java
@@ -12,6 +12,7 @@ public record LibraryWorksInfo(
         String originalAuthor,
         String thumbnailUrl,
         WorksType worksType,
-        Genre genre
+        Genre genre,
+        Double rating
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/repository/WorksRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/repository/WorksRepository.java
@@ -89,12 +89,12 @@ public interface WorksRepository extends JpaRepository<Works, Long>, WorksReposi
     );
 
     // 서재 관련 작품 정보 조회
-    @Query("SELECT new com.storix.domain.domains.works.dto.LibraryWorksInfo(w.id, w.worksName, w.author, w.illustrator, w.originalAuthor, w.thumbnailUrl, w.worksType, w.genre) " +
+    @Query("SELECT new com.storix.domain.domains.works.dto.LibraryWorksInfo(w.id, w.worksName, w.author, w.illustrator, w.originalAuthor, w.thumbnailUrl, w.worksType, w.genre, w.avgRating) " +
             "FROM Works w " +
             "WHERE w.id IN :worksIds")
     List<LibraryWorksInfo> findLibraryWorksInfoByIds(@Param("worksIds") List<Long> worksIds);
 
-    @Query("SELECT new com.storix.domain.domains.works.dto.LibraryWorksInfo(w.id, w.worksName, w.author, w.illustrator, w.originalAuthor, w.thumbnailUrl, w.worksType, w.genre) " +
+    @Query("SELECT new com.storix.domain.domains.works.dto.LibraryWorksInfo(w.id, w.worksName, w.author, w.illustrator, w.originalAuthor, w.thumbnailUrl, w.worksType, w.genre, w.avgRating) " +
             "FROM Works w " +
             "WHERE w.id IN :worksIds " +
             "AND w.worksName LIKE %:keyword% ")


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] 정책상 10개의 취향 탐색이 가능하므로 해당 수치를 통일하여 관리할 수 있도록 정적 변수로 분리하였습니다.
> - [x] 유저가 리뷰를 남긴 작품은 취향 분석 대상에서 배제하도록 구현하였습니다.
> - [x] 취향 분석 결과 반환시 작품 평점인 `rating`을 추가 반환하도록 DTO를 수정하였습니다.
> - [x] DTO 수정에 따라 `LibraryWorkInfo`를 projection에 사용하는 repository 코드도 수정하였습니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
close #85 

## 🖇️ 기타