### PR TITLE
Refactor: [인증] Apple/Naver 로그인 refresh_token 저장 및 탈퇴 시 연동 해제 추가

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/AuthController.java
@@ -108,7 +108,7 @@ public class AuthController {
     public ResponseEntity<CustomResponse<ReaderSocialLoginResponse>> naverNativeLogin(
             @Valid @RequestBody NaverNativeLoginRequest body
     ) {
-        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forNaverNative(body.accessToken());
+        OAuthAuthorizationRequest req = OAuthAuthorizationRequest.forNaverNative(body.accessToken(), body.refreshToken());
         return oauthLoginUseCase.readerOAuthNativeLogin(req, OAuthProvider.NAVER);
     }
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/NaverNativeLoginRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/NaverNativeLoginRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 
 public record NaverNativeLoginRequest(
         @NotBlank(message = "accessToken은 필수입니다.")
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/OAuthHelper.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/helper/OAuthHelper.java
@@ -93,10 +93,14 @@ public class OAuthHelper {
         return naverInfoClient.getUserInfo(BEARER + accessToken).response();
     }
 
-    // 네이버: 사용자 연결 해제
-    public void unlinkNaverUser(String oid) {
+    // 네이버: 연동 해제 (refresh_token으로 access 재발급 후 delete, best-effort)
+    public void unlinkNaverUser(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) return;
         var naver = oauthProperties.getNaver();
-        // 네이버는 토큰 캐싱 및 주기적 갱신 필요
+        NaverTokenResponse refreshed = naverOauthClient.naverRefresh(
+                "refresh_token", naver.getClientId(), naver.getClientSecret(), refreshToken);
+        naverOauthClient.naverDelete(
+                "delete", naver.getClientId(), naver.getClientSecret(), refreshed.accessToken(), "NAVER");
     }
 
     // 애플: 인가 코드로 토큰 발급 요청 -> accessToken, idToken (네이티브 전용)
@@ -108,6 +112,19 @@ public class OAuthHelper {
                 apple.getClientId(),
                 clientSecret,
                 code
+        );
+    }
+
+    // 애플: 연동 해제 (refresh_token revoke, best-effort)
+    public void unlinkAppleUser(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) return;
+        var apple = oauthProperties.getApple();
+        String clientSecret = appleClientSecretHelper.generateClientSecret();
+        appleOauthClient.appleRevoke(
+                apple.getClientId(),
+                clientSecret,
+                refreshToken,
+                "refresh_token"
         );
     }
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -39,7 +39,7 @@ public class AuthUseCase {
             }
             case NAVER -> {
                 NaverTokenResponse naverToken = oauthHelper.getNaverOAuthToken(req.authCode(), req.state());
-                yield validateNaver(naverToken.accessToken());
+                yield validateNaver(naverToken.accessToken(), naverToken.refreshToken());
             }
             case X -> {
                 XTokenResponse xToken = oauthHelper.getXOAuthToken(req.authCode(), req.redirectUri(), req.codeVerifier());
@@ -56,10 +56,10 @@ public class AuthUseCase {
     public ValidAuthDTO checkAvailableRegisterNative(OAuthAuthorizationRequest req, OAuthProvider provider) {
         return switch (provider) {
             case KAKAO -> validateKakao(req.accessToken(), req.idToken(), true);
-            case NAVER -> validateNaver(req.accessToken());
+            case NAVER -> validateNaver(req.accessToken(), req.refreshToken());
             case APPLE -> {
                 AppleTokenResponse appleToken = oauthHelper.getAppleOAuthToken(req.authCode());
-                yield validateApple(appleToken.idToken());
+                yield validateApple(appleToken.idToken(), appleToken.refreshToken());
             }
             case X -> {
                 XTokenResponse xToken = oauthHelper.getXOAuthToken(req.authCode(), req.redirectUri(), req.codeVerifier());
@@ -104,20 +104,21 @@ public class AuthUseCase {
     }
 
     // Naver 공통 검증 로직
-    private ValidAuthDTO validateNaver(String accessToken) {
+    private ValidAuthDTO validateNaver(String accessToken, String refreshToken) {
         // accessToken으로 사용자 정보 조회
         NaverUserResponse naverUser = oauthHelper.getNaverInformation(accessToken);
 
         // token 간 정보 일치 확인 후 회원가입 여부 반환
         if (naverUser.id() == null) throw FeignClientServerErrorException.EXCEPTION;
-        return authService.validNaverSignup(naverUser.id());
+        return authService.validNaverSignup(naverUser.id(), refreshToken);
     }
 
     // Apple 공통 검증 로직
     // - Apple은 Web/Native 모두 동일한 clientId(서비스 ID) 를 aud 로 사용하므로 isNative 구분 불필요 → false.
-    private ValidAuthDTO validateApple(String idToken) {
+    // - refresh_token은 탈퇴 시 연동 해제(revoke)용으로 보관
+    private ValidAuthDTO validateApple(String idToken, String refreshToken) {
         OAuthInfo oauthInfo = oauthHelper.getOauthInfoByIdToken(idToken, null, OAuthProvider.APPLE, false);
-        return authService.validAppleSignup(oauthInfo.getOid(), idToken);
+        return authService.validAppleSignup(oauthInfo.getOid(), idToken, refreshToken);
     }
 
     // X 공통 검증 로직

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
@@ -31,11 +31,10 @@ public class WithDrawUseCase {
         try {
             switch (oauthInfo.getProvider()) {
                 case KAKAO -> oauthHelper.unlinkKakaoUser(oauthInfo.getOid());
-                case NAVER -> oauthHelper.unlinkNaverUser(oauthInfo.getOid());
+                case NAVER -> oauthHelper.unlinkNaverUser(oauthInfo.getOauthRefreshToken());
                 case X -> oauthHelper.unlinkXUser(oauthInfo.getOauthRefreshToken());
+                case APPLE -> oauthHelper.unlinkAppleUser(oauthInfo.getOauthRefreshToken());
                 case SLACK -> {} // admin 만 해당 (연결 해제 불필요)
-                // TODO: Apple 은 refresh_token 저장 후 unlinkAppleUser 호출 필요
-                case APPLE -> {}
             }
         } catch (Exception e) {
             log.warn("OAuth unlink failed; continuing withdraw. userId={}, provider={}",

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/AppleTokenResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/AppleTokenResponse.java
@@ -6,6 +6,7 @@ public record AppleTokenResponse(
         @JsonProperty("access_token") String accessToken,
         @JsonProperty("id_token") String idToken,
         @JsonProperty("token_type") String tokenType,
-        @JsonProperty("expires_in") Long expiresIn
+        @JsonProperty("expires_in") Long expiresIn,
+        @JsonProperty("refresh_token") String refreshToken
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/NaverTokenResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/NaverTokenResponse.java
@@ -3,7 +3,7 @@ package com.storix.domain.domains.user.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record NaverTokenResponse(
-        @JsonProperty("access_token") String accessToken
-        // @JsonProperty("id_token") String idToken
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OAuthAuthorizationRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/OAuthAuthorizationRequest.java
@@ -6,41 +6,42 @@ public record OAuthAuthorizationRequest(
         String state,        // naver (web)
         String accessToken,  // native (kakao, naver)
         String idToken,      // native (kakao OIDC)
-        String codeVerifier  // x (web, PKCE)
+        String codeVerifier, // x (web, PKCE)
+        String refreshToken  // naver (native)
 ) {
     // Web: Kakao Redirect Uri -> authCode
     public static OAuthAuthorizationRequest forKakao(
             String authCode, String redirectUri
     ) {
-        return new OAuthAuthorizationRequest(authCode, redirectUri, null, null, null, null);
+        return new OAuthAuthorizationRequest(authCode, redirectUri, null, null, null, null, null);
     }
 
     // Web: Naver Redirect Uri -> authCode + state
     public static OAuthAuthorizationRequest forNaver(
             String authCode, String state
     ) {
-        return new OAuthAuthorizationRequest(authCode, null, state, null, null, null);
+        return new OAuthAuthorizationRequest(authCode, null, state, null, null, null, null);
     }
 
     // Web: X -> authCode + redirectUri + codeVerifier (PKCE)
     public static OAuthAuthorizationRequest forX(
             String authCode, String redirectUri, String codeVerifier
     ) {
-        return new OAuthAuthorizationRequest(authCode, redirectUri, null, null, null, codeVerifier);
+        return new OAuthAuthorizationRequest(authCode, redirectUri, null, null, null, codeVerifier, null);
     }
 
     // Native: Apple SDK -> authCode
     public static OAuthAuthorizationRequest forAppleNative(String authCode) {
-        return new OAuthAuthorizationRequest(authCode, null, null, null, null, null);
+        return new OAuthAuthorizationRequest(authCode, null, null, null, null, null, null);
     }
 
     // Native: Kakao SDK -> accessToken + idToken
     public static OAuthAuthorizationRequest forKakaoNative(String accessToken, String idToken) {
-        return new OAuthAuthorizationRequest(null, null, null, accessToken, idToken, null);
+        return new OAuthAuthorizationRequest(null, null, null, accessToken, idToken, null, null);
     }
 
     // Native: Naver SDK -> accessToken
-    public static OAuthAuthorizationRequest forNaverNative(String accessToken) {
-        return new OAuthAuthorizationRequest(null, null, null, accessToken, null, null);
+    public static OAuthAuthorizationRequest forNaverNative(String accessToken, String refreshToken) {
+        return new OAuthAuthorizationRequest(null, null, null, accessToken, null, null, refreshToken);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ValidAuthDTO.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/dto/ValidAuthDTO.java
@@ -6,9 +6,14 @@ public record ValidAuthDTO(
         String oid,               // 비OIDC provider(Naver/X)만, 그 외 null
         String oauthRefreshToken  // unlink 정책 있는 provider만, 그 외 null
 ) {
-    // OIDC provider(Kakao/Apple): idToken에서 oid 추출
+    // OIDC provider(Kakao): idToken에서 oid 추출
     public static ValidAuthDTO ofIdToken(boolean isRegistered, String idToken) {
         return new ValidAuthDTO(isRegistered, idToken, null, null);
+    }
+
+    // OIDC provider(Apple): idToken에서 oid 추출 + refresh_token 보관
+    public static ValidAuthDTO ofIdToken(boolean isRegistered, String idToken, String oauthRefreshToken) {
+        return new ValidAuthDTO(isRegistered, idToken, null, oauthRefreshToken);
     }
 
     // 비OIDC provider(Naver/X): oid 직접 전달

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -62,16 +62,16 @@ public class AuthService {
 
     // - 네이버
     @Transactional(readOnly = true)
-    public ValidAuthDTO validNaverSignup(String naverUserId) {
+    public ValidAuthDTO validNaverSignup(String naverUserId, String oauthRefreshToken) {
         boolean isRegistered = userAdaptor.isUserPresentWithProviderAndOid(OAuthProvider.NAVER, naverUserId);
-        return ValidAuthDTO.ofOid(isRegistered, naverUserId, null);
+        return ValidAuthDTO.ofOid(isRegistered, naverUserId, oauthRefreshToken);
     }
 
     // - 애플
     @Transactional(readOnly = true)
-    public ValidAuthDTO validAppleSignup(String appleUserId, String idToken) {
+    public ValidAuthDTO validAppleSignup(String appleUserId, String idToken, String oauthRefreshToken) {
         boolean isRegistered = userAdaptor.isUserPresentWithProviderAndOid(OAuthProvider.APPLE, appleUserId);
-        return ValidAuthDTO.ofIdToken(isRegistered, idToken);
+        return ValidAuthDTO.ofIdToken(isRegistered, idToken, oauthRefreshToken);
     }
 
     // - X

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/client/AppleOAuthClient.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/client/AppleOAuthClient.java
@@ -25,6 +25,15 @@ public interface AppleOAuthClient {
             @RequestParam("code") String code
     );
 
+    // 토큰 폐기 (회원 탈퇴 시 연동 해제)
+    @PostMapping("/auth/revoke")
+    void appleRevoke(
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("token") String token,
+            @RequestParam("token_type_hint") String tokenTypeHint
+    );
+
     // OIDC 공개키 목록 조회 (id_token 서명 검증용)
     @Cacheable(cacheNames = "AppleOIDC", cacheManager = "oidcCacheManager")
     @GetMapping("/auth/keys")

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/client/NaverOAuthClient.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/oauth/client/NaverOAuthClient.java
@@ -26,6 +26,25 @@ public interface NaverOAuthClient {
             @RequestParam("state") String state
     );
 
+    // refresh_token으로 access_token 재발급
+    @PostMapping("/oauth2.0/token")
+    NaverTokenResponse naverRefresh(
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("refresh_token") String refreshToken
+    );
+
+    // 연동 해제 (회원 탈퇴)
+    @PostMapping("/oauth2.0/token")
+    void naverDelete(
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("access_token") String accessToken,
+            @RequestParam("service_provider") String serviceProvider
+    );
+
     // OIDC 공개키 목록 조회 (인증용)
     @Cacheable(cacheNames = "NaverOIDC", cacheManager = "oidcCacheManager")
     @GetMapping("/jwks")


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. Apple 회원 탈퇴 시 연동 해제 (revoke)
- 로그인 시 Apple `refresh_token`을 함께 받아 User에 저장합니다. (`AppleTokenResponse`에 refresh_token 필드 추가)
- 탈퇴 시 `client_secret`(JWT) + refresh_token으로 Apple `/auth/revoke`를 호출해 연동을 해제합니다.
- 앱스토어 정책상 Sign in with Apple은 계정 삭제 시 토큰 폐기가 필수이며, Apple refresh_token은 만료/회전이 없어 탈퇴 시점에도 유효하게 동작합니다.

### 2. Naver 회원 탈퇴 시 연동 해제 (revoke)
- 로그인 시 Naver `refresh_token`을 저장합니다.
- 탈퇴 시 Naver 연동 해제(`grant_type=delete`)는 유효한 access_token이 필요하므로, 저장한 refresh_token으로 access_token을 재발급한 뒤 delete를 호출합니다.
- DTO 제약을 추가하진 않았습니다. 프론트에서 refreshToken 추가 필드 반환이 필요합니다.

### 3. 기타
- 연동 해제는 모두 best-effort로 처리해두었습니다. `WithDrawUseCase`의 try/catch로 감싸 revoke 실패(토큰 만료/무효 등) 시에도 탈퇴는 정상 진행됩니다. 재시도 워커 처리가 추가로 필요할 듯 합니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #90 

## 🖇️ 기타