### PR TITLE
Fix: 쿼리 수정

### DIFF
--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/domain/ReaderBoardReply.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/domain/ReaderBoardReply.java
@@ -4,6 +4,7 @@ import com.storix.domain.domains.plus.domain.DeletedBy;
 import com.storix.domain.domains.plus.domain.ReaderBoard;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ public class ReaderBoardReply extends BoardReply {
 
     @ToString.Exclude
     @OneToMany(mappedBy = "parentReply")
+    @SQLRestriction("deleted = false")
     private List<ReaderBoardReply> childReplies = new ArrayList<>();
 
     @ToString.Exclude

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/repository/ReaderBoardReplyRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/repository/ReaderBoardReplyRepository.java
@@ -58,8 +58,9 @@ public interface ReaderBoardReplyRepository extends JpaRepository<ReaderBoardRep
     Optional<Long> findActiveUserIdByIdAndBoardId(@Param("replyId") Long replyId, @Param("boardId") Long boardId);
 
     // 피드 댓글 조회 (최상위 댓글 + 답댓글 fetch join) — 삭제된 댓글 제외
-    @Query("SELECT DISTINCT r FROM ReaderBoardReply r " +
-            "LEFT JOIN FETCH r.childReplies c ON c.deleted = false " +
+    // FETCH JOIN with ON clause is invalid in JPQL; deleted filter applied via @SQLRestriction on childReplies
+    @Query("SELECT r FROM ReaderBoardReply r " +
+            "LEFT JOIN FETCH r.childReplies " +
             "WHERE r.board.id = :boardId AND r.parentReply IS NULL AND r.deleted = false")
     Slice<ReaderBoardReply> findAllByBoard_Id(@Param("boardId") Long boardId, Pageable pageable);
 


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> -  ReaderBoardReplyRepository.findAllByBoard_Id JPQL 쿼리의 LEFT JOIN FETCH ... ON 절 제거 — JPQL은 FETCH JOIN에 ON 조건을 지원하지 않아 애플리케이션 기동 시 query validation 실패로 서버가 뜨지 않던 문제 수정
- ReaderBoardReply.childReplies에 @SQLRestriction("deleted = false") 추가 — 기존 ON c.deleted = false가 담당하던 삭제된 답댓글 필터링을 SQL 레벨에서 유지

++ 로컬에서 실행할 때 고쳤던 에러였는데 머지하면서 오류 생긴듯 합니다 ^ㅠ^

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
## 🖇️ 기타