### PR TITLE
Fix: [알림] 푸시 알림 중복 발송 및 세션 만료 기기 발송 차단

### DIFF
--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/StalePushDeviceScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/StalePushDeviceScheduler.java
@@ -1,0 +1,31 @@
+package com.storix.batch.scheduler;
+
+import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StalePushDeviceScheduler {
+
+    private static final int INACTIVE_DAYS = 29;
+
+    private final PushDeviceAdaptor pushDeviceAdaptor;
+
+    @Scheduled(cron = "0 40 4 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void deactivateStaleDevices() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(INACTIVE_DAYS);
+        int deactivated = pushDeviceAdaptor.deactivateStaleDevices(threshold);
+        if (deactivated > 0) {
+            log.info(">>>> [StalePushDeviceScheduler] 미활동 디바이스 푸시 비활성화 count={}, threshold={}", deactivated, threshold);
+        }
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
@@ -60,9 +60,7 @@ public class PushDeviceAdaptor {
         }
 
         // 3. 한 기기 = 한 활성 계정 강제
-        if (created) {
-            pushDeviceRepository.deactivateOtherUsersOnDevice(userId, cmd.installationId());
-        }
+        pushDeviceRepository.deactivateOtherUsersOnDevice(userId, cmd.installationId());
 
         // 4. 같은 FCM 토큰을 들고 있는 다른 활성 디바이스 행 비활성화 (installationId 재발급 될 수 있는 경우)
         pushDeviceRepository.deactivateOtherActiveDevicesByToken(userId, cmd.installationId(), cmd.fcmToken());

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
@@ -49,15 +49,24 @@ public class PushDeviceAdaptor {
         // 1. (userId, installationId) 기존 row 조회
         Optional<PushDevice> existing = pushDeviceRepository.findByUserIdAndInstallationId(userId, cmd.installationId());
 
-        // 2-1. 기존 row 있으면 갱신 (dirty checking)
+        // 2-1. 기존 row 있으면 갱신 (dirty checking), 2-2. 없으면 등록
+        boolean created;
         if (existing.isPresent()) {
             existing.get().refresh(cmd);
-            return false;
+            created = false;
+        } else {
+            pushDeviceRepository.save(PushDevice.from(userId, cmd));
+            created = true;
         }
 
-        // 2-2. 기존 row 없으면 등록
-        pushDeviceRepository.save(PushDevice.from(userId, cmd));
-        return true;
+        // 3. 한 기기 = 한 활성 계정 강제
+        if (created) {
+            pushDeviceRepository.deactivateOtherUsersOnDevice(userId, cmd.installationId());
+        }
+
+        // 4. 같은 FCM 토큰을 들고 있는 다른 활성 디바이스 행 비활성화 (installationId 재발급 될 수 있는 경우)
+        pushDeviceRepository.deactivateOtherActiveDevicesByToken(userId, cmd.installationId(), cmd.fcmToken());
+        return created;
     }
 
     // [PushDevice] 단일 디바이스 비활성화
@@ -73,6 +82,11 @@ public class PushDeviceAdaptor {
     // [PushDispatch] FCM invalid 토큰 일괄 비활성화
     public int deactivateByFcmTokens(List<String> tokens) {
         return pushDeviceRepository.deactivateByFcmTokens(tokens);
+    }
+
+    // [PushDevice] 같은 FCM 토큰을 들고 있는 다른 활성 디바이스 행 비활성화
+    public int deactivateOtherActiveDevicesByToken(Long userId, String installationId, String fcmToken) {
+        return pushDeviceRepository.deactivateOtherActiveDevicesByToken(userId, installationId, fcmToken);
     }
 
     // [PushDispatch] 발송 성공한 토큰들의 lastSuccessAt 일괄 갱신

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
@@ -93,4 +93,9 @@ public class PushDeviceAdaptor {
     public void markFcmTokensSuccess(List<String> tokens, LocalDateTime now) {
         pushDeviceRepository.markFcmTokensSuccess(tokens, now);
     }
+
+    // [Batch] 장기 미활동 디바이스 일괄 비활성화 (threshold 이후 sync 없음, 기기별)
+    public int deactivateStaleDevices(LocalDateTime threshold) {
+        return pushDeviceRepository.deactivateStaleDevices(threshold);
+    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/domain/PushDevice.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/domain/PushDevice.java
@@ -20,7 +20,9 @@ import java.time.LocalDateTime;
         ),
         indexes = {
                 @Index(name = "idx_push_device_user_active", columnList = "user_id, is_active"),
-                @Index(name = "idx_push_device_fcm_token", columnList = "fcm_token")
+                @Index(name = "idx_push_device_fcm_token", columnList = "fcm_token"),
+                // 한 기기의 다른 유저 활성 행 정리용
+                @Index(name = "idx_push_device_installation", columnList = "installation_id, is_active")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/domain/PushDevice.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/domain/PushDevice.java
@@ -22,7 +22,9 @@ import java.time.LocalDateTime;
                 @Index(name = "idx_push_device_user_active", columnList = "user_id, is_active"),
                 @Index(name = "idx_push_device_fcm_token", columnList = "fcm_token"),
                 // 한 기기의 다른 유저 활성 행 정리용
-                @Index(name = "idx_push_device_installation", columnList = "installation_id, is_active")
+                @Index(name = "idx_push_device_installation", columnList = "installation_id, is_active"),
+                // 장기 미활동 디바이스 비활성화 배치 스캔용
+                @Index(name = "idx_push_device_active_updated", columnList = "is_active, updated_at")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
@@ -81,4 +81,13 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PushDevice d SET d.lastSuccessAt = :now WHERE d.fcmToken IN :tokens AND d.isActive = true")
     void markFcmTokensSuccess(@Param("tokens") List<String> tokens, @Param("now") LocalDateTime now);
+
+    // 장기 미활동 활성 디바이스 일괄 비활성화
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE PushDevice d SET d.isActive = false
+        WHERE d.isActive = true
+          AND d.updatedAt < :threshold
+    """)
+    int deactivateStaleDevices(@Param("threshold") LocalDateTime threshold);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
@@ -16,12 +16,12 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     // 단일 디바이스 조회
     Optional<PushDevice> findByUserIdAndInstallationId(Long userId, String installationId);
 
-    // 한 유저의 활성 디바이스 FCM 토큰 일괄 조회
-    @Query("SELECT d.fcmToken FROM PushDevice d WHERE d.userId = :userId AND d.isActive = true")
+    // 한 유저의 활성 디바이스 FCM 토큰 일괄 조회 (중복 토큰 무시)
+    @Query("SELECT DISTINCT d.fcmToken FROM PushDevice d WHERE d.userId = :userId AND d.isActive = true")
     List<String> findActiveFcmTokensByUserId(@Param("userId") Long userId);
 
     @Query("""
-        SELECT new com.storix.domain.domains.pushdevice.dto.ActivePushToken(d.userId, d.fcmToken)
+        SELECT DISTINCT new com.storix.domain.domains.pushdevice.dto.ActivePushToken(d.userId, d.fcmToken)
         FROM PushDevice d
         JOIN NotificationSetting s ON s.userId = d.userId
         WHERE d.userId IN :userIds
@@ -31,7 +31,7 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     List<ActivePushToken> findMarketingEnabledActiveTokensByUserIds(@Param("userIds") List<Long> userIds);
 
     @Query("""
-        SELECT new com.storix.domain.domains.pushdevice.dto.ActivePushToken(d.userId, d.fcmToken)
+        SELECT DISTINCT new com.storix.domain.domains.pushdevice.dto.ActivePushToken(d.userId, d.fcmToken)
         FROM PushDevice d
         WHERE d.userId IN :userIds
           AND d.isActive = true
@@ -48,6 +48,29 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PushDevice d SET d.isActive = false WHERE d.fcmToken IN :tokens")
     int deactivateByFcmTokens(@Param("tokens") List<String> tokens);
+
+    // 같은 FCM 토큰을 들고 있는 다른 활성 디바이스 행 비활성화
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE PushDevice d SET d.isActive = false
+        WHERE d.fcmToken = :fcmToken
+          AND d.isActive = true
+          AND NOT (d.userId = :userId AND d.installationId = :installationId)
+    """)
+    int deactivateOtherActiveDevicesByToken(@Param("userId") Long userId,
+                                            @Param("installationId") String installationId,
+                                            @Param("fcmToken") String fcmToken);
+
+    // 동일 기기 타 계정 활성 디바이스 행 비활성화
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE PushDevice d SET d.isActive = false
+        WHERE d.installationId = :installationId
+          AND d.isActive = true
+          AND d.userId <> :userId
+    """)
+    int deactivateOtherUsersOnDevice(@Param("userId") Long userId,
+                                     @Param("installationId") String installationId);
 
     // 유저 탈퇴 시 해당 유저의 모든 활성 디바이스 일괄 비활성화
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/service/PushDeviceService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/service/PushDeviceService.java
@@ -43,5 +43,8 @@ public class PushDeviceService {
     public void refreshFcmToken(Long userId, String installationId, String fcmToken) {
         PushDevice device = pushDeviceAdaptor.getByUserIdAndInstallationId(userId, installationId);
         device.refreshFcmToken(fcmToken);
+
+        // 같은 FCM 토큰을 들고 있는 다른 활성 디바이스 행 비활성화
+        pushDeviceAdaptor.deactivateOtherActiveDevicesByToken(userId, installationId, fcmToken);
     }
 }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 푸시 알림 중복 발송 방지
[문제 요약 -1]
- #120

[해결 방법]
- [x] 앱 진입 시 FCM 토큰 sync -> 같은 기기의 타 유저 행을 비활성화 처리
- [x] FCM 발송 시 같은 토큰 중복 행 / 발송 차단

### 2. 세션 만료 기기 발송 차단
[문제 요약 -2]
- #120

[해결 방법]
- [x] Refresh 토큰 만료 시간을 1주일 -> 1달로 연장
   - OS권한을 끄지 않은 기기에 한하여 푸시 알림 발송으로 인한 리텐션 기간을 1달까지 늘릴 수 있음
- [x] 'push_devices updated_at + (Refresh 토큰 TTL - 1일) < 스케줄러 cron 시점' 을 미진입 30일(Refresh 토큰 만료 시점)으로 처리 => 해당 FCM 토큰 행 비활성화 처리

*(Refresh 토큰 TTL - 1일)을 기준으로 잡는 이유 : Refresh 토큰 만료 '시각'은 발급 '시각'으로부터 + TTL(일)임. 만약 (Refresh 토큰 TTL)을 기준으로 잡게 되면, 스케줄러 cron 시점 이후에 Refresh 토큰이 만료되면서 익일 스케줄러 cron 잡 전까지 여전히 동일 문제가 발생할 수 있음. 따라서 실제 서버 DB 상에서 FCM 토큰 비활성화 처리를 1일 땡겨서 진행


## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #120 

## 🖇️ 기타