### PR TITLE
Feat: [인증] X(트위터) 소셜 로그인 및 연동 해제 추가

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -71,6 +71,25 @@ public class AuthController {
         return oauthLoginUseCase.readerOAuthNativeLogin(req, OAuthProvider.APPLE);
     }
 
+    @Operation(summary = "X(트위터) 로그인", description = "X(트위터) 로그인 api 입니다. (OAuth 2.0 PKCE, 웹/앱 공용)  \n" +
+            "code, redirectUri, codeVerifier(PKCE)를 보내주세요.  \n" +
+            "redirectUri로 클라이언트를 구분합니다.  \n" +
+            "- 웹(http/https): accessToken body + refreshToken 쿠키  \n" +
+            "- 앱(커스텀 스킴, 예: storix://): access/refresh 토큰을 body로 반환  \n" +
+            "회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")
+    @GetMapping("/oauth/x/login")
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> xLogin(
+            @RequestParam("code") String code,
+            @RequestParam("redirectUri") String redirectUri,
+            @RequestParam("codeVerifier") String codeVerifier
+    ) {
+        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forX(code, redirectUri, codeVerifier);
+        boolean isWeb = redirectUri.startsWith("http://") || redirectUri.startsWith("https://");
+        return isWeb
+                ? oauthLoginUseCase.readerOAuthLogin(req, OAuthProvider.X)
+                : oauthLoginUseCase.readerOAuthNativeLogin(req, OAuthProvider.X);
+    }
+
     @Operation(summary = "카카오 네이티브 로그인", description = "iOS/Android 네이티브 SDK에서 받은 accessToken/idToken을 그대로 검증하여 로그인합니다.  \n" +
             "회원가입한 유저의 경우 readerLoginResponse로 액세스 토큰을 리프레쉬 토큰 쿠키와 함께 반환합니다.   \n" +
             "회원가입이 필요한 유저의 경우 readerPreLoginResponse로 온보딩 토큰을 반환합니다.")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/OAuthHelper.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/OAuthHelper.java
@@ -7,6 +7,8 @@ import com.storix.infrastructure.external.oauth.client.KakaoInfoClient;
 import com.storix.infrastructure.external.oauth.client.KakaoOAuthClient;
 import com.storix.infrastructure.external.oauth.client.NaverInfoClient;
 import com.storix.infrastructure.external.oauth.client.NaverOAuthClient;
+import com.storix.infrastructure.external.oauth.client.XInfoClient;
+import com.storix.infrastructure.external.oauth.client.XOAuthClient;
 import com.storix.domain.domains.user.dto.*;
 import com.storix.domain.domains.user.domain.OAuthInfo;
 import com.storix.domain.domains.user.domain.OAuthProvider;
@@ -16,6 +18,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import static com.storix.common.utils.STORIXStatic.BEARER;
 
@@ -38,6 +43,10 @@ public class OAuthHelper {
     // 애플
     private final AppleOAuthClient appleOauthClient;
     private final AppleClientSecretHelper appleClientSecretHelper;
+
+    // X
+    private final XOAuthClient xOauthClient;
+    private final XInfoClient xInfoClient;
 
     // 카카오: 인가 코드로 토큰 발급 요청 -> accessToken, idToken
     public KakaoTokenResponse getKakaoOAuthToken(String code, String redirectUri) {
@@ -102,13 +111,51 @@ public class OAuthHelper {
         );
     }
 
+    // X: 인가 코드 -> accessToken (PKCE, Basic 인증)
+    public XTokenResponse getXOAuthToken(String code, String redirectUri, String codeVerifier) {
+        var x = oauthProperties.getX();
+        return xOauthClient.xAuth(
+                buildBasicAuthHeader(x.getClientId(), x.getClientSecret()),
+                "authorization_code",
+                x.getClientId(),
+                redirectUri,
+                code,
+                codeVerifier
+        );
+    }
+
+    // X: 사용자 정보 조회 (accessToken)
+    public XUserResponse getXInformation(String accessToken) {
+        return xInfoClient.getUserInfo(BEARER + accessToken).data();
+    }
+
+    // X: 연동 해제 (refresh_token revoke, best-effort)
+    public void unlinkXUser(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) return;
+        var x = oauthProperties.getX();
+        xOauthClient.xRevoke(
+                buildBasicAuthHeader(x.getClientId(), x.getClientSecret()),
+                refreshToken,
+                "refresh_token",
+                x.getClientId()
+        );
+    }
+
+    // Base64 인코딩
+    private String buildBasicAuthHeader(String clientId, String clientSecret) {
+        String credentials = clientId + ":" + clientSecret;
+        String encoded = Base64.getEncoder()
+                .encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + encoded;
+    }
+
     // OIDC 스펙: OIDC 공개키 목록 조회
     public OIDCPublicKeysResponse getOIDCPublicKeys(OAuthProvider provider) {
         return switch (provider) {
             case KAKAO -> kakaoOauthClient.getKakaoOIDCOpenKeys();
             case NAVER -> naverOauthClient.getNaverOIDCOpenKeys();
             case APPLE -> appleOauthClient.getAppleOIDCOpenKeys();
-            case SLACK -> throw UnsupportedOAuthProviderException.EXCEPTION;
+            case X, SLACK -> throw UnsupportedOAuthProviderException.EXCEPTION;
         };
     }
 
@@ -165,14 +212,15 @@ public class OAuthHelper {
     }
 
     // OIDC 스펙: 검증된 idToken으로 OAuthInfo 반환 (provider, oid)
-    public OAuthInfo getOauthInfoByIdToken(String idToken, OAuthProvider provider, boolean isNative) {
+    public OAuthInfo getOauthInfoByIdToken(String idToken, String oid, OAuthProvider provider, boolean isNative) {
         if (provider == OAuthProvider.SLACK) {
             throw UnsupportedOAuthProviderException.EXCEPTION;
         }
-        if (provider == OAuthProvider.NAVER) {
+        // 비OIDC(Naver/X): oid를 직접 전달받음
+        if (oid != null) {
             return OAuthInfo.builder()
                     .provider(provider)
-                    .oid(idToken) // 네이버인 경우, 일시적으로 idToken 값에 oid 값 반환
+                    .oid(oid)
                     .build();
         }
         // KAKAO, APPLE: OIDC idToken에서 sub 클레임 추출

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/TokenGenerateHelper.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/TokenGenerateHelper.java
@@ -69,7 +69,7 @@ public class TokenGenerateHelper {
     }
 
     @Transactional
-    public OAuthLoginWithTokenResponse generateOAuthLoginWithToken(OAuthInfo oAuthInfo) {
+    public OAuthLoginWithTokenResponse generateOAuthLoginWithToken(OAuthInfo oAuthInfo, String oauthRefreshToken) {
 
         OAuthProvider provider = oAuthInfo.getProvider();
         String oid = oAuthInfo.getOid();
@@ -81,6 +81,7 @@ public class TokenGenerateHelper {
                 .jti(oti.jti())
                 .provider(provider)
                 .oid(oid)
+                .oauthRefreshToken(oauthRefreshToken)
                 .onboardingToken(oti.onboardingToken())
                 .ttl(ttlSeconds)
                 .build();

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -41,6 +41,10 @@ public class AuthUseCase {
                 NaverTokenResponse naverToken = oauthHelper.getNaverOAuthToken(req.authCode(), req.state());
                 yield validateNaver(naverToken.accessToken());
             }
+            case X -> {
+                XTokenResponse xToken = oauthHelper.getXOAuthToken(req.authCode(), req.redirectUri(), req.codeVerifier());
+                yield validateX(xToken.accessToken(), xToken.refreshToken());
+            }
 
             case APPLE, SLACK -> throw UnsupportedOAuthProviderException.EXCEPTION;
         };
@@ -48,7 +52,7 @@ public class AuthUseCase {
 
     // 독자 회원 가입 가능 여부 (Native)
     // - Kakao/Naver: SDK가 내려준 accessToken(+idToken)으로 검증
-    // - Apple: SDK가 내려준 authorizationCode로 토큰을 얻은 뒤 공통 검증
+    // - Apple/X: 앱이 내려준 authorizationCode로 토큰을 얻은 뒤 공통 검증
     public ValidAuthDTO checkAvailableRegisterNative(OAuthAuthorizationRequest req, OAuthProvider provider) {
         return switch (provider) {
             case KAKAO -> validateKakao(req.accessToken(), req.idToken(), true);
@@ -56,6 +60,10 @@ public class AuthUseCase {
             case APPLE -> {
                 AppleTokenResponse appleToken = oauthHelper.getAppleOAuthToken(req.authCode());
                 yield validateApple(appleToken.idToken());
+            }
+            case X -> {
+                XTokenResponse xToken = oauthHelper.getXOAuthToken(req.authCode(), req.redirectUri(), req.codeVerifier());
+                yield validateX(xToken.accessToken(), xToken.refreshToken());
             }
 
             case SLACK -> throw UnsupportedOAuthProviderException.EXCEPTION;
@@ -88,7 +96,7 @@ public class AuthUseCase {
         // accessToken으로 사용자 정보 조회
         KakaoUserResponse kakaoUser = oauthHelper.getKakaoInformation(accessToken);
         // idToken으로 OIDC 검증
-        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, OAuthProvider.KAKAO, isNative);
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, null, OAuthProvider.KAKAO, isNative);
 
         // token 간 정보 일치 확인 후 회원가입 여부 반환
         if (!oauthInfo.getOid().equals(kakaoUser.id())) throw UnknownUserException.EXCEPTION;
@@ -108,8 +116,17 @@ public class AuthUseCase {
     // Apple 공통 검증 로직
     // - Apple은 Web/Native 모두 동일한 clientId(서비스 ID) 를 aud 로 사용하므로 isNative 구분 불필요 → false.
     private ValidAuthDTO validateApple(String idToken) {
-        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, OAuthProvider.APPLE, false);
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, null, OAuthProvider.APPLE, false);
         return authService.validAppleSignup(oauthInfo.getOid(), idToken);
+    }
+
+    // X 공통 검증 로직
+    // accessToken으로 oid 조회, refresh_token은 탈퇴 revoke용 best-effort 보관
+    private ValidAuthDTO validateX(String accessToken, String refreshToken) {
+        XUserResponse xUser = oauthHelper.getXInformation(accessToken);
+
+        if (xUser == null || xUser.id() == null) throw FeignClientServerErrorException.EXCEPTION;
+        return authService.validXSignup(xUser.id(), refreshToken);
     }
 
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LoginUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LoginUseCase.java
@@ -34,10 +34,10 @@ public class LoginUseCase {
      * 독자용
      * */
     // 회원가입한 경우 로그인
-    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerLoginWithIdToken(String idToken, OAuthProvider provider, boolean isNative) {
-        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, provider, isNative);
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerLoginWithIdToken(String idToken, String oid, OAuthProvider provider, boolean isNative, String oauthRefreshToken) {
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, oid, provider, isNative);
 
-        AuthUserDetails userDetails = readerLoginService.execute(oauthInfo);
+        AuthUserDetails userDetails = readerLoginService.execute(oauthInfo, oauthRefreshToken);
         LoginWithTokenResponse loginToken = tokenGenerateHelper.generateLoginWithToken(userDetails);
 
         // Native: body로 access/refresh 둘 다 반환
@@ -59,10 +59,10 @@ public class LoginUseCase {
     }
 
     // 회원가입하지 않은 경우 로그인
-    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerPreLoginWithIdToken(String idToken, OAuthProvider provider, boolean isNative) {
-        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, provider, isNative);
+    public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> readerPreLoginWithIdToken(String idToken, String oid, OAuthProvider provider, boolean isNative, String oauthRefreshToken) {
+        OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, oid, provider, isNative);
 
-        OAuthLoginWithTokenResponse onboardingToken = tokenGenerateHelper.generateOAuthLoginWithToken(oauthInfo);
+        OAuthLoginWithTokenResponse onboardingToken = tokenGenerateHelper.generateOAuthLoginWithToken(oauthInfo, oauthRefreshToken);
 
         ReaderPreLoginResponse readerPreLoginResponse = new ReaderPreLoginResponse(
                 onboardingToken.onboardingToken()

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/OAuthLoginUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/OAuthLoginUseCase.java
@@ -38,9 +38,9 @@ public class OAuthLoginUseCase {
             ValidAuthDTO valid, OAuthProvider provider, boolean isNative
     ) {
         if (valid.isRegistered()) {
-            return loginUseCase.readerLoginWithIdToken(valid.idToken(), provider, isNative);
+            return loginUseCase.readerLoginWithIdToken(valid.idToken(), valid.oid(), provider, isNative, valid.oauthRefreshToken());
         }
-        return loginUseCase.readerPreLoginWithIdToken(valid.idToken(), provider, isNative);
+        return loginUseCase.readerPreLoginWithIdToken(valid.idToken(), valid.oid(), provider, isNative, valid.oauthRefreshToken());
     }
 
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
@@ -32,6 +32,7 @@ public class WithDrawUseCase {
             switch (oauthInfo.getProvider()) {
                 case KAKAO -> oauthHelper.unlinkKakaoUser(oauthInfo.getOid());
                 case NAVER -> oauthHelper.unlinkNaverUser(oauthInfo.getOid());
+                case X -> oauthHelper.unlinkXUser(oauthInfo.getOauthRefreshToken());
                 case SLACK -> {} // admin 만 해당 (연결 해제 불필요)
                 // TODO: Apple 은 refresh_token 저장 후 unlinkAppleUser 호출 필요
                 case APPLE -> {}

--- a/STORIX-Common/src/main/java/com/storix/common/property/OAuthProperties.java
+++ b/STORIX-Common/src/main/java/com/storix/common/property/OAuthProperties.java
@@ -10,11 +10,13 @@ public class OAuthProperties {
     private final KakaoProperties kakao;
     private final NaverProperties naver;
     private final AppleProperties apple;
+    private final XProperties x;
 
-    public OAuthProperties(KakaoProperties kakao, NaverProperties naver, AppleProperties apple) {
+    public OAuthProperties(KakaoProperties kakao, NaverProperties naver, AppleProperties apple, XProperties x) {
         this.kakao = kakao;
         this.naver = naver;
         this.apple = apple;
+        this.x = x;
     }
 
 }

--- a/STORIX-Common/src/main/java/com/storix/common/property/XProperties.java
+++ b/STORIX-Common/src/main/java/com/storix/common/property/XProperties.java
@@ -1,0 +1,16 @@
+package com.storix.common.property;
+
+import lombok.Getter;
+
+@Getter
+public class XProperties {
+
+    private final String clientId;
+    private final String clientSecret;
+
+    public XProperties(String clientId, String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/TokenAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/TokenAdaptor.java
@@ -56,7 +56,10 @@ public class TokenAdaptor {
             throw InvalidTokenException.EXCEPTION;
         }
 
-        return new OnboardingPrincipal(onboardingToken.get().getProvider(), onboardingToken.get().getOid());
+        return new OnboardingPrincipal(
+                onboardingToken.get().getProvider(),
+                onboardingToken.get().getOid(),
+                onboardingToken.get().getOauthRefreshToken());
     }
 
     public void deleteOnboardingTokenByJti(String jti) { onboardingTokenRepository.deleteById(jti);}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OAuthInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OAuthInfo.java
@@ -22,10 +22,18 @@ public class OAuthInfo {
 
     private String oid;
 
+    private String oauthRefreshToken;
+
     @Builder
-    public OAuthInfo(OAuthProvider provider, String oid) {
+    public OAuthInfo(OAuthProvider provider, String oid, String oauthRefreshToken) {
         this.provider = provider;
         this.oid = oid;
+        this.oauthRefreshToken = oauthRefreshToken;
+    }
+
+    // refresh_token 갱신
+    public void updateOauthRefreshToken(String oauthRefreshToken) {
+        this.oauthRefreshToken = oauthRefreshToken;
     }
 
     // 회원 탈퇴 시

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OAuthProvider.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OAuthProvider.java
@@ -10,6 +10,7 @@ public enum OAuthProvider {
     KAKAO("카카오"),
     NAVER("네이버"),
     APPLE("애플"),
+    X("X"),
     SLACK("슬랙");
 
     private final String dbValue;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OnboardingToken.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OnboardingToken.java
@@ -17,6 +17,7 @@ public class OnboardingToken {
 
     private final OAuthProvider provider;
     private final String oid;
+    private final String oauthRefreshToken;
 
     @Indexed
     private final String onboardingToken;
@@ -25,10 +26,11 @@ public class OnboardingToken {
     private final Long ttl;
 
     @Builder
-    public OnboardingToken(String jti, OAuthProvider provider, String oid, String onboardingToken, Long ttl) {
+    public OnboardingToken(String jti, OAuthProvider provider, String oid, String oauthRefreshToken, String onboardingToken, Long ttl) {
         this.jti = jti;
         this.provider = provider;
         this.oid = oid;
+        this.oauthRefreshToken = oauthRefreshToken;
         this.onboardingToken = onboardingToken;
         this.ttl = ttl;
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
@@ -92,7 +92,8 @@ public class User extends BaseTimeEntity {
     @Embedded
     @AttributeOverrides({
             @AttributeOverride(name = "provider", column = @Column(name = "oauth_provider")),
-            @AttributeOverride(name = "oid", column = @Column(name = "oauth_oid"))
+            @AttributeOverride(name = "oid", column = @Column(name = "oauth_oid")),
+            @AttributeOverride(name = "oauthRefreshToken", column = @Column(name = "oauth_refresh_token", length = 1024))
     })
     private OAuthInfo oauthInfo;
 
@@ -113,6 +114,13 @@ public class User extends BaseTimeEntity {
     public void login() {
         // 계정 상태 = 정지 -> 로그인 제한 Exception
         lastLoginAt = LocalDateTime.now();
+    }
+
+    // refresh_token 갱신 (X 등 회전형)
+    public void updateOauthRefreshToken(String oauthRefreshToken) {
+        if (oauthRefreshToken != null) {
+            this.oauthInfo.updateOauthRefreshToken(oauthRefreshToken);
+        }
     }
 
     // 계정 정보 수정

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateDeveloperUserCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateDeveloperUserCommand.java
@@ -16,7 +16,10 @@ public record CreateDeveloperUserCommand(
         Set<Genre> favoriteGenreList
 ) {
     public User toEntity() {
-        OAuthInfo oauthInfo = new OAuthInfo(OAuthProvider.SLACK, oid);
+        OAuthInfo oauthInfo = OAuthInfo.builder()
+                .provider(OAuthProvider.SLACK)
+                .oid(oid)
+                .build();
         Set<Genre> genres = (favoriteGenreList == null) ?
                 Collections.emptySet() : new LinkedHashSet<>(favoriteGenreList);
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateReaderUserCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/CreateReaderUserCommand.java
@@ -13,12 +13,17 @@ public record CreateReaderUserCommand(
         Boolean ageOver14,
         OAuthProvider provider,
         String oid,
+        String oauthRefreshToken,
         String nickName,
         Set<Genre> favoriteGenreList,
         String profileDescription
 ) {
     public User toEntity() {
-        OAuthInfo oauthInfo = new OAuthInfo(provider, oid);
+        OAuthInfo oauthInfo = OAuthInfo.builder()
+                .provider(provider)
+                .oid(oid)
+                .oauthRefreshToken(oauthRefreshToken)
+                .build();
         Set<Genre> genres = (favoriteGenreList == null) ?
                         Collections.emptySet() : new LinkedHashSet<>(favoriteGenreList);
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OAuthAuthorizationRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OAuthAuthorizationRequest.java
@@ -2,37 +2,45 @@ package com.storix.domain.domains.user.dto;
 
 public record OAuthAuthorizationRequest(
         String authCode,
-        String redirectUri, // kakao (web)
-        String state,       // naver (web)
-        String accessToken, // native (kakao, naver)
-        String idToken      // native (kakao OIDC)
+        String redirectUri,  // kakao, naver, x (web)
+        String state,        // naver (web)
+        String accessToken,  // native (kakao, naver)
+        String idToken,      // native (kakao OIDC)
+        String codeVerifier  // x (web, PKCE)
 ) {
     // Web: Kakao Redirect Uri -> authCode
     public static OAuthAuthorizationRequest forKakao(
             String authCode, String redirectUri
     ) {
-        return new OAuthAuthorizationRequest(authCode, redirectUri, null, null, null);
+        return new OAuthAuthorizationRequest(authCode, redirectUri, null, null, null, null);
     }
 
     // Web: Naver Redirect Uri -> authCode + state
     public static OAuthAuthorizationRequest forNaver(
             String authCode, String state
     ) {
-        return new OAuthAuthorizationRequest(authCode, null, state, null, null);
+        return new OAuthAuthorizationRequest(authCode, null, state, null, null, null);
+    }
+
+    // Web: X -> authCode + redirectUri + codeVerifier (PKCE)
+    public static OAuthAuthorizationRequest forX(
+            String authCode, String redirectUri, String codeVerifier
+    ) {
+        return new OAuthAuthorizationRequest(authCode, redirectUri, null, null, null, codeVerifier);
     }
 
     // Native: Apple SDK -> authCode
     public static OAuthAuthorizationRequest forAppleNative(String authCode) {
-        return new OAuthAuthorizationRequest(authCode, null, null, null, null);
+        return new OAuthAuthorizationRequest(authCode, null, null, null, null, null);
     }
 
     // Native: Kakao SDK -> accessToken + idToken
     public static OAuthAuthorizationRequest forKakaoNative(String accessToken, String idToken) {
-        return new OAuthAuthorizationRequest(null, null, null, accessToken, idToken);
+        return new OAuthAuthorizationRequest(null, null, null, accessToken, idToken, null);
     }
 
     // Native: Naver SDK -> accessToken
     public static OAuthAuthorizationRequest forNaverNative(String accessToken) {
-        return new OAuthAuthorizationRequest(null, null, null, accessToken, null);
+        return new OAuthAuthorizationRequest(null, null, null, accessToken, null, null);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OnboardingPrincipal.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OnboardingPrincipal.java
@@ -4,5 +4,6 @@ import com.storix.domain.domains.user.domain.OAuthProvider;
 
 public record OnboardingPrincipal(
         OAuthProvider provider,
-        String oid
+        String oid,
+        String oauthRefreshToken
 ) {}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ValidAuthDTO.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ValidAuthDTO.java
@@ -2,6 +2,17 @@ package com.storix.domain.domains.user.dto;
 
 public record ValidAuthDTO(
         boolean isRegistered,
-        String idToken
+        String idToken,           // OIDC provider(Kakao/Apple)만, 그 외 null
+        String oid,               // 비OIDC provider(Naver/X)만, 그 외 null
+        String oauthRefreshToken  // unlink 정책 있는 provider만, 그 외 null
 ) {
+    // OIDC provider(Kakao/Apple): idToken에서 oid 추출
+    public static ValidAuthDTO ofIdToken(boolean isRegistered, String idToken) {
+        return new ValidAuthDTO(isRegistered, idToken, null, null);
+    }
+
+    // 비OIDC provider(Naver/X): oid 직접 전달
+    public static ValidAuthDTO ofOid(boolean isRegistered, String oid, String oauthRefreshToken) {
+        return new ValidAuthDTO(isRegistered, null, oid, oauthRefreshToken);
+    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/XProfileResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/XProfileResponse.java
@@ -1,0 +1,9 @@
+package com.storix.domain.domains.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record XProfileResponse(
+        XUserResponse data // { "data": { "id", "name", "username" } }
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/XTokenResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/XTokenResponse.java
@@ -1,0 +1,12 @@
+package com.storix.domain.domains.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record XTokenResponse(
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("expires_in") Long expiresIn,
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("scope") String scope,
+        @JsonProperty("refresh_token") String refreshToken
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/XUserResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/XUserResponse.java
@@ -1,0 +1,8 @@
+package com.storix.domain.domains.user.dto;
+
+public record XUserResponse(
+        String id,
+        String name,
+        String username
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -57,21 +57,28 @@ public class AuthService {
     @Transactional(readOnly = true)
     public ValidAuthDTO validKakaoSignup(String kakaoUserId, String idToken) {
         boolean isRegistered = userAdaptor.isUserPresentWithProviderAndOid(OAuthProvider.KAKAO, kakaoUserId);
-        return new ValidAuthDTO(isRegistered, idToken);
+        return ValidAuthDTO.ofIdToken(isRegistered, idToken);
     }
 
     // - 네이버
     @Transactional(readOnly = true)
     public ValidAuthDTO validNaverSignup(String naverUserId) {
         boolean isRegistered = userAdaptor.isUserPresentWithProviderAndOid(OAuthProvider.NAVER, naverUserId);
-        return new ValidAuthDTO(isRegistered, naverUserId);
+        return ValidAuthDTO.ofOid(isRegistered, naverUserId, null);
     }
 
     // - 애플
     @Transactional(readOnly = true)
     public ValidAuthDTO validAppleSignup(String appleUserId, String idToken) {
         boolean isRegistered = userAdaptor.isUserPresentWithProviderAndOid(OAuthProvider.APPLE, appleUserId);
-        return new ValidAuthDTO(isRegistered, idToken);
+        return ValidAuthDTO.ofIdToken(isRegistered, idToken);
+    }
+
+    // - X
+    @Transactional(readOnly = true)
+    public ValidAuthDTO validXSignup(String xUserId, String oauthRefreshToken) {
+        boolean isRegistered = userAdaptor.isUserPresentWithProviderAndOid(OAuthProvider.X, xUserId);
+        return ValidAuthDTO.ofOid(isRegistered, xUserId, oauthRefreshToken);
     }
 
     // 독자 회원 가입 (소셜 로그인)
@@ -81,6 +88,7 @@ public class AuthService {
         // 1. 온보딩 토큰 정보 조회
         OnboardingPrincipal principal = tokenAdaptor.findOnboardingPrincipalByJti(jti);
         OAuthProvider provider = principal.provider(); String oid = principal.oid();
+        String oauthRefreshToken = principal.oauthRefreshToken();
 
         // 2. 회원 가입 관련 검증
         boolean isUserPresent = userAdaptor.isUserPresentWithProviderAndOid(provider, oid);
@@ -97,6 +105,7 @@ public class AuthService {
                 cmd.ageOver14(),
                 provider,
                 oid,
+                oauthRefreshToken,
                 cmd.nickName(),
                 cmd.favoriteGenreList(),
                 cmd.profileDescription()

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/DeveloperAuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/DeveloperAuthService.java
@@ -84,7 +84,10 @@ public class DeveloperAuthService {
     public AuthUserDetails loginDeveloper(String pendingId) {
         try {
             User user = userAdaptor.findReaderUserByOAuthInfo(
-                    new OAuthInfo(OAuthProvider.SLACK, pendingId));
+                    OAuthInfo.builder()
+                            .provider(OAuthProvider.SLACK)
+                            .oid(pendingId)
+                            .build());
             user.login();
             return new AuthUserDetails(user.getId(), user.getRole());
         } catch (Exception e) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/ReaderLoginService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/ReaderLoginService.java
@@ -6,6 +6,7 @@ import com.storix.domain.domains.user.domain.OAuthInfo;
 import com.storix.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,9 +15,11 @@ public class ReaderLoginService {
     private final UserAdaptor userAdaptor;
 
     // 회원가입한 경우 로그인 처리
-    public AuthUserDetails execute(OAuthInfo oauthInfo) {
+    @Transactional
+    public AuthUserDetails execute(OAuthInfo oauthInfo, String oauthRefreshToken) {
         User user = userAdaptor.findReaderUserByOAuthInfo(oauthInfo);
         user.login();
+        user.updateOauthRefreshToken(oauthRefreshToken);
         return new AuthUserDetails(user.getId(), user.getRole());
     }
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/FeignClientConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/FeignClientConfig.java
@@ -5,6 +5,8 @@ import com.storix.infrastructure.external.oauth.client.KakaoInfoClient;
 import com.storix.infrastructure.external.oauth.client.KakaoOAuthClient;
 import com.storix.infrastructure.external.oauth.client.NaverInfoClient;
 import com.storix.infrastructure.external.oauth.client.NaverOAuthClient;
+import com.storix.infrastructure.external.oauth.client.XInfoClient;
+import com.storix.infrastructure.external.oauth.client.XOAuthClient;
 import feign.codec.Encoder;
 import feign.form.FormEncoder;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -17,7 +19,9 @@ import org.springframework.context.annotation.Configuration;
         KakaoOAuthClient.class,
         NaverInfoClient.class,
         NaverOAuthClient.class,
-        AppleOAuthClient.class
+        AppleOAuthClient.class,
+        XOAuthClient.class,
+        XInfoClient.class
 })
 public class FeignClientConfig {
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/client/XInfoClient.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/client/XInfoClient.java
@@ -1,0 +1,18 @@
+package com.storix.infrastructure.external.oauth.client;
+
+import com.storix.domain.domains.user.dto.XProfileResponse;
+import com.storix.infrastructure.external.oauth.config.XInfoConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(
+        name = "XInfoClient",
+        url = "https://api.x.com",
+        configuration = XInfoConfig.class
+)
+public interface XInfoClient {
+    // 사용자 정보 조회 (accessToken)
+    @GetMapping("/2/users/me")
+    XProfileResponse getUserInfo(@RequestHeader("Authorization") String authorization);
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/client/XOAuthClient.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/client/XOAuthClient.java
@@ -1,0 +1,36 @@
+package com.storix.infrastructure.external.oauth.client;
+
+import com.storix.domain.domains.user.dto.XTokenResponse;
+import com.storix.infrastructure.external.oauth.config.XOauthConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "XOAuthClient",
+        url = "https://api.x.com",
+        configuration = XOauthConfig.class
+)
+public interface XOAuthClient {
+
+    // 인가 코드로 토큰 발급 (PKCE, Basic 인증)
+    @PostMapping("/2/oauth2/token")
+    XTokenResponse xAuth(
+            @RequestHeader("Authorization") String basicAuth,
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("code") String code,
+            @RequestParam("code_verifier") String codeVerifier
+    );
+
+    // 토큰 폐기 (탈퇴 시 연동 해제, Basic 인증)
+    @PostMapping("/2/oauth2/revoke")
+    void xRevoke(
+            @RequestHeader("Authorization") String basicAuth,
+            @RequestParam("token") String token,
+            @RequestParam("token_type_hint") String tokenTypeHint,
+            @RequestParam("client_id") String clientId
+    );
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/config/XInfoConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/config/XInfoConfig.java
@@ -1,0 +1,15 @@
+package com.storix.infrastructure.external.oauth.config;
+
+import com.storix.infrastructure.external.oauth.exception.decoder.XOauthErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class XInfoConfig {
+
+    @Bean
+    public ErrorDecoder xInfoErrorDecoder() {
+        return new XOauthErrorDecoder();
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/config/XOauthConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/config/XOauthConfig.java
@@ -1,0 +1,15 @@
+package com.storix.infrastructure.external.oauth.config;
+
+import com.storix.infrastructure.external.oauth.exception.decoder.XOauthErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class XOauthConfig {
+
+    @Bean
+    public ErrorDecoder xOauthErrorDecoder() {
+        return new XOauthErrorDecoder();
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/exception/decoder/XOauthErrorDecoder.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/exception/decoder/XOauthErrorDecoder.java
@@ -1,0 +1,54 @@
+package com.storix.infrastructure.external.oauth.exception.decoder;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+import com.storix.infrastructure.external.oauth.exception.dto.XOauthErrorResponse;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class XOauthErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        log.error("[X] OAuth 에러 응답 수신: methodKey={}, status={}, reason={}",
+                methodKey, response.status(), response.reason());
+
+        XOauthErrorResponse body = XOauthErrorResponse.from(response);
+        log.error("[X] OAuth 에러 본문: error={}, errorDescription={}",
+                body.error(), body.errorDescription());
+
+        String error = body.error();
+        String desc = body.errorDescription();
+        if (error == null) {
+            return new STORIXCodeException(ErrorCode.XOE_INVALID_REQUEST);
+        }
+
+        // X는 인가 코드 만료/무효/재사용도 invalid_request로 내려주므로 description으로 구분
+        boolean isAuthCodeProblem = desc != null && desc.toLowerCase().contains("authorization code");
+
+        return switch (error) {
+            case "invalid_client", "unauthorized_client" -> {
+                log.error("[X] {}: client_id/client_secret(Basic 인증) 검증 실패 가능성", error);
+                yield new STORIXCodeException(ErrorCode.XOE_UNAUTHORIZED_CLIENT);
+            }
+            case "invalid_grant" -> {
+                log.error("[X] invalid_grant: 인가 코드 만료/재사용, redirect_uri 또는 code_verifier 불일치 가능성");
+                yield new STORIXCodeException(ErrorCode.XOE_INVALID_GRANT);
+            }
+            case "invalid_request" -> {
+                if (isAuthCodeProblem) {
+                    log.error("[X] invalid_request: 인가 코드 만료/무효/재사용 (유효시간 약 30초)");
+                    yield new STORIXCodeException(ErrorCode.XOE_INVALID_GRANT);
+                }
+                log.error("[X] invalid_request: 파라미터 누락/형식 오류 가능성");
+                yield new STORIXCodeException(ErrorCode.XOE_INVALID_REQUEST);
+            }
+            default -> {
+                log.error("[X] 처리되지 않은 error 타입: {}", error);
+                yield new STORIXCodeException(ErrorCode.XOE_INVALID_REQUEST);
+            }
+        };
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/exception/dto/XOauthErrorResponse.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/exception/dto/XOauthErrorResponse.java
@@ -1,0 +1,32 @@
+package com.storix.infrastructure.external.oauth.exception.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.storix.domain.domains.user.exception.oauth.UnHandleException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record XOauthErrorResponse(
+        String error,
+        String errorDescription
+) {
+    public static XOauthErrorResponse from(feign.Response response) {
+        try (var is = response.body().asInputStream()) {
+            byte[] raw = is.readAllBytes();
+            String rawBody = new String(raw, StandardCharsets.UTF_8);
+            log.error("[X] 원본 에러 응답 본문: {}", rawBody);
+            return new ObjectMapper().readValue(raw, XOauthErrorResponse.class);
+        } catch (IOException e) {
+            log.error("[X] 에러 응답 JSON 파싱 실패: type={}, message={}",
+                    e.getClass().getSimpleName(), e.getMessage(), e);
+            throw UnHandleException.EXCEPTION;
+        }
+    }
+}


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. X(트위터) 소셜 로그인 추가
- confidential client로, 토큰 교환 시 `Authorization: Basic base64(clientId:clientSecret)` 헤더로 인증합니다.
- 단일 엔드포인트(`GET /api/v1/auth/oauth/x/login`)에서 **redirectUri 스킴으로 웹/앱을 구분**합니다.
  - 웹(http/https): accessToken은 body, refreshToken은 쿠키로 반환 (백엔드에서 테스트 시 127.0.0.1/3000 번대로 하시면 됩니다)
  - 앱(커스텀 스킴, 예: `storix://`): access/refresh 토큰을 body로 반환

### 2. 회원 탈퇴 시 X 연동 해제 (best-effort)
- 별도 API 없이 회원 탈퇴 플로우(`WithDrawUseCase`)에 통합했습니다.
- 로그인 시 X refresh_token을 User에 보관하고(가입 전에는 온보딩 토큰으로 전달), 재로그인 시마다 갱신합니다.
- 탈퇴 시 보관한 refresh_token으로 X의 토큰 폐기 엔드포인트(`/2/oauth2/revoke`)를 호출해 연동을 해제합니다.
- revoke 실패(토큰 만료/무효 등) 시에도 탈퇴는 정상 진행되도록 best-effort(try/catch)로 처리했습니다.
   - 현재 서비스 내 인가 진입 경로가 1) 소셜 로그인 재시도, 2) 토큰 재발급 (RefreshToken Rotation) 인데, 토큰 재발급을 통해 진입 후 회원탈퇴를 시도하는 경우, X-RefreshToken TTL이 소셜 로그인 시도 후 +2시간 인점을 감안하면 토큰 만료로 revoke가 실패합니다. 다만 토큰을 주기적으로 관리하는 데 드는 리소스가 큰 데 비해, 정책상 X에서 연결 해제가 필수는 아닌 것으로 알고 있어 best-effort 구조로 두었습니다. (추후 정책상 반영이 필요할 경우 강제 재로그인을 시키는 것이 더 좋을 것 같습니다.)

### 3. X 전용 에러 디코더 추가
- 토큰 엔드포인트 에러를 `XOE_*` 코드로 매핑합니다.
- 인가 코드 만료/무효/재사용은 X가 `invalid_request`로 내려주므로, description으로 구분해 `XOE_INVALID_GRANT`로 처리합니다.

### 4. 기타
- `ValidAuthDTO`에 `oid` 필드를 분리해, 기존 idToken 파라미터로 oid를 보내고 주석을 달아서 암묵적으로 처리하던 로직을 제거했습니다.
- `getOauthInfoByIdToken(idToken, oid, provider, isNative)`로 명시화했습니다. (oid 있으면 그대로, 없으면 idToken 디코딩)
- `OAuthInfo`에 `oauthRefreshToken` 필드를 추가했습니다. (Apple에서는 RefreshToken TTL이 영구적이고, 앱스토어 정책 상 회원 탈퇴 시 unlink가 필수적이라고 하여 이후 PR에서 반영할 예정입니다.)

## 📸 작업 화면 (스크린샷)
- STORIX X공식 계정으로 developers 등록해두었으며, 앱 정보 세팅 완료하였습니다. 
- 현재는 Development 환경에 두었으며 추후 배포 시 Production으로 옮겨야 합니다. (환경변수 변경 없음)
<img width="550" height="717" alt="스크린샷 2026-06-12 오후 6 24 19" src="https://github.com/user-attachments/assets/3e61077d-6c0c-49c2-b18a-1b7dd920519e" />

<img width="532" height="386" alt="스크린샷 2026-06-12 오후 6 24 32" src="https://github.com/user-attachments/assets/dcd01cdc-d303-485e-97b7-aa388ee4e6d9" />

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #88 

## 🖇️ 기타
배포 전 X 관련 환경변수를 서버에 등록해야 합니다.