### PR TITLE
Fix: [신고] 토픽룸 유저/채팅 신고 불가 수정 및 중복 방지 DB 보강

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/AdminUserSanctionRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/AdminUserSanctionRequest.java
@@ -8,6 +8,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
+import java.util.Set;
+
 public record AdminUserSanctionRequest(
         @Schema(description = "제재 타입. CONTENT_DELETED 선택 시 targetType과 targetId가 필수입니다.", example = "CONTENT_DELETED")
         @NotNull UserSanctionType type,
@@ -22,9 +24,22 @@ public record AdminUserSanctionRequest(
         @Size(max = 500) String memo
 ) {
 
+    // 콘텐츠 삭제 제재로 처리 가능한 대상 타입. TOPIC_ROOM(유저 신고 전용)은 제외
+    private static final Set<TargetContentType> DELETABLE_TARGET_TYPES =
+            Set.of(TargetContentType.FEED, TargetContentType.FEED_REPLY, TargetContentType.REVIEW, TargetContentType.CHAT);
+
     @AssertTrue(message = "CONTENT_DELETED 처리 시 targetType과 targetId는 필수입니다")
     @Schema(hidden = true)
     public boolean isValidContentDeleteTarget() {
         return type != UserSanctionType.CONTENT_DELETED || (targetType != null && targetId != null);
+    }
+
+    @AssertTrue(message = "targetType은 FEED, FEED_REPLY, REVIEW, CHAT 중 하나여야 합니다")
+    @Schema(hidden = true)
+    public boolean isDeletableTargetType() {
+        // targetType 미입력(null)은 위 필수 검증에서 처리하므로 여기서는 통과시킨다.
+        return type != UserSanctionType.CONTENT_DELETED
+                || targetType == null
+                || DELETABLE_TARGET_TYPES.contains(targetType);
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/AdminUserSanctionRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/controller/dto/AdminUserSanctionRequest.java
@@ -11,7 +11,10 @@ import jakarta.validation.constraints.Size;
 public record AdminUserSanctionRequest(
         @Schema(description = "제재 타입. CONTENT_DELETED 선택 시 targetType과 targetId가 필수입니다.", example = "CONTENT_DELETED")
         @NotNull UserSanctionType type,
-        @Schema(description = "삭제 대상 콘텐츠 타입. CONTENT_DELETED 처리 시 필수입니다. FEED=게시글, FEED_REPLY=댓글, REVIEW=리뷰, CHAT=채팅 메시지", example = "FEED")
+        @Schema(description = "삭제 대상 콘텐츠 타입. CONTENT_DELETED 처리 시 필수입니다. "
+                + "신고(report)와 동일한 TargetContentType enum을 사용하며, 콘텐츠 삭제에는 아래 값만 활용해주세요. "
+                + "FEED=게시글, FEED_REPLY=댓글, REVIEW=리뷰, CHAT=채팅 메시지 "
+                + "(TOPIC_ROOM은 유저 신고 전용이라 콘텐츠 삭제 대상이 아님)", example = "FEED")
         TargetContentType targetType,
         @Schema(description = "삭제 대상 콘텐츠 ID. CONTENT_DELETED 처리 시 필수입니다. CHAT은 chatMessageId를 의미합니다.", example = "1")
         @Positive Long targetId,

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomReportAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomReportAdaptor.java
@@ -28,12 +28,7 @@ public class TopicRoomReportAdaptor {
                 ));
     }
 
-    public boolean hasAlreadyReported(Long reporterId, Long reportedUserId, Long topicRoomId, Long chatMessageId) {
-        if (chatMessageId == null) {
-            return topicRoomReportRepository.existsByReporterIdAndReportedUserIdAndTopicRoomIdAndChatMessageIdIsNull(
-                    reporterId, reportedUserId, topicRoomId);
-        }
-        return topicRoomReportRepository.existsByReporterIdAndReportedUserIdAndTopicRoomIdAndChatMessageId(
+    public boolean hasAlreadyReported(Long reporterId, Long reportedUserId, Long topicRoomId, Long chatMessageId) {        return topicRoomReportRepository.existsByReporterIdAndReportedUserIdAndTopicRoomIdAndChatMessageId(
                 reporterId, reportedUserId, topicRoomId, chatMessageId);
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/domain/TopicRoomReport.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/domain/TopicRoomReport.java
@@ -29,6 +29,9 @@ public class TopicRoomReport extends BaseTimeEntity {
     private Long reporterId;
     private Long reportedUserId;
     private Long topicRoomId;
+
+    // 유저 신고는 0으로 저장함. NULL을 허용하면 중복이 DB단에서 막히지 않으므로 NOT NULL
+    @Column(name = "chat_message_id", nullable = false)
     private Long chatMessageId;
 
     @Enumerated(EnumType.STRING)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/TopicRoomReportRequestDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/TopicRoomReportRequestDto.java
@@ -15,7 +15,7 @@ public class TopicRoomReportRequestDto {
 
     private Long chatMessageId;
 
-    @NotNull
+    // TO DO: 유저 신고 및 채팅 신고 시 DEFAULT로 들어가며, 기획 측 요청이 들어올 경우 리팩토링 예정
     private ReportReason reason;
 
     @Size(max = 100)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomReportRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomReportRepository.java
@@ -20,8 +20,6 @@ public interface TopicRoomReportRepository extends JpaRepository<TopicRoomReport
 
     List<TopicRoomReport> findAllByReportCaseIdOrderByCreatedAtAsc(Long reportCaseId);
 
-    boolean existsByReporterIdAndReportedUserIdAndTopicRoomIdAndChatMessageIdIsNull(Long reporterId, Long reportedUserId, Long topicRoomId);
-
     boolean existsByReporterIdAndReportedUserIdAndTopicRoomIdAndChatMessageId(Long reporterId, Long reportedUserId, Long topicRoomId, Long chatMessageId);
 
     long countByReporterId(Long reporterId);

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -293,12 +293,15 @@ public class TopicRoomService implements TopicRoomUseCase {
             throw SelfReportException.EXCEPTION;
         }
 
-        if (topicRoomReportAdaptor.hasAlreadyReported(reporterId, request.getReportedUserId(), roomId, request.getChatMessageId())) {
+        boolean isChatMessageReport = request.getChatMessageId() != null;
+        Long chatMessageId = isChatMessageReport ? request.getChatMessageId() : 0L;
+
+        if (topicRoomReportAdaptor.hasAlreadyReported(reporterId, request.getReportedUserId(), roomId, chatMessageId)) {
             throw DuplicateTopicRoomReportException.EXCEPTION;
         }
 
-        TargetContentType targetType = request.getChatMessageId() == null ? TargetContentType.TOPIC_ROOM : TargetContentType.CHAT;
-        Long targetId = request.getChatMessageId() == null ? roomId : request.getChatMessageId();
+        TargetContentType targetType = isChatMessageReport ? TargetContentType.CHAT : TargetContentType.TOPIC_ROOM;
+        Long targetId = isChatMessageReport ? request.getChatMessageId() : roomId;
 
         ReportCase reportCase = reportCaseAdaptor.findOrCreate(
                 targetType,
@@ -306,14 +309,12 @@ public class TopicRoomService implements TopicRoomUseCase {
                 request.getReportedUserId()
         );
 
-        boolean isChatMessageReport = request.getChatMessageId() != null;
-
         // 신고 사유(reason)는 별도로 받지 않고 유저/채팅 신고 모두 DEFAULT로 저장한다.
         TopicRoomReport report = TopicRoomReport.builder()
                 .reporterId(reporterId)
                 .reportedUserId(request.getReportedUserId())
                 .topicRoomId(roomId)
-                .chatMessageId(request.getChatMessageId())
+                .chatMessageId(chatMessageId)
                 .reason(ReportReason.DEFAULT)
                 .otherReason(isChatMessageReport ? request.getOtherReason() : null)
                 .reportCaseId(reportCase.getId())

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -308,12 +308,13 @@ public class TopicRoomService implements TopicRoomUseCase {
 
         boolean isChatMessageReport = request.getChatMessageId() != null;
 
+        // 신고 사유(reason)는 별도로 받지 않고 유저/채팅 신고 모두 DEFAULT로 저장한다.
         TopicRoomReport report = TopicRoomReport.builder()
                 .reporterId(reporterId)
                 .reportedUserId(request.getReportedUserId())
                 .topicRoomId(roomId)
                 .chatMessageId(request.getChatMessageId())
-                .reason(isChatMessageReport ? request.getReason() : ReportReason.DEFAULT)
+                .reason(ReportReason.DEFAULT)
                 .otherReason(isChatMessageReport ? request.getOtherReason() : null)
                 .reportCaseId(reportCase.getId())
                 .build();


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [x] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [x] 기타 (DB 마이그레이션 필요 — 아래 참고)

## 📋 세부 작업 내용
### 1. 토픽룸 신고 불가 수정 (유저/채팅 신고)
- `TopicRoomReportRequestDto.reason`의 `@NotNull` 제거 → FE가 사유 없이도 신고 가능
- 유저/채팅 신고 모두 `reason`을 서버에서 `DEFAULT`로 저장 (사유 미수신)
  - 유저 신고: `{ reportedUserId }` 만으로 신고 가능
  - 채팅 신고: `{ reportedUserId, chatMessageId }` (chatMessageId 유무로 분기)

### 2. 신고 중복 방지 DB단 보강 (chatMessageId NULL → 0 정규화)
- 유저 신고 시 `chat_message_id`를 `0`으로 저장하도록 서비스단 정규화
- `TopicRoomReport.chatMessageId` 컬럼 `nullable = false` 적용
- 기존: NULL은 unique 제약에서 서로 다른 값으로 취급돼 유저 신고 중복이 DB단에서 안 막힘(앱단 체크만 존재, 동시성 레이스 O)
- 변경: unique 제약 `{reporter, reported, room, chat_message_id}`이 유저 신고 중복까지 DB단에서 검증
- 관련 정리: 어댑터 null 분기 제거, 미사용 `...ChatMessageIdIsNull` 리포지토리 메서드 삭제

### 3. 관리자 유저 제재 생성 API 개선
- `AdminUserSanctionRequest.targetType` Swagger 설명 보강 (신고와 동일한 TargetContentType enum 사용, 삭제 가능 값은 FEED/FEED_REPLY/REVIEW/CHAT 안내, TOPIC_ROOM 제외)
- `type=CONTENT_DELETED` 시 `targetType`이 삭제 가능 4종인지 검증하는 `@AssertTrue` 추가 (TOPIC_ROOM 등 차단)

## 📸 작업 화면 (스크린샷)
-

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [ ] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]

## 🖇️ 기타
### DB 마이그레이션 완료했습니다.
```sql
-- 1) 기존 유저 신고(NULL) 중복 제거: (reporter, reported, room) 조합당 가장 오래된 1건만 유지
DELETE t1 FROM topic_room_report t1
JOIN topic_room_report t2
  ON t1.reporter_id      = t2.reporter_id
 AND t1.reported_user_id = t2.reported_user_id
 AND t1.topic_room_id    = t2.topic_room_id
 AND t1.chat_message_id IS NULL
 AND t2.chat_message_id IS NULL
 AND t1.id > t2.id;

-- 2) 남은 NULL → 0
UPDATE topic_room_report SET chat_message_id = 0 WHERE chat_message_id IS NULL;

-- 3) NOT NULL 제약
ALTER TABLE topic_room_report MODIFY COLUMN chat_message_id BIGINT NOT NULL;
