### PR TITLE
Fix: Batch 모듈 PasswordEncoder 의존성 누락 문제 해결

### DIFF
--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/PasswordEncoderConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/PasswordEncoderConfig.java
@@ -1,0 +1,16 @@
+package com.storix.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
@@ -16,7 +16,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
@@ -42,6 +41,7 @@ public class SecurityConfig {
     private final SecurityEntryPoint securityEntryPoint;
     private final SecurityDeniedHandler securityDeniedHandler;
     private final Environment environment;
+    private final PasswordEncoder passwordEncoder;
 
     @Value("${swagger.user:}")
     private String swaggerUser;
@@ -68,12 +68,12 @@ public class SecurityConfig {
         } else {
             InMemoryUserDetailsManager swaggerUserDetailsManager = new InMemoryUserDetailsManager(
                     User.withUsername(swaggerUser)
-                            .password(passwordEncoder().encode(swaggerPassword))
+                            .password(passwordEncoder.encode(swaggerPassword))
                             .roles("SWAGGER")
                             .build()
             );
             DaoAuthenticationProvider swaggerAuthProvider = new DaoAuthenticationProvider(swaggerUserDetailsManager);
-            swaggerAuthProvider.setPasswordEncoder(passwordEncoder());
+            swaggerAuthProvider.setPasswordEncoder(passwordEncoder);
 
             http
                     .authenticationProvider(swaggerAuthProvider)
@@ -181,11 +181,6 @@ public class SecurityConfig {
     @Bean
     public RoleHierarchy roleHierarchy() {
         return RoleHierarchyImpl.fromHierarchy("ROLE_SUPER_ADMIN > ROLE_ADMIN > ROLE_READER");
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
     }
 
 }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### Batch 모듈 PasswordEncoder 의존성 누락 문제 해결
[문제]
- #97 
작업에서 Domain 모듈에 있는 AdminAuthService에 PasswordEncoder 빈 의존성을 주입하였음
-> PasswordEncoder 빈은 Infrasturcture 모듈에 있는 SpringSecurity 클래스에서 정의되어 있음
Batch 컨테이너에서 PasswordEncoder 의존성을 찾지 못하고 죽어버리는 문제 발생

[해결방법]
- PasswordEncoder 빈을 @ Configuation에 등록
- SpringSecurity 파일에서 정의된 의존성을 제거

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #99 

## 🖇️ 기타