### PR TITLE
Feat: [프로필] 레벨 삭제 및 장르 기반 칭호 기능 추가

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/profile/controller/ProfileController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/profile/controller/ProfileController.java
@@ -37,7 +37,7 @@ public class ProfileController {
     private final ProfileFavoriteUseCase profileFavoriteUseCase;
     private final ProfileActivityUseCase profileActivityUseCase;
 
-    @Operation(summary = "기본 프로필 조회", description = "기본 프로필을 조회하는 api 입니다.")
+    @Operation(summary = "기본 프로필 조회", description = "기본 프로필을 조회하는 api 입니다.", deprecated = true)
     @GetMapping("/me")
     public ResponseEntity<CustomResponse<UserInfo>> getProfile(
             @AuthenticationPrincipal AuthUserDetails authUserDetails

--- a/STORIX-Api/src/main/java/com/storix/api/domain/profile/controller/ProfileV2Controller.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/profile/controller/ProfileV2Controller.java
@@ -1,0 +1,33 @@
+package com.storix.api.domain.profile.controller;
+
+import com.storix.api.domain.profile.usecase.ProfileUseCase;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.profile.dto.UserInfoV2;
+import com.storix.domain.domains.user.adaptor.AuthUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/profile")
+@RequiredArgsConstructor
+@Tag(name = "프로필", description = "프로필 관련 API")
+public class ProfileV2Controller {
+
+    private final ProfileUseCase profileUseCase;
+
+    @Operation(summary = "기본 프로필 조회 V2",
+            description = "칭호와 다음 칭호까지의 진행도(남은 점수/진행률)를 포함한 프로필을 조회하는 api 입니다.")
+    @GetMapping("/me")
+    public ResponseEntity<CustomResponse<UserInfoV2>> getProfileV2(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails
+    ) {
+        return ResponseEntity.ok()
+                .body(profileUseCase.getUserProfileV2(authUserDetails));
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/profile/usecase/ProfileUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/profile/usecase/ProfileUseCase.java
@@ -4,6 +4,7 @@ import com.storix.common.annotation.UseCase;
 import com.storix.domain.domains.image.service.S3CacheHelper;
 import com.storix.domain.domains.profile.service.ProfileService;
 import com.storix.domain.domains.profile.dto.UserInfo;
+import com.storix.domain.domains.profile.dto.UserInfoV2;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.common.payload.CustomResponse;
 import com.storix.common.code.SuccessCode;
@@ -21,6 +22,13 @@ public class ProfileUseCase {
     public CustomResponse<UserInfo> getUserProfile(AuthUserDetails authUserDetails) {
         Long userId = authUserDetails.getUserId();
         UserInfo readerProfileInfo = profileService.getReaderProfileInfo(userId);
+        return CustomResponse.onSuccess(SuccessCode.PROFILE_LOAD_SUCCESS, readerProfileInfo);
+    }
+
+    // 기본 프로필 조회 V2 (칭호/진행도 포함)
+    public CustomResponse<UserInfoV2> getUserProfileV2(AuthUserDetails authUserDetails) {
+        Long userId = authUserDetails.getUserId();
+        UserInfoV2 readerProfileInfo = profileService.getReaderProfileInfoV2(userId);
         return CustomResponse.onSuccess(SuccessCode.PROFILE_LOAD_SUCCESS, readerProfileInfo);
     }
 

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
@@ -5,6 +5,9 @@ import com.storix.domain.domains.genrescore.service.GenreScoreAggregationService
 import com.storix.domain.domains.user.service.UserTitleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -23,9 +26,24 @@ public class GenreScoreAggregationScheduler {
     private final GenreScoreAggregationService aggregationService;
     private final UserTitleService userTitleService;
 
+    @Value("${storix.title.backfill-on-startup:false}")
+    private boolean backfillTitleOnStartup;
 
-    // 매 시간 정각, 미처리 로그 청크 단위로 집계
-    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+    // 기동 시 미부여 칭호 보정
+    @EventListener(ApplicationReadyEvent.class)
+    public void assignTitlesOnStartup() {
+        if (!backfillTitleOnStartup) return;
+
+        try {
+            int assigned = userTitleService.assignMissingTitles();
+            log.info(">>> [UserTitle] startup backfill users={}", assigned);
+        } catch (Exception e) {
+            log.warn(">>> [UserTitle] startup backfill failed", e);
+        }
+    }
+
+    // 5분마다 미처리 로그 청크 단위로 집계
+    @Scheduled(cron = "0 */5 * * * *", zone = "Asia/Seoul")
     public void run() {
         long started = System.currentTimeMillis();
         Set<Long> touchedUsers = new HashSet<>();

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
@@ -2,6 +2,7 @@ package com.storix.batch.scheduler;
 
 import com.storix.domain.domains.genrescore.service.GenreScoreAggregationService;
 import com.storix.domain.domains.genrescore.service.GenreScoreAggregationService.ChunkResult;
+import com.storix.domain.domains.user.service.UserTitleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -20,6 +21,7 @@ public class GenreScoreAggregationScheduler {
     private static final int MAX_ITERATIONS = 10_000;
 
     private final GenreScoreAggregationService aggregationService;
+    private final UserTitleService userTitleService;
 
 
     // 매 시간 정각, 미처리 로그 청크 단위로 집계
@@ -44,6 +46,13 @@ public class GenreScoreAggregationScheduler {
 
         if (iter >= MAX_ITERATIONS) {
             log.warn(">>> [GenreScoreBatch] MAX_ITERATIONS({}) 도달 — 다음 실행 시 잔여분 처리", MAX_ITERATIONS);
+        }
+
+        // 집계로 점수가 변동된 유저의 칭호 일괄 갱신 (단일 트랜잭션 + JDBC 배치)
+        try {
+            userTitleService.assignTitles(touchedUsers);
+        } catch (Exception e) {
+            log.warn(">>> [GenreScoreBatch] 칭호 일괄 갱신 실패 (users={})", touchedUsers.size(), e);
         }
 
         int oldDeleted = aggregationService.cleanupOldProcessed();

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/GenreScoreAggregationScheduler.java
@@ -67,10 +67,12 @@ public class GenreScoreAggregationScheduler {
         }
 
         // 집계로 점수가 변동된 유저의 칭호 일괄 갱신 (단일 트랜잭션 + JDBC 배치)
+        // 실패해도 멱등 — 다음 재집계/기동 backfill 로 보정. 복구용으로 실패 userId 만 남긴다.
         try {
             userTitleService.assignTitles(touchedUsers);
         } catch (Exception e) {
-            log.warn(">>> [GenreScoreBatch] 칭호 일괄 갱신 실패 (users={})", touchedUsers.size(), e);
+            log.error(">>> [GenreScoreBatch] 칭호 일괄 갱신 실패 (count={}, userIds={})",
+                    touchedUsers.size(), touchedUsers, e);
         }
 
         int oldDeleted = aggregationService.cleanupOldProcessed();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/adaptor/GenreScoreAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/adaptor/GenreScoreAdaptor.java
@@ -2,6 +2,7 @@ package com.storix.domain.domains.genrescore.adaptor;
 
 import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
 import com.storix.domain.domains.genrescore.domain.UserGenreScoreLog;
+import com.storix.domain.domains.genrescore.dto.RecentGenreScore;
 import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
 import com.storix.domain.domains.genrescore.repository.UserGenreRawScoreRepository;
 import com.storix.domain.domains.genrescore.repository.UserGenreScoreLogRepository;
@@ -28,15 +29,22 @@ public class GenreScoreAdaptor {
         return rawScoreRepository.findAllByIdUserId(userId);
     }
 
+    // 여러 유저의 장르별 raw_score 조회
+    public List<UserGenreRawScore> findRawScoresByUserIds(Collection<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) return List.of();
+        return rawScoreRepository.findAllByIdUserIdIn(userIds);
+    }
+
     // 미처리 로그 청크 조회
     public List<UnprocessedLogRow> findUnprocessedLogChunk(Pageable pageable) {
         return logRepository.findUnprocessedChunk(pageable);
     }
 
-    // 동점처리용 최근 점수 상위 장르 조회
-    public List<Genre> findTopGenresByRecentScore(Long userId, Collection<Genre> genres,
-                                                  LocalDateTime since, Pageable pageable) {
-        return logRepository.findTopGenresByRecentScore(userId, genres, since, pageable);
+    // 동점처리용 최근 점수 조회
+    public List<RecentGenreScore> findRecentScoresByGenres(Long userId, Collection<Genre> genres,
+                                                           LocalDateTime since) {
+        if (genres == null || genres.isEmpty()) return List.of();
+        return logRepository.findRecentScoresByGenres(userId, genres, since);
     }
 
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/adaptor/GenreScoreAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/adaptor/GenreScoreAdaptor.java
@@ -1,0 +1,68 @@
+package com.storix.domain.domains.genrescore.adaptor;
+
+import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
+import com.storix.domain.domains.genrescore.domain.UserGenreScoreLog;
+import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
+import com.storix.domain.domains.genrescore.repository.UserGenreRawScoreRepository;
+import com.storix.domain.domains.genrescore.repository.UserGenreScoreLogRepository;
+import com.storix.domain.domains.works.domain.Genre;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+// 장르 점수(raw_score / score_log) 데이터 접근 어댑터
+@Component
+@RequiredArgsConstructor
+public class GenreScoreAdaptor {
+
+    private final UserGenreRawScoreRepository rawScoreRepository;
+    private final UserGenreScoreLogRepository logRepository;
+
+    /** 조회 작업 관련 메서드 */
+    // 유저의 장르별 raw_score 전체 조회
+    public List<UserGenreRawScore> findRawScoresByUserId(Long userId) {
+        return rawScoreRepository.findAllByIdUserId(userId);
+    }
+
+    // 미처리 로그 청크 조회
+    public List<UnprocessedLogRow> findUnprocessedLogChunk(Pageable pageable) {
+        return logRepository.findUnprocessedChunk(pageable);
+    }
+
+    // 동점처리용 최근 점수 상위 장르 조회
+    public List<Genre> findTopGenresByRecentScore(Long userId, Collection<Genre> genres,
+                                                  LocalDateTime since, Pageable pageable) {
+        return logRepository.findTopGenresByRecentScore(userId, genres, since, pageable);
+    }
+
+
+    /** 쓰기 작업 관련 메서드 */
+    // (user, genre) raw_score 누적 UPSERT
+    public void addRawScore(Long userId, Genre genre, long delta) {
+        rawScoreRepository.upsertAdd(userId, genre, delta);
+    }
+
+    // raw_score 전체 삭제 (주기 초기화)
+    public void deleteAllRawScores() {
+        rawScoreRepository.deleteAllInBatch();
+    }
+
+    // 점수 로그 1건 저장
+    public UserGenreScoreLog saveLog(UserGenreScoreLog log) {
+        return logRepository.save(log);
+    }
+
+    // 미처리 로그를 처리 완료로 일괄 갱신
+    public int markLogProcessedUntil(Long maxId, LocalDateTime now) {
+        return logRepository.markProcessedUntil(maxId, now);
+    }
+
+    // 보존기간 지난 처리 로그 삭제
+    public int deleteProcessedLogBefore(LocalDateTime threshold) {
+        return logRepository.deleteProcessedBefore(threshold);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/adaptor/GenreScoreAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/adaptor/GenreScoreAdaptor.java
@@ -1,6 +1,7 @@
 package com.storix.domain.domains.genrescore.adaptor;
 
 import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
+import com.storix.domain.domains.genrescore.domain.UserGenreRawScoreId;
 import com.storix.domain.domains.genrescore.domain.UserGenreScoreLog;
 import com.storix.domain.domains.genrescore.dto.RecentGenreScore;
 import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
@@ -29,6 +30,13 @@ public class GenreScoreAdaptor {
         return rawScoreRepository.findAllByIdUserId(userId);
     }
 
+    // 유저의 특정 장르 raw_score 조회
+    public long findRawScore(Long userId, Genre genre) {
+        return rawScoreRepository.findById(UserGenreRawScoreId.of(userId, genre))
+                .map(UserGenreRawScore::getRawScore)
+                .orElse(0L);
+    }
+
     // 여러 유저의 장르별 raw_score 조회
     public List<UserGenreRawScore> findRawScoresByUserIds(Collection<Long> userIds) {
         if (userIds == null || userIds.isEmpty()) return List.of();
@@ -45,6 +53,13 @@ public class GenreScoreAdaptor {
                                                            LocalDateTime since) {
         if (genres == null || genres.isEmpty()) return List.of();
         return logRepository.findRecentScoresByGenres(userId, genres, since);
+    }
+
+    // 여러 유저의 동점처리용 최근 점수 조회
+    public List<RecentGenreScore> findRecentScoresByUsersAndGenres(Collection<Long> userIds, Collection<Genre> genres,
+                                                                   LocalDateTime since) {
+        if (userIds == null || userIds.isEmpty() || genres == null || genres.isEmpty()) return List.of();
+        return logRepository.findRecentScoresByUsersAndGenres(userIds, genres, since);
     }
 
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreScoreLog.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/domain/UserGenreScoreLog.java
@@ -18,7 +18,8 @@ import java.time.LocalDateTime;
 @Table(name = "user_genre_score_log",
         indexes = {
                 @Index(name = "idx_unprocessed", columnList = "processed_at, created_at"),
-                @Index(name = "idx_user_event", columnList = "user_id, event_type, works_id")
+                @Index(name = "idx_user_event", columnList = "user_id, event_type, works_id"),
+                @Index(name = "idx_user_genre_created", columnList = "user_id, genre, created_at")
         }
 )
 public class UserGenreScoreLog extends BaseTimeEntity {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/dto/RecentGenreScore.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/dto/RecentGenreScore.java
@@ -5,6 +5,7 @@ import com.storix.domain.domains.works.domain.Genre;
 import java.time.LocalDateTime;
 
 public record RecentGenreScore(
+        Long userId,
         Genre genre,
         Long score,
         LocalDateTime latestAt

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/dto/RecentGenreScore.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/dto/RecentGenreScore.java
@@ -1,0 +1,12 @@
+package com.storix.domain.domains.genrescore.dto;
+
+import com.storix.domain.domains.works.domain.Genre;
+
+import java.time.LocalDateTime;
+
+public record RecentGenreScore(
+        Genre genre,
+        Long score,
+        LocalDateTime latestAt
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/dto/TopGenreInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/dto/TopGenreInfo.java
@@ -1,0 +1,9 @@
+package com.storix.domain.domains.genrescore.dto;
+
+import com.storix.domain.domains.works.domain.Genre;
+
+public record TopGenreInfo(
+        Genre genre,
+        long score
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/listener/GenreScoreLogListener.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/listener/GenreScoreLogListener.java
@@ -1,8 +1,8 @@
 package com.storix.domain.domains.genrescore.listener;
 
+import com.storix.domain.domains.genrescore.adaptor.GenreScoreAdaptor;
 import com.storix.domain.domains.genrescore.domain.UserGenreScoreLog;
 import com.storix.domain.domains.genrescore.event.GenreScoreEvent;
-import com.storix.domain.domains.genrescore.repository.UserGenreScoreLogRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -16,7 +16,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class GenreScoreLogListener {
 
-    private final UserGenreScoreLogRepository logRepository;
+    private final GenreScoreAdaptor genreScoreAdaptor;
 
     // 트랜잭션 커밋 후 반영
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -28,7 +28,7 @@ public class GenreScoreLogListener {
         }
 
         try {
-            logRepository.save(UserGenreScoreLog.from(event));
+            genreScoreAdaptor.saveLog(UserGenreScoreLog.from(event));
         } catch (Exception e) {
             log.error(">>> [GenreScore] log persist failed for event={}, cause={}", event, e.getMessage());
         }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreRawScoreRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreRawScoreRepository.java
@@ -8,11 +8,14 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface UserGenreRawScoreRepository extends JpaRepository<UserGenreRawScore, UserGenreRawScoreId> {
 
     List<UserGenreRawScore> findAllByIdUserId(Long userId);
+
+    List<UserGenreRawScore> findAllByIdUserIdIn(Collection<Long> userIds);
 
     @Modifying
     @Query(value = """

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreScoreLogRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreScoreLogRepository.java
@@ -1,6 +1,7 @@
 package com.storix.domain.domains.genrescore.repository;
 
 import com.storix.domain.domains.genrescore.domain.UserGenreScoreLog;
+import com.storix.domain.domains.genrescore.dto.RecentGenreScore;
 import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
 import com.storix.domain.domains.works.domain.Genre;
 import org.springframework.data.domain.Pageable;
@@ -24,20 +25,22 @@ public interface UserGenreScoreLogRepository extends JpaRepository<UserGenreScor
     """)
     List<UnprocessedLogRow> findUnprocessedChunk(Pageable pageable);
 
-    // 동점 대표 장르 타이브레이크: 최근 N일 점수 합 -> 최신 획득 시각 순으로 상위 장르 (Pageable 로 1건만 조회)
+    // 동점 대표 장르 타이브레이크용 최근 N일 점수 합/최신 획득 시각 조회
     @Query("""
-            SELECT l.genre
+            SELECT new com.storix.domain.domains.genrescore.dto.RecentGenreScore(
+                l.genre,
+                SUM(l.weight),
+                MAX(l.createdAt)
+            )
             FROM UserGenreScoreLog l
             WHERE l.userId = :userId
               AND l.genre IN :genres
               AND l.createdAt >= :since
             GROUP BY l.genre
-            ORDER BY SUM(l.weight) DESC, MAX(l.createdAt) DESC, l.genre ASC
     """)
-    List<Genre> findTopGenresByRecentScore(@Param("userId") Long userId,
-                                           @Param("genres") Collection<Genre> genres,
-                                           @Param("since") LocalDateTime since,
-                                           Pageable pageable);
+    List<RecentGenreScore> findRecentScoresByGenres(@Param("userId") Long userId,
+                                                    @Param("genres") Collection<Genre> genres,
+                                                    @Param("since") LocalDateTime since);
 
     // 미처리 로그 -> 처리 로그 (벌크 업데이트)
     @Modifying

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreScoreLogRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreScoreLogRepository.java
@@ -2,6 +2,7 @@ package com.storix.domain.domains.genrescore.repository;
 
 import com.storix.domain.domains.genrescore.domain.UserGenreScoreLog;
 import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
+import com.storix.domain.domains.works.domain.Genre;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 
 public interface UserGenreScoreLogRepository extends JpaRepository<UserGenreScoreLog, Long> {
@@ -21,6 +23,21 @@ public interface UserGenreScoreLogRepository extends JpaRepository<UserGenreScor
             ORDER BY l.id ASC
     """)
     List<UnprocessedLogRow> findUnprocessedChunk(Pageable pageable);
+
+    // 동점 대표 장르 타이브레이크: 최근 N일 점수 합 -> 최신 획득 시각 순으로 상위 장르 (Pageable 로 1건만 조회)
+    @Query("""
+            SELECT l.genre
+            FROM UserGenreScoreLog l
+            WHERE l.userId = :userId
+              AND l.genre IN :genres
+              AND l.createdAt >= :since
+            GROUP BY l.genre
+            ORDER BY SUM(l.weight) DESC, MAX(l.createdAt) DESC, l.genre ASC
+    """)
+    List<Genre> findTopGenresByRecentScore(@Param("userId") Long userId,
+                                           @Param("genres") Collection<Genre> genres,
+                                           @Param("since") LocalDateTime since,
+                                           Pageable pageable);
 
     // 미처리 로그 -> 처리 로그 (벌크 업데이트)
     @Modifying

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreScoreLogRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/repository/UserGenreScoreLogRepository.java
@@ -28,6 +28,7 @@ public interface UserGenreScoreLogRepository extends JpaRepository<UserGenreScor
     // 동점 대표 장르 타이브레이크용 최근 N일 점수 합/최신 획득 시각 조회
     @Query("""
             SELECT new com.storix.domain.domains.genrescore.dto.RecentGenreScore(
+                l.userId,
                 l.genre,
                 SUM(l.weight),
                 MAX(l.createdAt)
@@ -41,6 +42,24 @@ public interface UserGenreScoreLogRepository extends JpaRepository<UserGenreScor
     List<RecentGenreScore> findRecentScoresByGenres(@Param("userId") Long userId,
                                                     @Param("genres") Collection<Genre> genres,
                                                     @Param("since") LocalDateTime since);
+
+    // 여러 유저의 동점 대표 장르 타이브레이크용 최근 점수 조회
+    @Query("""
+            SELECT new com.storix.domain.domains.genrescore.dto.RecentGenreScore(
+                l.userId,
+                l.genre,
+                SUM(l.weight),
+                MAX(l.createdAt)
+            )
+            FROM UserGenreScoreLog l
+            WHERE l.userId IN :userIds
+              AND l.genre IN :genres
+              AND l.createdAt >= :since
+            GROUP BY l.userId, l.genre
+    """)
+    List<RecentGenreScore> findRecentScoresByUsersAndGenres(@Param("userIds") Collection<Long> userIds,
+                                                            @Param("genres") Collection<Genre> genres,
+                                                            @Param("since") LocalDateTime since);
 
     // 미처리 로그 -> 처리 로그 (벌크 업데이트)
     @Modifying

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreAggregationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreAggregationService.java
@@ -2,6 +2,7 @@ package com.storix.domain.domains.genrescore.service;
 
 import com.storix.domain.domains.genrescore.adaptor.GenreScoreAdaptor;
 import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
+import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import com.storix.domain.domains.works.domain.Genre;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -24,6 +25,7 @@ public class GenreScoreAggregationService {
     public static final int LOG_RETENTION_DAYS = 30;
 
     private final GenreScoreAdaptor genreScoreAdaptor;
+    private final UserAdaptor userAdaptor;
 
     // 미처리 로그를 청크 단위로 처리
     @Transactional
@@ -62,6 +64,7 @@ public class GenreScoreAggregationService {
     @Transactional
     public void resetAllRawScores() {
         genreScoreAdaptor.deleteAllRawScores();
+        userAdaptor.clearAllTitles();
     }
 
     public record ChunkResult(int processedLogs, int groups, Set<Long> users) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreAggregationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreAggregationService.java
@@ -1,8 +1,7 @@
 package com.storix.domain.domains.genrescore.service;
 
+import com.storix.domain.domains.genrescore.adaptor.GenreScoreAdaptor;
 import com.storix.domain.domains.genrescore.dto.UnprocessedLogRow;
-import com.storix.domain.domains.genrescore.repository.UserGenreRawScoreRepository;
-import com.storix.domain.domains.genrescore.repository.UserGenreScoreLogRepository;
 import com.storix.domain.domains.works.domain.Genre;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -24,14 +23,13 @@ public class GenreScoreAggregationService {
     public static final int DEFAULT_CHUNK_SIZE = 1000;
     public static final int LOG_RETENTION_DAYS = 30;
 
-    private final UserGenreScoreLogRepository logRepository;
-    private final UserGenreRawScoreRepository rawScoreRepository;
+    private final GenreScoreAdaptor genreScoreAdaptor;
 
     // 미처리 로그를 청크 단위로 처리
     @Transactional
     public ChunkResult processChunk(int chunkSize) {
         // 1. 미처리 로그 조회
-        List<UnprocessedLogRow> rows = logRepository.findUnprocessedChunk(PageRequest.of(0, chunkSize));
+        List<UnprocessedLogRow> rows = genreScoreAdaptor.findUnprocessedLogChunk(PageRequest.of(0, chunkSize));
         if (rows.isEmpty()) return ChunkResult.empty();
 
         // 2. (user, genre)별 가중치 합산
@@ -46,10 +44,10 @@ public class GenreScoreAggregationService {
         }
 
         // 3. raw_score 테이블 UPSERT
-        sums.forEach((key, sum) -> rawScoreRepository.upsertAdd(key.userId(), key.genre(), sum));
+        sums.forEach((key, sum) -> genreScoreAdaptor.addRawScore(key.userId(), key.genre(), sum));
 
         // 4. 로그 처리
-        logRepository.markProcessedUntil(maxId, LocalDateTime.now());
+        genreScoreAdaptor.markLogProcessedUntil(maxId, LocalDateTime.now());
 
         return new ChunkResult(rows.size(), sums.size(), users);
     }
@@ -57,13 +55,13 @@ public class GenreScoreAggregationService {
     // 처리된 로그 삭제
     @Transactional
     public int cleanupOldProcessed() {
-        return logRepository.deleteProcessedBefore(LocalDateTime.now().minusDays(LOG_RETENTION_DAYS));
+        return genreScoreAdaptor.deleteProcessedLogBefore(LocalDateTime.now().minusDays(LOG_RETENTION_DAYS));
     }
 
     // 주기별 raw_score 테이블 전체 초기화
     @Transactional
     public void resetAllRawScores() {
-        rawScoreRepository.deleteAllInBatch();
+        genreScoreAdaptor.deleteAllRawScores();
     }
 
     public record ChunkResult(int processedLogs, int groups, Set<Long> users) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/GenreScoreQueryService.java
@@ -1,7 +1,7 @@
 package com.storix.domain.domains.genrescore.service;
 
+import com.storix.domain.domains.genrescore.adaptor.GenreScoreAdaptor;
 import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
-import com.storix.domain.domains.genrescore.repository.UserGenreRawScoreRepository;
 import com.storix.domain.domains.preference.dto.GenreScoreInfo;
 import com.storix.domain.domains.works.domain.Genre;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +27,11 @@ public class GenreScoreQueryService {
             Genre.SENTIMENTAL
     );
 
-    private final UserGenreRawScoreRepository rawScoreRepository;
+    private final GenreScoreAdaptor genreScoreAdaptor;
 
     // 장르별 raw_score 반환
     public List<GenreScoreInfo> getRawScores(Long userId) {
-        List<UserGenreRawScore> scores = rawScoreRepository.findAllByIdUserId(userId);
+        List<UserGenreRawScore> scores = genreScoreAdaptor.findRawScoresByUserId(userId);
 
         Map<Genre, Long> rawByGenre = scores.stream()
                 .collect(Collectors.toMap(UserGenreRawScore::getGenre, UserGenreRawScore::getRawScore));

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/TopGenreResolver.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/TopGenreResolver.java
@@ -1,0 +1,63 @@
+package com.storix.domain.domains.genrescore.service;
+
+import com.storix.domain.domains.genrescore.adaptor.GenreScoreAdaptor;
+import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
+import com.storix.domain.domains.genrescore.dto.TopGenreInfo;
+import com.storix.domain.domains.user.domain.Title;
+import com.storix.domain.domains.works.domain.Genre;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+// 유저의 대표 장르(가장 점수가 높은 장르)와 그 점수를 해석
+// - 칭호가 정의된 장르만 대상 (칭호 없는 개그/액션/스포츠/감성은 제외)
+// - 동점 장르가 둘 이상이면 최근 14일 획득 점수 -> 최신 획득 시각 순으로 대표 선택
+@Service
+@RequiredArgsConstructor
+public class TopGenreResolver {
+
+    private static final int TIE_BREAK_WINDOW_DAYS = 14;
+    private static final Set<Genre> TITLED_GENRES = Title.titledGenres();
+
+    private final GenreScoreAdaptor genreScoreAdaptor;
+
+    @Transactional(readOnly = true)
+    public Optional<TopGenreInfo> resolve(Long userId) {
+        Map<Genre, Long> scoreByGenre = genreScoreAdaptor.findRawScoresByUserId(userId).stream()
+                .filter(s -> TITLED_GENRES.contains(s.getGenre()))
+                .collect(Collectors.toMap(UserGenreRawScore::getGenre, UserGenreRawScore::getRawScore));
+
+        // 장르 점수 데이터가 아예 없을 때만 대표 장르 없음. 점수가 0이어도 최고점 장르는 반환
+        if (scoreByGenre.isEmpty()) return Optional.empty();
+
+        long max = Collections.max(scoreByGenre.values());
+
+        List<Genre> topGenres = scoreByGenre.entrySet().stream()
+                .filter(e -> e.getValue() == max)
+                .map(Map.Entry::getKey)
+                .toList();
+
+        Genre representative = topGenres.size() == 1 ? topGenres.get(0) : breakTie(userId, topGenres);
+        return Optional.of(new TopGenreInfo(representative, max));
+    }
+
+    // 동점 장르의 대표 선택: 최근 N일 점수 합 -> 최신 획득 시각 순 1위 (DB에서 정렬·LIMIT)
+    private Genre breakTie(Long userId, List<Genre> candidates) {
+        LocalDateTime since = LocalDateTime.now().minusDays(TIE_BREAK_WINDOW_DAYS);
+
+        return genreScoreAdaptor.findTopGenresByRecentScore(userId, candidates, since, PageRequest.of(0, 1)).stream()
+                .findFirst()
+                // 최근 활동 로그가 없으면 enum 선언 순서가 빠른 장르로 결정 (결정적)
+                .orElseGet(() -> candidates.stream().min(Comparator.comparingInt(Enum::ordinal)).orElseThrow());
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/TopGenreResolver.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/TopGenreResolver.java
@@ -8,12 +8,14 @@ import com.storix.domain.domains.user.domain.Title;
 import com.storix.domain.domains.works.domain.Genre;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +41,7 @@ public class TopGenreResolver {
         return resolve(userId, genreScoreAdaptor.findRawScoresByUserId(userId));
     }
 
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
     public Map<Long, Optional<TopGenreInfo>> resolveAll(Collection<Long> userIds) {
         if (userIds == null || userIds.isEmpty()) return Collections.emptyMap();
 
@@ -47,17 +49,46 @@ public class TopGenreResolver {
                 .filter(s -> TITLED_GENRES.contains(s.getGenre()))
                 .collect(Collectors.groupingBy(UserGenreRawScore::getUserId));
 
-        return userIds.stream()
-                .distinct()
-                .collect(Collectors.toMap(
-                        userId -> userId,
-                        userId -> resolve(userId, scoresByUser.getOrDefault(userId, List.of())),
-                        (a, b) -> a,
-                        LinkedHashMap::new
-                ));
+        Map<Long, Optional<TopGenreInfo>> result = new LinkedHashMap<>();
+        Map<Long, TopGenreCandidate> tieCandidates = new LinkedHashMap<>();
+
+        userIds.stream().distinct().forEach(userId -> {
+            Optional<TopGenreCandidate> candidate = resolveCandidate(scoresByUser.getOrDefault(userId, List.of()));
+            if (candidate.isEmpty()) {
+                result.put(userId, Optional.empty());
+                return;
+            }
+
+            TopGenreCandidate top = candidate.get();
+            if (top.genres().size() == 1) {
+                result.put(userId, Optional.of(new TopGenreInfo(top.genres().get(0), top.score())));
+            } else {
+                tieCandidates.put(userId, top);
+            }
+        });
+
+        if (!tieCandidates.isEmpty()) {
+            Map<Long, Map<Genre, RecentGenreScore>> recentScores = findRecentScores(tieCandidates);
+            tieCandidates.forEach((userId, candidate) -> {
+                Genre genre = breakTie(candidate.genres(), recentScores.getOrDefault(userId, Collections.emptyMap()));
+                result.put(userId, Optional.of(new TopGenreInfo(genre, candidate.score())));
+            });
+        }
+
+        return result;
     }
 
     private Optional<TopGenreInfo> resolve(Long userId, List<UserGenreRawScore> rawScores) {
+        return resolveCandidate(rawScores)
+                .map(candidate -> {
+                    Genre representative = candidate.genres().size() == 1
+                            ? candidate.genres().get(0)
+                            : breakTie(userId, candidate.genres());
+                    return new TopGenreInfo(representative, candidate.score());
+                });
+    }
+
+    private Optional<TopGenreCandidate> resolveCandidate(List<UserGenreRawScore> rawScores) {
         Map<Genre, Long> scoreByGenre = rawScores.stream()
                 .filter(s -> TITLED_GENRES.contains(s.getGenre()))
                 .collect(Collectors.toMap(UserGenreRawScore::getGenre, UserGenreRawScore::getRawScore));
@@ -72,8 +103,20 @@ public class TopGenreResolver {
                 .map(Map.Entry::getKey)
                 .toList();
 
-        Genre representative = topGenres.size() == 1 ? topGenres.get(0) : breakTie(userId, topGenres);
-        return Optional.of(new TopGenreInfo(representative, max));
+        return Optional.of(new TopGenreCandidate(max, topGenres));
+    }
+
+    private Map<Long, Map<Genre, RecentGenreScore>> findRecentScores(Map<Long, TopGenreCandidate> tieCandidates) {
+        LocalDateTime since = LocalDateTime.now().minusDays(TIE_BREAK_WINDOW_DAYS);
+        Set<Genre> genres = tieCandidates.values().stream()
+                .flatMap(candidate -> candidate.genres().stream())
+                .collect(Collectors.toCollection(HashSet::new));
+
+        return genreScoreAdaptor.findRecentScoresByUsersAndGenres(tieCandidates.keySet(), genres, since).stream()
+                .collect(Collectors.groupingBy(
+                        RecentGenreScore::userId,
+                        Collectors.toMap(RecentGenreScore::genre, Function.identity())
+                ));
     }
 
     // 동점 장르 대표 선택
@@ -83,6 +126,10 @@ public class TopGenreResolver {
         Map<Genre, RecentGenreScore> recentByGenre = genreScoreAdaptor.findRecentScoresByGenres(userId, candidates, since).stream()
                 .collect(Collectors.toMap(RecentGenreScore::genre, Function.identity()));
 
+        return breakTie(candidates, recentByGenre);
+    }
+
+    private Genre breakTie(List<Genre> candidates, Map<Genre, RecentGenreScore> recentByGenre) {
         return candidates.stream()
                 .sorted(Comparator
                         .comparingLong((Genre genre) -> recentScore(recentByGenre.get(genre))).reversed()
@@ -102,4 +149,6 @@ public class TopGenreResolver {
     private LocalDateTime latestAt(RecentGenreScore recent) {
         return recent == null ? null : recent.latestAt();
     }
+
+    private record TopGenreCandidate(long score, List<Genre> genres) {}
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/TopGenreResolver.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/genrescore/service/TopGenreResolver.java
@@ -2,21 +2,24 @@ package com.storix.domain.domains.genrescore.service;
 
 import com.storix.domain.domains.genrescore.adaptor.GenreScoreAdaptor;
 import com.storix.domain.domains.genrescore.domain.UserGenreRawScore;
+import com.storix.domain.domains.genrescore.dto.RecentGenreScore;
 import com.storix.domain.domains.genrescore.dto.TopGenreInfo;
 import com.storix.domain.domains.user.domain.Title;
 import com.storix.domain.domains.works.domain.Genre;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 // 유저의 대표 장르(가장 점수가 높은 장르)와 그 점수를 해석
@@ -33,7 +36,29 @@ public class TopGenreResolver {
 
     @Transactional(readOnly = true)
     public Optional<TopGenreInfo> resolve(Long userId) {
-        Map<Genre, Long> scoreByGenre = genreScoreAdaptor.findRawScoresByUserId(userId).stream()
+        return resolve(userId, genreScoreAdaptor.findRawScoresByUserId(userId));
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, Optional<TopGenreInfo>> resolveAll(Collection<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) return Collections.emptyMap();
+
+        Map<Long, List<UserGenreRawScore>> scoresByUser = genreScoreAdaptor.findRawScoresByUserIds(userIds).stream()
+                .filter(s -> TITLED_GENRES.contains(s.getGenre()))
+                .collect(Collectors.groupingBy(UserGenreRawScore::getUserId));
+
+        return userIds.stream()
+                .distinct()
+                .collect(Collectors.toMap(
+                        userId -> userId,
+                        userId -> resolve(userId, scoresByUser.getOrDefault(userId, List.of())),
+                        (a, b) -> a,
+                        LinkedHashMap::new
+                ));
+    }
+
+    private Optional<TopGenreInfo> resolve(Long userId, List<UserGenreRawScore> rawScores) {
+        Map<Genre, Long> scoreByGenre = rawScores.stream()
                 .filter(s -> TITLED_GENRES.contains(s.getGenre()))
                 .collect(Collectors.toMap(UserGenreRawScore::getGenre, UserGenreRawScore::getRawScore));
 
@@ -51,13 +76,30 @@ public class TopGenreResolver {
         return Optional.of(new TopGenreInfo(representative, max));
     }
 
-    // 동점 장르의 대표 선택: 최근 N일 점수 합 -> 최신 획득 시각 순 1위 (DB에서 정렬·LIMIT)
+    // 동점 장르 대표 선택
     private Genre breakTie(Long userId, List<Genre> candidates) {
         LocalDateTime since = LocalDateTime.now().minusDays(TIE_BREAK_WINDOW_DAYS);
 
-        return genreScoreAdaptor.findTopGenresByRecentScore(userId, candidates, since, PageRequest.of(0, 1)).stream()
+        Map<Genre, RecentGenreScore> recentByGenre = genreScoreAdaptor.findRecentScoresByGenres(userId, candidates, since).stream()
+                .collect(Collectors.toMap(RecentGenreScore::genre, Function.identity()));
+
+        return candidates.stream()
+                .sorted(Comparator
+                        .comparingLong((Genre genre) -> recentScore(recentByGenre.get(genre))).reversed()
+                        .thenComparing(
+                                genre -> latestAt(recentByGenre.get(genre)),
+                                Comparator.nullsLast(Comparator.reverseOrder())
+                        )
+                        .thenComparingInt(Enum::ordinal))
                 .findFirst()
-                // 최근 활동 로그가 없으면 enum 선언 순서가 빠른 장르로 결정 (결정적)
-                .orElseGet(() -> candidates.stream().min(Comparator.comparingInt(Enum::ordinal)).orElseThrow());
+                .orElseThrow();
+    }
+
+    private long recentScore(RecentGenreScore recent) {
+        return recent == null || recent.score() == null ? 0L : recent.score();
+    }
+
+    private LocalDateTime latestAt(RecentGenreScore recent) {
+        return recent == null ? null : recent.latestAt();
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/dto/UserInfoV2.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/dto/UserInfoV2.java
@@ -1,0 +1,52 @@
+package com.storix.domain.domains.profile.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "프로필 조회 V2 응답. 칭호 및 다음 칭호까지의 진행도 포함 (null 필드도 그대로 응답에 포함)")
+@Builder
+public record UserInfoV2(
+
+        @Schema(description = "유저 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "권한", example = "READER")
+        String role,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://cdn.storix.com/profile/xxx.png")
+        String profileImageUrl,
+
+        @Schema(description = "닉네임", example = "스토릭스독자")
+        String nickName,
+
+        @Schema(description = "포인트", example = "120")
+        Integer point,
+
+        @Schema(description = "한 줄 소개", example = "로맨스 정주행 중")
+        String profileDescription,
+
+        @Schema(description = "소셜 로그인 제공자", example = "kakao")
+        String oauthProvider,
+
+        @Schema(description = "대표 장르 (활동 점수가 가장 높은 장르). 점수가 없으면 null.", example = "로맨스")
+        String topGenre,
+
+        @Schema(description = "현재 칭호명. 미진입(0~9점)이면 null.", example = "두근거림 수집가")
+        String title,
+
+        @Schema(description = "현재 단계 라벨 (미진입/입문/탐색/몰입)", example = "탐색")
+        String stage,
+
+        @Schema(description = "다음 단계 라벨. 최고 단계(몰입)면 null.", example = "몰입")
+        String nextStage,
+
+        @Schema(description = "대표 장르 점수 (raw_score)", example = "16")
+        long topGenreScore,
+
+        @Schema(description = "다음 칭호까지 남은 점수. 최고 단계면 null.", example = "24")
+        Integer remainingScore,
+
+        @Schema(description = "현재 단계 진행률 (0~100). 최고 단계면 100.", example = "20.0")
+        double progressPercentage
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileService.java
@@ -1,8 +1,14 @@
 package com.storix.domain.domains.profile.service;
 
+import com.storix.domain.domains.genrescore.dto.TopGenreInfo;
+import com.storix.domain.domains.genrescore.service.TopGenreResolver;
 import com.storix.domain.domains.profile.dto.UserInfo;
+import com.storix.domain.domains.profile.dto.UserInfoV2;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
+import com.storix.domain.domains.user.domain.Title;
+import com.storix.domain.domains.user.domain.TitleStage;
 import com.storix.domain.domains.user.domain.User;
+import com.storix.domain.domains.works.domain.Genre;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -15,8 +21,9 @@ public class ProfileService {
     @Value("${AWS_S3_BASE_URL}") private String baseUrl;
 
     private final UserAdaptor userAdaptor;
+    private final TopGenreResolver topGenreResolver;
 
-    // 독자 프로필 조회
+    // 독자 프로필 조회 (V1)
     @Transactional(readOnly = true)
     public UserInfo getReaderProfileInfo(Long userId) {
         User readerUser = userAdaptor.findUserById(userId);
@@ -25,13 +32,48 @@ public class ProfileService {
                 .userId(userId)
                 .role(readerUser.getRole().toString())
                 .nickName(readerUser.getNickName())
-                .level(readerUser.getLevel())
+                .level(1)// level 미사용
                 .point(readerUser.getPoint())
                 .profileDescription(readerUser.getProfileDescription())
                 .profileImageUrl(readerUser.getProfileObjectKey() == null
                         ? null : baseUrl + "/" + readerUser.getProfileObjectKey())
                 .oauthProvider(readerUser.getOauthInfo() == null
                         ? null : readerUser.getOauthInfo().getProvider().getDbValue())
+                .build();
+    }
+
+    // 독자 프로필 조회 (V2)
+    @Transactional(readOnly = true)
+    public UserInfoV2 getReaderProfileInfoV2(Long userId) {
+        User readerUser = userAdaptor.findUserById(userId);
+
+        // 대표 장르가 없는 유저(활동 0)면 null/0 으로 처리
+        TopGenreInfo top = topGenreResolver.resolve(userId).orElse(null);
+        Genre topGenre = top == null ? null : top.genre();
+        long score = top == null ? 0L : top.score();
+
+        TitleStage stage = TitleStage.from(score);
+        Title title = topGenre == null ? null : Title.resolve(topGenre, score).orElse(null);
+        Integer remainingScore = stage.isMax() ? null : stage.getNextScore() - (int) score;
+        String nextStage = stage.isMax() ? null : stage.next().getLabel();
+
+        return UserInfoV2.builder()
+                .userId(userId)
+                .role(readerUser.getRole().toString())
+                .nickName(readerUser.getNickName())
+                .point(readerUser.getPoint())
+                .profileDescription(readerUser.getProfileDescription())
+                .profileImageUrl(readerUser.getProfileObjectKey() == null
+                        ? null : baseUrl + "/" + readerUser.getProfileObjectKey())
+                .oauthProvider(readerUser.getOauthInfo() == null
+                        ? null : readerUser.getOauthInfo().getProvider().getDbValue())
+                .topGenre(topGenre == null ? null : topGenre.getDbValue())
+                .title(title == null ? null : title.getDisplayName())
+                .stage(stage.getLabel())
+                .nextStage(nextStage)
+                .topGenreScore(score)
+                .remainingScore(remainingScore)
+                .progressPercentage(stage.progressPercentage(score))
                 .build();
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileService.java
@@ -1,7 +1,6 @@
 package com.storix.domain.domains.profile.service;
 
-import com.storix.domain.domains.genrescore.dto.TopGenreInfo;
-import com.storix.domain.domains.genrescore.service.TopGenreResolver;
+import com.storix.domain.domains.genrescore.adaptor.GenreScoreAdaptor;
 import com.storix.domain.domains.profile.dto.UserInfo;
 import com.storix.domain.domains.profile.dto.UserInfoV2;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
@@ -21,7 +20,7 @@ public class ProfileService {
     @Value("${AWS_S3_BASE_URL}") private String baseUrl;
 
     private final UserAdaptor userAdaptor;
-    private final TopGenreResolver topGenreResolver;
+    private final GenreScoreAdaptor genreScoreAdaptor;
 
     // 독자 프로필 조회 (V1)
     @Transactional(readOnly = true)
@@ -47,15 +46,14 @@ public class ProfileService {
     public UserInfoV2 getReaderProfileInfoV2(Long userId) {
         User readerUser = userAdaptor.findUserById(userId);
 
-        // 대표 장르가 없는 유저(활동 0)면 null/0 으로 처리
-        TopGenreInfo top = topGenreResolver.resolve(userId).orElse(null);
-        Genre topGenre = top == null ? null : top.genre();
-        long score = top == null ? 0L : top.score();
+        Title title = readerUser.getTitle();
+        Genre topGenre = title == null ? null : title.getGenre();
+        long score = topGenre == null ? 0L : genreScoreAdaptor.findRawScore(userId, topGenre);
 
-        TitleStage stage = TitleStage.from(score);
-        Title title = topGenre == null ? null : Title.resolve(topGenre, score).orElse(null);
-        Integer remainingScore = stage.isMax() ? null : stage.getNextScore() - (int) score;
-        String nextStage = stage.isMax() ? null : stage.next().getLabel();
+        TitleStage stage = title == null ? TitleStage.NONE : title.getStage();
+        Integer remainingScore = title == null || stage.isMax() ? null : stage.getNextScore() - (int) score;
+        String nextStage = title == null ? null : stage.next().map(TitleStage::getLabel).orElse(null);
+        double progressPercentage = title == null ? 0.0 : stage.progressPercentage(score);
 
         return UserInfoV2.builder()
                 .userId(userId)
@@ -73,7 +71,7 @@ public class ProfileService {
                 .nextStage(nextStage)
                 .topGenreScore(score)
                 .remainingScore(remainingScore)
-                .progressPercentage(stage.progressPercentage(score))
+                .progressPercentage(progressPercentage)
                 .build();
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserAdaptor.java
@@ -98,6 +98,10 @@ public class UserAdaptor {
         return user.get();
     }
 
+    public List<User> findUsersByIds(Collection<Long> userIds) {
+        return userRepository.findAllById(userIds);
+    }
+
     public Map<Long, StandardProfileInfo> findStandardProfileInfoByUserIds(List<Long> userIds) {
         if (userIds == null || userIds.isEmpty()) {
             return Collections.emptyMap();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserAdaptor.java
@@ -13,6 +13,7 @@ import com.storix.domain.domains.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -104,6 +105,10 @@ public class UserAdaptor {
 
     public int clearAllTitles() {
         return userRepository.clearAllTitles();
+    }
+
+    public List<Long> findUntitledUserIdsHavingRawScore(Pageable pageable) {
+        return userRepository.findUntitledUserIdsHavingRawScore(pageable);
     }
 
     public Map<Long, StandardProfileInfo> findStandardProfileInfoByUserIds(List<Long> userIds) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserAdaptor.java
@@ -102,6 +102,10 @@ public class UserAdaptor {
         return userRepository.findAllById(userIds);
     }
 
+    public int clearAllTitles() {
+        return userRepository.clearAllTitles();
+    }
+
     public Map<Long, StandardProfileInfo> findStandardProfileInfoByUserIds(List<Long> userIds) {
         if (userIds == null || userIds.isEmpty()) {
             return Collections.emptyMap();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserTitleHistoryAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserTitleHistoryAdaptor.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -16,6 +17,8 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class UserTitleHistoryAdaptor {
+
+    private static final int MYSQL_DUPLICATE_ENTRY = 1062; // ER_DUP_ENTRY
 
     private final UserTitleHistoryRepository userTitleHistoryRepository;
 
@@ -41,9 +44,19 @@ public class UserTitleHistoryAdaptor {
 
         try {
             userTitleHistoryRepository.saveAll(newHistories);
-        } catch (DataIntegrityViolationException ignored) {
-            // 병렬 저장 시 unique key 로 중복 획득 방지
+        } catch (DataIntegrityViolationException e) {
+            // 중복 획득(unique 충돌)만 무시, 그 외는 전파
+            if (!isDuplicateKey(e)) throw e;
         }
+    }
+
+    private boolean isDuplicateKey(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof SQLException sql && sql.getErrorCode() == MYSQL_DUPLICATE_ENTRY) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public UserTitleHistory create(Long userId, Title title, LocalDateTime acquiredAt) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserTitleHistoryAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserTitleHistoryAdaptor.java
@@ -1,0 +1,56 @@
+package com.storix.domain.domains.user.adaptor;
+
+import com.storix.domain.domains.user.domain.Title;
+import com.storix.domain.domains.user.domain.UserTitleHistory;
+import com.storix.domain.domains.user.repository.UserTitleHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserTitleHistoryAdaptor {
+
+    private final UserTitleHistoryRepository userTitleHistoryRepository;
+
+    // 획득 칭호 저장
+    public void saveNewTitles(Collection<UserTitleHistory> histories) {
+        if (histories == null || histories.isEmpty()) return;
+
+        Set<Long> userIds = histories.stream()
+                .map(UserTitleHistory::getUserId)
+                .collect(Collectors.toSet());
+        Set<Title> titles = histories.stream()
+                .map(UserTitleHistory::getTitle)
+                .collect(Collectors.toSet());
+
+        Set<String> existingKeys = userTitleHistoryRepository.findAllByUserIdInAndTitleIn(userIds, titles).stream()
+                .map(history -> key(history.getUserId(), history.getTitle()))
+                .collect(Collectors.toSet());
+
+        List<UserTitleHistory> newHistories = histories.stream()
+                .filter(history -> !existingKeys.contains(key(history.getUserId(), history.getTitle())))
+                .toList();
+        if (newHistories.isEmpty()) return;
+
+        try {
+            userTitleHistoryRepository.saveAll(newHistories);
+        } catch (DataIntegrityViolationException ignored) {
+            // 병렬 저장 시 unique key 로 중복 획득 방지
+        }
+    }
+
+    public UserTitleHistory create(Long userId, Title title, LocalDateTime acquiredAt) {
+        return UserTitleHistory.of(userId, title, acquiredAt);
+    }
+
+    private String key(Long userId, Title title) {
+        return userId + ":" + title.name();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/Title.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/Title.java
@@ -89,4 +89,14 @@ public enum Title {
                 .filter(t -> t.genre == genre && t.stage == stage)
                 .findFirst();
     }
+
+    // 장르와 점수로 획득 가능한 칭호 조회
+    public static Set<Title> resolveAcquired(Genre genre, long score) {
+        TitleStage currentStage = TitleStage.from(score);
+        return Arrays.stream(values())
+                .filter(t -> t.genre == genre)
+                .filter(t -> t.stage != TitleStage.NONE)
+                .filter(t -> t.stage.getStartScore() <= currentStage.getStartScore())
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(Title.class)));
+    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/Title.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/Title.java
@@ -1,0 +1,92 @@
+package com.storix.domain.domains.user.domain;
+
+import com.storix.domain.domains.works.domain.Genre;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+// 칭호. 장르 × 단계 조합으로 정의되며, 노출용 칭호명은 displayName 필드로 관리 (칭호명 변경 시 값만 수정)
+// 칭호가 정의된 장르만 존재 -> 칭호 없는 개그/액션/스포츠/감성은 부여 대상에서 제외
+// 미진입(NONE) 단계는 대표 장르 추적용 -> 칭호명(displayName) 없음(null)
+@Getter
+@RequiredArgsConstructor
+public enum Title {
+
+    // 로맨스
+    ROMANCE_NONE(Genre.ROMANCE, TitleStage.NONE, null),
+    ROMANCE_ENTRY(Genre.ROMANCE, TitleStage.ENTRY, "풋사랑 독자"),
+    ROMANCE_EXPLORE(Genre.ROMANCE, TitleStage.EXPLORE, "두근거림 수집가"),
+    ROMANCE_IMMERSE(Genre.ROMANCE, TitleStage.IMMERSE, "사랑 중독자"),
+
+    // 로판
+    ROFAN_NONE(Genre.ROFAN, TitleStage.NONE, null),
+    ROFAN_ENTRY(Genre.ROFAN, TitleStage.ENTRY, "공작 영애"),
+    ROFAN_EXPLORE(Genre.ROFAN, TitleStage.EXPLORE, "사교계의 꽃"),
+    ROFAN_IMMERSE(Genre.ROFAN, TitleStage.IMMERSE, "황궁의 실세"),
+
+    // 드라마
+    DRAMA_NONE(Genre.DRAMA, TitleStage.NONE, null),
+    DRAMA_ENTRY(Genre.DRAMA, TitleStage.ENTRY, "첫 회 시청자"),
+    DRAMA_EXPLORE(Genre.DRAMA, TitleStage.EXPLORE, "과몰입 초기"),
+    DRAMA_IMMERSE(Genre.DRAMA, TitleStage.IMMERSE, "인생작 수집가"),
+
+    // BL
+    BL_NONE(Genre.BL, TitleStage.NONE, null),
+    BL_ENTRY(Genre.BL, TitleStage.ENTRY, "벨 초심자"),
+    BL_EXPLORE(Genre.BL, TitleStage.EXPLORE, "벨 사냥꾼"),
+    BL_IMMERSE(Genre.BL, TitleStage.IMMERSE, "벨 전도사"),
+
+    // 판타지
+    FANTASY_NONE(Genre.FANTASY, TitleStage.NONE, null),
+    FANTASY_ENTRY(Genre.FANTASY, TitleStage.ENTRY, "길드 신참"),
+    FANTASY_EXPLORE(Genre.FANTASY, TitleStage.EXPLORE, "던전 탐험가"),
+    FANTASY_IMMERSE(Genre.FANTASY, TitleStage.IMMERSE, "전설의 용사"),
+
+    // 현판
+    MODERN_FANTASY_NONE(Genre.MODERN_FANTASY, TitleStage.NONE, null),
+    MODERN_FANTASY_ENTRY(Genre.MODERN_FANTASY, TitleStage.ENTRY, "각성자"),
+    MODERN_FANTASY_EXPLORE(Genre.MODERN_FANTASY, TitleStage.EXPLORE, "게이트 공략자"),
+    MODERN_FANTASY_IMMERSE(Genre.MODERN_FANTASY, TitleStage.IMMERSE, "랭킹권 헌터"),
+
+    // 무협
+    HISTORICAL_NONE(Genre.HISTORICAL, TitleStage.NONE, null),
+    HISTORICAL_ENTRY(Genre.HISTORICAL, TitleStage.ENTRY, "강호초출"),
+    HISTORICAL_EXPLORE(Genre.HISTORICAL, TitleStage.EXPLORE, "일류고수"),
+    HISTORICAL_IMMERSE(Genre.HISTORICAL, TitleStage.IMMERSE, "무림지존"),
+
+    // 일상
+    DAILY_NONE(Genre.DAILY, TitleStage.NONE, null),
+    DAILY_ENTRY(Genre.DAILY, TitleStage.ENTRY, "단골 구경꾼"),
+    DAILY_EXPLORE(Genre.DAILY, TitleStage.EXPLORE, "단짝 이웃"),
+    DAILY_IMMERSE(Genre.DAILY, TitleStage.IMMERSE, "명예 객식구"),
+
+    // 스릴러
+    THRILLER_NONE(Genre.THRILLER, TitleStage.NONE, null),
+    THRILLER_ENTRY(Genre.THRILLER, TitleStage.ENTRY, "최초 목격자"),
+    THRILLER_EXPLORE(Genre.THRILLER, TitleStage.EXPLORE, "진실 추격자"),
+    THRILLER_IMMERSE(Genre.THRILLER, TitleStage.IMMERSE, "최후 생존자");
+
+    private final Genre genre;
+    private final TitleStage stage;
+    private final String displayName;
+
+    // 칭호가 정의된 장르 집합 (= 칭호 부여 대상 장르)
+    public static Set<Genre> titledGenres() {
+        return Arrays.stream(values())
+                .map(Title::getGenre)
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(Genre.class)));
+    }
+
+    // 장르와 점수로 칭호 해석. 미진입(0~9)도 NONE 항목으로 반환됨(칭호명 null)
+    public static Optional<Title> resolve(Genre genre, long score) {
+        TitleStage stage = TitleStage.from(score);
+        return Arrays.stream(values())
+                .filter(t -> t.genre == genre && t.stage == stage)
+                .findFirst();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/TitleStage.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/TitleStage.java
@@ -3,6 +3,8 @@ package com.storix.domain.domains.user.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Optional;
+
 @Getter
 @RequiredArgsConstructor
 public enum TitleStage {
@@ -27,13 +29,13 @@ public enum TitleStage {
         return nextScore == null;
     }
 
-    // 다음 단계 (최고 단계면 null)
-    public TitleStage next() {
+    // 다음 단계
+    public Optional<TitleStage> next() {
         return switch (this) {
-            case NONE -> ENTRY;
-            case ENTRY -> EXPLORE;
-            case EXPLORE -> IMMERSE;
-            case IMMERSE -> null;
+            case NONE -> Optional.of(ENTRY);
+            case ENTRY -> Optional.of(EXPLORE);
+            case EXPLORE -> Optional.of(IMMERSE);
+            case IMMERSE -> Optional.empty();
         };
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/TitleStage.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/TitleStage.java
@@ -1,0 +1,48 @@
+package com.storix.domain.domains.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TitleStage {
+    // 대표 장르 점수를 4단계로 매핑 (미진입 0~9 / 입문 10~39 / 탐색 40~119 / 몰입 120~)
+    NONE("미진입", 0, 10),
+    ENTRY("입문", 10, 40),
+    EXPLORE("탐색", 40, 120),
+    IMMERSE("몰입", 120, null);
+
+    private final String label;
+    private final int startScore;
+    private final Integer nextScore;
+
+    public static TitleStage from(long score) {
+        if (score >= 120) return IMMERSE;
+        if (score >= 40) return EXPLORE;
+        if (score >= 10) return ENTRY;
+        return NONE;
+    }
+
+    public boolean isMax() {
+        return nextScore == null;
+    }
+
+    // 다음 단계 (최고 단계면 null)
+    public TitleStage next() {
+        return switch (this) {
+            case NONE -> ENTRY;
+            case ENTRY -> EXPLORE;
+            case EXPLORE -> IMMERSE;
+            case IMMERSE -> null;
+        };
+    }
+
+    // 비율 = (현재 점수 - 현재 단계 시작 점수) / (다음 단계 기준 점수 - 현재 단계 시작 점수) × 100
+    public double progressPercentage(long score) {
+        if (isMax()) return 100.0;
+        double ratio = (double) (score - startScore) / (nextScore - startScore) * 100.0;
+        if (ratio < 0) ratio = 0;
+        if (ratio > 100) ratio = 100;
+        return Math.round(ratio * 10) / 10.0;
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
@@ -53,8 +53,10 @@ public class User extends BaseTimeEntity {
     @Column(length = 30)
     private String profileDescription;
 
-    @Column(nullable = false)
-    private int level = 1;
+    // 칭호
+    @Enumerated(EnumType.STRING)
+    @Column(name = "title", length = 40)
+    private Title title;
 
     @Min(0)
     @Column(nullable = false)
@@ -124,11 +126,8 @@ public class User extends BaseTimeEntity {
 
     public void changeProfileImage(String objectKey) { this.profileObjectKey = objectKey; }
 
-    public void changeLevel(int level) {
-//        if (level < 1 || level > 5) {
-//            throw new IllegalArgumentException("레벨 범위 오류");
-//        }
-        this.level = level;
+    public void changeTitle(Title title) {
+        this.title = title;
     }
 
     public void increasePoint(int point) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserTitleHistory.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserTitleHistory.java
@@ -1,0 +1,55 @@
+package com.storix.domain.domains.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(
+        name = "user_title_history",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_title_history",
+                columnNames = {"user_id", "title"}
+        ),
+        indexes = {
+                @Index(name = "idx_user_title_history_user", columnList = "user_id")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserTitleHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_title_history_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "title", nullable = false, length = 40)
+    private Title title;
+
+    @Column(name = "acquired_at", nullable = false)
+    private LocalDateTime acquiredAt;
+
+    @Builder
+    public UserTitleHistory(Long userId, Title title, LocalDateTime acquiredAt) {
+        this.userId = userId;
+        this.title = title;
+        this.acquiredAt = acquiredAt;
+    }
+
+    public static UserTitleHistory of(Long userId, Title title, LocalDateTime acquiredAt) {
+        return UserTitleHistory.builder()
+                .userId(userId)
+                .title(title)
+                .acquiredAt(acquiredAt)
+                .build();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserRepository.java
@@ -6,6 +6,7 @@ import com.storix.domain.domains.user.dto.StandardProfileInfo;
 import com.storix.domain.domains.user.dto.UserNicknameInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.storix.domain.domains.user.domain.User;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -57,5 +58,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
         WHERE u.id IN :userIds
     """)
     List<UserNicknameInfo> findNicknameInfoByUserIds(@Param("userIds") List<Long> userIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE User u SET u.title = null")
+    int clearAllTitles();
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserRepository.java
@@ -4,6 +4,7 @@ import com.storix.domain.domains.user.domain.OAuthProvider;
 import com.storix.domain.domains.user.domain.Role;
 import com.storix.domain.domains.user.dto.StandardProfileInfo;
 import com.storix.domain.domains.user.dto.UserNicknameInfo;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.storix.domain.domains.user.domain.User;
 import org.springframework.data.jpa.repository.Modifying;
@@ -62,5 +63,18 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE User u SET u.title = null")
     int clearAllTitles();
+
+    @Query("""
+        SELECT u.id
+        FROM User u
+        WHERE u.title IS NULL
+          AND EXISTS (
+              SELECT s.id.userId
+              FROM UserGenreRawScore s
+              WHERE s.id.userId = u.id
+          )
+        ORDER BY u.id ASC
+    """)
+    List<Long> findUntitledUserIdsHavingRawScore(Pageable pageable);
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserTitleHistoryRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserTitleHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.storix.domain.domains.user.repository;
+
+import com.storix.domain.domains.user.domain.Title;
+import com.storix.domain.domains.user.domain.UserTitleHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface UserTitleHistoryRepository extends JpaRepository<UserTitleHistory, Long> {
+
+    List<UserTitleHistory> findAllByUserIdInAndTitleIn(Collection<Long> userIds, Collection<Title> titles);
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/UserTitleService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/UserTitleService.java
@@ -5,54 +5,62 @@ import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import com.storix.domain.domains.user.domain.Title;
 import com.storix.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 // 대표 장르 점수 기준으로 칭호를 산출하여 User 엔티티에 반영
 // 장르 점수 집계(score_log -> raw_score) 직후 호출되어 함께 갱신됨
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserTitleService {
 
+    private static final int TITLE_ASSIGN_CHUNK_SIZE = 500;
+
     private final TopGenreResolver topGenreResolver;
     private final UserAdaptor userAdaptor;
 
-    // 여러 유저의 칭호를 한 트랜잭션에서 일괄 갱신.
-    // (1) 읽기 단계에서 칭호를 모두 계산한 뒤 (2) 쓰기 단계에서 한꺼번에 변경 ->
-    // 변경 사이에 쿼리가 끼지 않아 commit 시점에 dirty UPDATE 들이 JDBC 배치로 flush 된다.
+    // 여러 유저의 칭호 일괄 갱신
     @Transactional
-    public void assignTitles(Collection<Long> userIds) {
-        // (1) 읽기 단계: 유저별 칭호 계산 (한 명 실패는 건너뜀)
-        Map<Long, Title> titleByUser = new HashMap<>();
-        for (Long userId : userIds) {
-            try {
-                titleByUser.put(userId, resolveTitle(userId));
-            } catch (Exception e) {
-                log.warn(">>> [UserTitle] 칭호 계산 실패 userId={}", userId, e);
-            }
-        }
+    public void assignTitles(Set<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) return;
 
-        // (2) 쓰기 단계: 대상 유저를 한 번에 로드 후 변경 (중간 쿼리 없음)
-        Map<Long, User> users = userAdaptor.findUsersByIds(titleByUser.keySet()).stream()
+        // 1. 대상 유저 정리
+        List<Long> targetUserIds = userIds.stream()
+                .filter(Objects::nonNull)
+                .toList();
+
+        // 2. 청크 단위 칭호 갱신
+        for (int from = 0; from < targetUserIds.size(); from += TITLE_ASSIGN_CHUNK_SIZE) {
+            int to = Math.min(from + TITLE_ASSIGN_CHUNK_SIZE, targetUserIds.size());
+            assignTitleChunk(targetUserIds.subList(from, to));
+        }
+    }
+
+    private void assignTitleChunk(List<Long> userIds) {
+        // 1. 칭호 계산
+        Map<Long, Title> titleByUser = new HashMap<>();
+        topGenreResolver.resolveAll(userIds)
+                .forEach((userId, top) -> titleByUser.put(userId, top
+                        .flatMap(t -> Title.resolve(t.genre(), t.score()))
+                        .orElse(null)));
+
+        // 2. 유저 조회
+        Map<Long, User> users = userAdaptor.findUsersByIds(userIds).stream()
                 .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        // 3. 칭호 반영 (dirty checking)
         titleByUser.forEach((userId, title) -> {
             User user = users.get(userId);
             if (user != null) user.changeTitle(title);
         });
     }
 
-    // 대표 장르 점수 기준 칭호 산출. 미진입(칭호 없음)이면 null
-    public Title resolveTitle(Long userId) {
-        return topGenreResolver.resolve(userId)
-                .flatMap(top -> Title.resolve(top.genre(), top.score()))
-                .orElse(null);
-    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/UserTitleService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/UserTitleService.java
@@ -1,17 +1,25 @@
 package com.storix.domain.domains.user.service;
 
+import com.storix.domain.domains.genrescore.dto.TopGenreInfo;
 import com.storix.domain.domains.genrescore.service.TopGenreResolver;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
+import com.storix.domain.domains.user.adaptor.UserTitleHistoryAdaptor;
 import com.storix.domain.domains.user.domain.Title;
 import com.storix.domain.domains.user.domain.User;
+import com.storix.domain.domains.user.domain.UserTitleHistory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -26,6 +34,7 @@ public class UserTitleService {
 
     private final TopGenreResolver topGenreResolver;
     private final UserAdaptor userAdaptor;
+    private final UserTitleHistoryAdaptor userTitleHistoryAdaptor;
 
     // 여러 유저의 칭호 일괄 갱신
     @Transactional
@@ -44,23 +53,58 @@ public class UserTitleService {
         }
     }
 
+    // 미부여 칭호 보정
+    @Transactional
+    public int assignMissingTitles() {
+        int assigned = 0;
+
+        while (true) {
+            List<Long> userIds = userAdaptor.findUntitledUserIdsHavingRawScore(PageRequest.of(0, TITLE_ASSIGN_CHUNK_SIZE));
+            if (userIds.isEmpty()) break;
+
+            assignTitleChunk(userIds);
+            assigned += userIds.size();
+
+            if (userIds.size() < TITLE_ASSIGN_CHUNK_SIZE) break;
+        }
+
+        return assigned;
+    }
+
     private void assignTitleChunk(List<Long> userIds) {
         // 1. 칭호 계산
         Map<Long, Title> titleByUser = new HashMap<>();
-        topGenreResolver.resolveAll(userIds)
-                .forEach((userId, top) -> titleByUser.put(userId, top
-                        .flatMap(t -> Title.resolve(t.genre(), t.score()))
-                        .orElse(null)));
+        List<UserTitleHistory> acquiredTitleHistories = new ArrayList<>();
+        LocalDateTime now = LocalDateTime.now();
+
+        topGenreResolver.resolveAll(userIds).forEach((userId, top) -> {
+            titleByUser.put(userId, resolveTitle(top));
+            acquiredTitleHistories.addAll(resolveAcquiredTitles(userId, top, now));
+        });
 
         // 2. 유저 조회
         Map<Long, User> users = userAdaptor.findUsersByIds(userIds).stream()
                 .collect(Collectors.toMap(User::getId, Function.identity()));
 
-        // 3. 칭호 반영 (dirty checking)
+        // 3. 칭호 반영
         titleByUser.forEach((userId, title) -> {
             User user = users.get(userId);
             if (user != null) user.changeTitle(title);
         });
+
+        // 4. 획득 칭호 저장
+        userTitleHistoryAdaptor.saveNewTitles(acquiredTitleHistories);
+    }
+
+    private Title resolveTitle(Optional<TopGenreInfo> top) {
+        return top.flatMap(t -> Title.resolve(t.genre(), t.score())).orElse(null);
+    }
+
+    private Collection<UserTitleHistory> resolveAcquiredTitles(Long userId, Optional<TopGenreInfo> top, LocalDateTime acquiredAt) {
+        return top.stream()
+                .flatMap(info -> Title.resolveAcquired(info.genre(), info.score()).stream())
+                .map(title -> userTitleHistoryAdaptor.create(userId, title, acquiredAt))
+                .toList();
     }
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/UserTitleService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/UserTitleService.java
@@ -1,0 +1,58 @@
+package com.storix.domain.domains.user.service;
+
+import com.storix.domain.domains.genrescore.service.TopGenreResolver;
+import com.storix.domain.domains.user.adaptor.UserAdaptor;
+import com.storix.domain.domains.user.domain.Title;
+import com.storix.domain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+// 대표 장르 점수 기준으로 칭호를 산출하여 User 엔티티에 반영
+// 장르 점수 집계(score_log -> raw_score) 직후 호출되어 함께 갱신됨
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserTitleService {
+
+    private final TopGenreResolver topGenreResolver;
+    private final UserAdaptor userAdaptor;
+
+    // 여러 유저의 칭호를 한 트랜잭션에서 일괄 갱신.
+    // (1) 읽기 단계에서 칭호를 모두 계산한 뒤 (2) 쓰기 단계에서 한꺼번에 변경 ->
+    // 변경 사이에 쿼리가 끼지 않아 commit 시점에 dirty UPDATE 들이 JDBC 배치로 flush 된다.
+    @Transactional
+    public void assignTitles(Collection<Long> userIds) {
+        // (1) 읽기 단계: 유저별 칭호 계산 (한 명 실패는 건너뜀)
+        Map<Long, Title> titleByUser = new HashMap<>();
+        for (Long userId : userIds) {
+            try {
+                titleByUser.put(userId, resolveTitle(userId));
+            } catch (Exception e) {
+                log.warn(">>> [UserTitle] 칭호 계산 실패 userId={}", userId, e);
+            }
+        }
+
+        // (2) 쓰기 단계: 대상 유저를 한 번에 로드 후 변경 (중간 쿼리 없음)
+        Map<Long, User> users = userAdaptor.findUsersByIds(titleByUser.keySet()).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+        titleByUser.forEach((userId, title) -> {
+            User user = users.get(userId);
+            if (user != null) user.changeTitle(title);
+        });
+    }
+
+    // 대표 장르 점수 기준 칭호 산출. 미진입(칭호 없음)이면 null
+    public Title resolveTitle(Long userId) {
+        return topGenreResolver.resolve(userId)
+                .flatMap(top -> Title.resolve(top.genre(), top.score()))
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 프로필 레벨 제거 및 칭호 도메인 추가
- 기존 `User.level` 필드를 제거하고, 장르 기반 칭호를 저장할 수 있도록 `User.title` 필드를 추가했습니다.
- 칭호는 장르와 단계 조합으로 관리하며, 단계는 아래 기준으로 구분합니다.
  - 0 ~ 9점: 미진입 (칭호 없음)
  - 10 ~ 39점: 입문
  - 40 ~ 119점: 탐색
  - 120점 이상: 몰입
- 칭호가 정의된 장르만 칭호 부여 대상으로 사용합니다.
  - 로맨스, 로판, 드라마, BL, 판타지, 현판, 무협, 일상, 스릴러

### 2. 대표 장르 및 칭호 산출 로직 구현
- 유저의 장르별 raw score 중 가장 점수가 높은 장르를 대표 장르로 선정합니다.
- 대표 장르 점수에 따라 현재 칭호 단계를 산출합니다.
- 최고 점수 장르가 여러 개인 경우, 최근 14일간 획득한 장르 점수 합계를 기준으로 대표 장르를 결정합니다.
  - 최근 14일 점수 합 DESC
  - 최신 획득 시각 DESC
  - enum 선언 순
- 최근 로그가 없는 후보 장르는 최근 점수 0점으로 처리하여, 음수 로그(관심 작품 해제 시 -3점)만 존재하는 장르가 우선되는 케이스를 방지했습니다.

### 3. 프로필 V2 API 추가
- 칭호와 다음 칭호까지의 진행도를 포함한 프로필 조회 API를 추가했습니다.
  - `GET /api/v2/profile/me`
- 응답에는 기존 프로필 정보와 함께 아래 정보를 포함합니다.
  - 대표 장르
  - 현재 칭호
  - 현재 단계
  - 다음 단계
  - 대표 장르 점수
  - 다음 단계까지 남은 점수
  - 프로그레스바 비율
- 기존 V1 프로필 API는 마이그레이션용으로 유지하되, User 엔티티에서 level 컬럼이 삭제되므로 `level=1`로 고정 반환합니다.

### 4. 장르 점수 집계 후 칭호 일괄 갱신
- 장르 점수 로그 집계 배치 이후, 점수가 변경된 유저들의 칭호를 함께 갱신합니다.
- touched-user 를 청크 단위(500)로 나누어 raw score 를 일괄 조회하고, 메모리에서 대표 장르와 칭호를 계산합니다.
- 칭호 반영은 `User.changeTitle()`을 통한 dirty checking 방식으로 처리하며, Hibernate JDBC batch 로 UPDATE 가 묶이도록 구성했습니다.

### 5. 칭호 획득 이력 저장
- 칭호 획득 시점을 별도 테이블(`user_title_history`)에 이력으로 저장합니다.
- `user_id + title` unique 제약으로 동일 칭호 중복 획득을 방지합니다.
- 추후 칭호 획득 시점이나 여러 장르 칭호 획득 처리가 가능하도록 지원할 수도 있으므로 이력 관리 테이블을 추가하였습니다.

### 6. 기타 
- 기획 사항에 따른 주기별 장르 점수 리셋 시 칭호 정보도 초기화하도록 처리했습니다.
- 장르 점수 데이터 (raw score, score log) 접근을 `GenreScoreAdaptor`로 분리했습니다.
- 기동 시 미부여 칭호 1회성 보정 기능 추가
   - `ApplicationReadyEvent` 시점에 `title` 이 비어 있고 raw score 가 존재하는 유저를 청크(500) 단위로 조회해 칭호를 일괄 보정합니다.
   - 기본 비활성(`storix.title.backfill-on-startup=false`)이며, 보정이 필요한 배포에서만 활성화합니다. (배치 컨테이너 환경변수로 토글)


## 📸 작업 화면 (스크린샷)
<img width="370" height="371" alt="스크린샷 2026-06-12 오전 2 11 48" src="https://github.com/user-attachments/assets/fb06e75b-80fb-4921-b33b-a0e0cb08f2a1" />

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #83 

## 🖇️ 기타
~~서버 docker-compose.yml 수정이 필요합니다. 배포 전에 수정해두겠습니다.~~
~  - `spring.jpa.properties.hibernate.jdbc.batch_size=500`~
~  - `spring.jpa.properties.hibernate.order_updates=true`~
  
~~- 배포 이후 user 테이블의 level 컬럼 직접 삭제가 필요합니다.~~
~~- backfill-true로 테이블 갱신 이후 false로 다시 변경해두겠습니다.~~