### PR TITLE
Feat: [알림] 차단/신고/정지 알림 및 HOT 토픽룸·오늘의 피드 선정 알림

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/NotificationDispatchTestRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/NotificationDispatchTestRequest.java
@@ -31,7 +31,7 @@ public record NotificationDispatchTestRequest(
 ) {
     public NotificationEvent toEvent() {
         return new NotificationEvent(
-                recipientUserId, type, targetType, targetId, parentTargetId, title, content
+                recipientUserId, null, type, targetType, targetId, parentTargetId, title, content
         );
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/topicroom/TopicRoomController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/topicroom/TopicRoomController.java
@@ -123,7 +123,7 @@ public class TopicRoomController {
 
     // 8. 지금 핫한 토픽룸
     @GetMapping("/popular")
-    @Operation(summary = "지금 핫한 토픽룸 조회", description = "토픽룸 depth로 들어왔을 때 보여지는 목록입니다. 최대 5개까지 조회됩니다. 비로그인 사용자일 경우 isJoined가 무조건 false로 반환됩니다.")
+    @Operation(summary = "지금 핫한 토픽룸 조회", description = "토픽룸 depth로 들어왔을 때 보여지는 목록입니다. 활동 점수 상위 최대 15개까지 조회됩니다. 비로그인 사용자일 경우 isJoined가 무조건 false로 반환됩니다.")
     public CustomResponse<List<TopicRoomPreviewResponseDto>> getPopularRooms(
             @AuthenticationPrincipal AuthUserDetails authUserDetails
     ) {

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/FeaturedContentNotificationScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/FeaturedContentNotificationScheduler.java
@@ -1,0 +1,37 @@
+package com.storix.batch.scheduler;
+
+import com.storix.domain.domains.feed.service.TodayFeedFeatureService;
+import com.storix.domain.domains.topicroom.service.HotTopicRoomFeatureService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FeaturedContentNotificationScheduler {
+
+    private final TodayFeedFeatureService todayFeedFeatureService;
+    private final HotTopicRoomFeatureService hotTopicRoomFeatureService;
+
+    // 피드 랭킹 20분 갱신 직후 실행
+    @Scheduled(cron = "0 5/20 * * * *", zone = "Asia/Seoul")
+    public void notifyTodayFeed() {
+        try {
+            todayFeedFeatureService.selectAndNotify();
+        } catch (Exception e) {
+            log.error(">>> [FeaturedContentNotificationScheduler] 오늘의 피드 선정 알림 실패 cause={}", e.getMessage(), e);
+        }
+    }
+
+    // 토픽룸 활동 점수 매시 갱신 직후 실행
+    @Scheduled(cron = "0 5 * * * *", zone = "Asia/Seoul")
+    public void notifyHotTopicRoom() {
+        try {
+            hotTopicRoomFeatureService.selectAndNotify();
+        } catch (Exception e) {
+            log.error(">>> [FeaturedContentNotificationScheduler] HOT 토픽룸 선정 알림 실패 cause={}", e.getMessage(), e);
+        }
+    }
+}

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/TopicRoomRankingScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/TopicRoomRankingScheduler.java
@@ -19,6 +19,9 @@ import java.util.List;
 @Slf4j
 public class TopicRoomRankingScheduler {
 
+    private static final int MESSAGE_WINDOW_HOURS = 24;
+    private static final int FRESHNESS_HOURS = 24;
+
     private final LoadTopicRoomPort loadTopicRoomPort;
     private final UpdateTopicRoomPort updateTopicRoomPort;
 
@@ -60,6 +63,15 @@ public class TopicRoomRankingScheduler {
 
         updateTopicRoomPort.updatePreviousActiveUserNumbers(activeRooms);
         log.info(">>>> [Scheduler] 총 {}개의 토픽룸 스냅샷 완료", activeRooms.size());
+    }
+
+    // HOT 토픽룸 활동 점수 계산
+    @Scheduled(cron = "0 0 * * * *")
+    public void calculateHotActivityScore() {
+        LocalDateTime now = LocalDateTime.now();
+        int updated = updateTopicRoomPort.updateActivityScores(
+                now.minusHours(MESSAGE_WINDOW_HOURS), now.minusHours(FRESHNESS_HOURS));
+        log.info(">>>> [Scheduler] 토픽룸 활동 점수 {}건 갱신 완료", updated);
     }
 
     // 인기도 점수: 기존 공식

--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -116,6 +116,10 @@ public class STORIXStatic {
         // 댓글 본문 미리보기 — 10자 노출 후 ...
         public static final int CONTENT_PREVIEW_MAX = 10;
         public static final String CONTENT_PREVIEW_SUFFIX = "...";
+
+        // 선정 알림 dedup Redis 키 prefix — {prefix}{yyyyMMdd}:{id}
+        public static final String FEATURED_FEED_KEY_PREFIX = "featured:feed:";
+        public static final String FEATURED_TOPIC_ROOM_KEY_PREFIX = "featured:topicroom:";
     }
 
     // 사용자 이력 — 마케팅 동의/거부 모달 표시 문구

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedKebabService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedKebabService.java
@@ -6,6 +6,8 @@ import com.storix.domain.domains.feed.dto.CreateFeedReportCommand;
 import com.storix.domain.domains.feed.exception.DuplicateFeedReplyReportException;
 import com.storix.domain.domains.feed.exception.DuplicateFeedReportException;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
 import com.storix.domain.domains.plus.adaptor.BoardAdaptor;
 import com.storix.domain.domains.report.adaptor.ReportCaseAdaptor;
 import com.storix.domain.domains.report.domain.ReportCase;
@@ -24,6 +26,7 @@ public class FeedKebabService {
     private final ReaderFeedAdaptor readerFeedAdaptor;
     private final FeedReportAdaptor feedReportAdaptor;
     private final ReportCaseAdaptor reportCaseAdaptor;
+    private final NotificationPublisher notificationPublisher;
 
     // 내 게시물 삭제
     @Transactional
@@ -56,6 +59,7 @@ public class FeedKebabService {
         );
 
         feedReportAdaptor.saveReport(cmd);
+        notificationPublisher.publish(NotificationEvent.reportReceived(userId));
     }
 
     // 내 댓글 삭제
@@ -88,5 +92,6 @@ public class FeedKebabService {
         );
 
         feedReportAdaptor.saveReplyReport(cmd);
+        notificationPublisher.publish(NotificationEvent.reportReceived(userId));
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedReactionService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedReactionService.java
@@ -60,7 +60,7 @@ public class FeedReactionService {
         // 3. 알림 발행
         notificationPublisher.publishUnlessSelf(
                 userId,
-                NotificationEvent.commentOnFeed(readerBoard.getUserId(), boardId, profile.nickName(), comment)
+                NotificationEvent.commentOnFeed(readerBoard.getUserId(), userId, boardId, profile.nickName(), comment)
         );
 
         return ReaderBoardReplyResponse.of(profile, reply);
@@ -90,7 +90,7 @@ public class FeedReactionService {
         // 3. 알림
         notificationPublisher.publishUnlessSelf(
                 userId,
-                NotificationEvent.replyOnComment(parentReply.getUserId(), parentReplyId, boardId, profile.nickName(), comment)
+                NotificationEvent.replyOnComment(parentReply.getUserId(), userId, parentReplyId, boardId, profile.nickName(), comment)
         );
 
         return ReaderBoardReplyResponse.of(profile, reply);
@@ -119,7 +119,7 @@ public class FeedReactionService {
         StandardProfileInfo actor = userAdaptor.findStandardProfileInfoByUserId(actorUserId);
         notificationPublisher.publishUnlessSelf(
                 actorUserId,
-                NotificationEvent.likeFeed(boardOwnerUserId, boardId, actor.nickName())
+                NotificationEvent.likeFeed(boardOwnerUserId, actorUserId, boardId, actor.nickName())
         );
     }
 
@@ -127,7 +127,7 @@ public class FeedReactionService {
         StandardProfileInfo actor = userAdaptor.findStandardProfileInfoByUserId(actorUserId);
         notificationPublisher.publishUnlessSelf(
                 actorUserId,
-                NotificationEvent.likeComment(replyOwnerUserId, replyId, boardId, actor.nickName())
+                NotificationEvent.likeComment(replyOwnerUserId, actorUserId, replyId, boardId, actor.nickName())
         );
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/TodayFeedFeatureService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/TodayFeedFeatureService.java
@@ -1,17 +1,16 @@
 package com.storix.domain.domains.feed.service;
 
 import com.storix.domain.domains.feed.adaptor.ReaderFeedAdaptor;
-import com.storix.domain.domains.notification.adaptor.FeaturedNotificationDedupAdaptor;
-import com.storix.domain.domains.notification.event.NotificationEvent;
-import com.storix.domain.domains.notification.publisher.NotificationPublisher;
+import com.storix.domain.domains.notification.service.FeaturedNotificationService;
 import com.storix.domain.domains.plus.dto.StandardReaderBoardInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TodayFeedFeatureService {
@@ -19,16 +18,16 @@ public class TodayFeedFeatureService {
     private static final int TRENDING_WINDOW_HOURS = 24;
 
     private final ReaderFeedAdaptor readerFeedAdaptor;
-    private final FeaturedNotificationDedupAdaptor dedupAdaptor;
-    private final NotificationPublisher notificationPublisher;
+    private final FeaturedNotificationService featuredNotificationService;
 
-    @Transactional
     public void selectAndNotify() {
         LocalDateTime threshold = LocalDateTime.now().minusHours(TRENDING_WINDOW_HOURS);
         List<StandardReaderBoardInfo> selected = readerFeedAdaptor.findTop3TrendingFeed(threshold);
         for (StandardReaderBoardInfo feed : selected) {
-            if (dedupAdaptor.markFeedIfFirstToday(feed.boardId())) {
-                notificationPublisher.publish(NotificationEvent.todayFeed(feed.userId(), feed.boardId()));
+            try {
+                featuredNotificationService.notifyTodayFeedIfFirst(feed.boardId(), feed.userId());
+            } catch (Exception e) {
+                log.error(">>> [TodayFeed] 피드 선정 알림 실패 feedId={}", feed.boardId(), e);
             }
         }
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/TodayFeedFeatureService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/TodayFeedFeatureService.java
@@ -1,0 +1,35 @@
+package com.storix.domain.domains.feed.service;
+
+import com.storix.domain.domains.feed.adaptor.ReaderFeedAdaptor;
+import com.storix.domain.domains.notification.adaptor.FeaturedNotificationDedupAdaptor;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
+import com.storix.domain.domains.plus.dto.StandardReaderBoardInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TodayFeedFeatureService {
+
+    private static final int TRENDING_WINDOW_HOURS = 24;
+
+    private final ReaderFeedAdaptor readerFeedAdaptor;
+    private final FeaturedNotificationDedupAdaptor dedupAdaptor;
+    private final NotificationPublisher notificationPublisher;
+
+    @Transactional
+    public void selectAndNotify() {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(TRENDING_WINDOW_HOURS);
+        List<StandardReaderBoardInfo> selected = readerFeedAdaptor.findTop3TrendingFeed(threshold);
+        for (StandardReaderBoardInfo feed : selected) {
+            if (dedupAdaptor.markFeedIfFirstToday(feed.boardId())) {
+                notificationPublisher.publish(NotificationEvent.todayFeed(feed.userId(), feed.boardId()));
+            }
+        }
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/FeaturedNotificationDedupAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/FeaturedNotificationDedupAdaptor.java
@@ -1,0 +1,35 @@
+package com.storix.domain.domains.notification.adaptor;
+
+import com.storix.common.utils.STORIXStatic;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@RequiredArgsConstructor
+public class FeaturedNotificationDedupAdaptor {
+
+    private static final Duration DEDUP_TTL = Duration.ofDays(2);
+    private static final DateTimeFormatter DATE = DateTimeFormatter.BASIC_ISO_DATE;
+
+    private final StringRedisTemplate redisTemplate;
+
+    public boolean markFeedIfFirstToday(Long feedId) {
+        return markIfFirstToday(STORIXStatic.Notification.FEATURED_FEED_KEY_PREFIX, feedId);
+    }
+
+    public boolean markTopicRoomIfFirstToday(Long topicRoomId) {
+        return markIfFirstToday(STORIXStatic.Notification.FEATURED_TOPIC_ROOM_KEY_PREFIX, topicRoomId);
+    }
+
+    // SETNX + TTL 원자 연산 -> 오늘 첫 선정이면 true, 이미 보냈으면 false
+    private boolean markIfFirstToday(String prefix, Long id) {
+        String key = prefix + LocalDate.now().format(DATE) + ":" + id;
+        Boolean first = redisTemplate.opsForValue().setIfAbsent(key, "1", DEDUP_TTL);
+        return Boolean.TRUE.equals(first);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationType.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationType.java
@@ -29,21 +29,12 @@ public enum NotificationType {
     FEATURE_UPDATE;    // 신기능 업데이트
 
 
-    // 일시 정지(SUSPENDED) 유저에게도 푸시 알림을 발송할지 여부 (운영/정책 알림만 발송)
+    // 일시 정지 유저에게도 푸시 알림을 발송할지 여부 (운영/정책 알림만 발송)
     public boolean deliverableToSuspendedUser() {
         return switch (this) {
             case REPORT_RECEIVED, REPORT_PROCESSED,
                  RESTRICTION_7D, RESTRICTION_30D,
                  TOS_UPDATE, PRIVACY_UPDATE, FEATURE_UPDATE -> true;
-            default -> false;
-        };
-    }
-
-    // 수신 동의 설정과 무관하게 무조건 발송해야 하는 필수 고지 타입인지 (제재/약관·정책 변경 등 법적·정책상 필수 안내)
-    public boolean bypassConsent() {
-        return switch (this) {
-            case RESTRICTION_7D, RESTRICTION_30D,
-                 TOS_UPDATE, PRIVACY_UPDATE -> true;
             default -> false;
         };
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/event/AdminNotificationChunkEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/event/AdminNotificationChunkEvent.java
@@ -1,18 +1,43 @@
 package com.storix.domain.domains.notification.event;
 
+import com.storix.common.utils.STORIXStatic;
 import com.storix.domain.domains.notification.domain.AdminNotificationType;
 import com.storix.domain.domains.notification.domain.AdminNotificationTargetType;
+import com.storix.domain.domains.notification.dto.AdminNotificationBroadcastInfo;
 
 import java.util.List;
 
 public record AdminNotificationChunkEvent(
         Long adminNotificationId,
-        String title,
-        String content,
+        String title,          // 인앱 알림함 — 원문
+        String content,        // 인앱 알림함 — 원문
+        String pushTitle,      // 푸시 — 마케팅이면 (광고) 표기
+        String pushContent,    // 푸시 — 마케팅이면 (수신거부) 표기
         AdminNotificationType notificationType,
         AdminNotificationTargetType targetType,
         Long eventTargetId,
         String targetLink,
         List<Long> userIds
 ) {
+
+    // 인앱은 원문, 푸시는 마케팅일 때 (광고)/(수신거부) 표기
+    public static AdminNotificationChunkEvent of(Long adminNotificationId, AdminNotificationBroadcastInfo info, List<Long> userIds) {
+        boolean marketing = info.notificationType() == AdminNotificationType.MARKETING;
+        return new AdminNotificationChunkEvent(
+                adminNotificationId,
+                info.title(),
+                info.content(),
+                marketing ? String.format(STORIXStatic.Notification.TITLE_MARKETING, info.title()) : info.title(),
+                marketing ? String.format(STORIXStatic.Notification.TPL_MARKETING, info.content()) : info.content(),
+                info.notificationType(),
+                info.targetType(),
+                info.eventTargetId(),
+                info.targetLink(),
+                userIds
+        );
+    }
+
+    public boolean isMarketing() {
+        return notificationType == AdminNotificationType.MARKETING;
+    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/event/NotificationEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/event/NotificationEvent.java
@@ -4,11 +4,15 @@ import com.storix.common.utils.STORIXStatic;
 import com.storix.domain.domains.notification.domain.NotificationType;
 import com.storix.domain.domains.notification.domain.TargetType;
 
-// 알림 발송 트리거 이벤트.
-// 발행 지점(Service) 은 정적 팩토리로 만들어 publisher.publish() 만 호출.
-// AFTER_COMMIT 시점에 NotificationEventListener 가 인앱 저장 + FCM 발송 수행.
+/**
+ * 알림 발송 트리거 이벤트
+ *
+ * 발행 지점(Service) 은 정적 팩토리로 만들어 publisher.publish() 만 호출
+ * AFTER_COMMIT 시점에 NotificationEventListener 가 인앱 저장 + FCM 발송 수행
+ * */
 public record NotificationEvent(
         Long recipientUserId,
+        Long actorUserId,
         NotificationType notificationType,
         TargetType targetType,
         Long targetId,
@@ -19,9 +23,10 @@ public record NotificationEvent(
 
     /** 좋아요 */
     // 1. 내 피드에 좋아요
-    public static NotificationEvent likeFeed(Long recipientUserId, Long feedId, String actorNickname) {
+    public static NotificationEvent likeFeed(Long recipientUserId, Long actorUserId, Long feedId, String actorNickname) {
         return new NotificationEvent(
                 recipientUserId,
+                actorUserId,
                 NotificationType.LIKE_FEED,
                 TargetType.FEED,
                 feedId,
@@ -32,9 +37,10 @@ public record NotificationEvent(
     }
 
     // 2. 내 리뷰에 좋아요
-    public static NotificationEvent likeReview(Long recipientUserId, Long reviewId, String actorNickname) {
+    public static NotificationEvent likeReview(Long recipientUserId, Long actorUserId, Long reviewId, String actorNickname) {
         return new NotificationEvent(
                 recipientUserId,
+                actorUserId,
                 NotificationType.LIKE_REVIEW,
                 TargetType.REVIEW,
                 reviewId,
@@ -45,10 +51,11 @@ public record NotificationEvent(
     }
 
     // 3. 내 피드 댓글에 좋아요 — parentTargetId 로 부모 피드 ID 전달
-    public static NotificationEvent likeComment(Long recipientUserId, Long commentId, Long feedId,
+    public static NotificationEvent likeComment(Long recipientUserId, Long actorUserId, Long commentId, Long feedId,
                                                 String actorNickname) {
         return new NotificationEvent(
                 recipientUserId,
+                actorUserId,
                 NotificationType.LIKE_COMMENT,
                 TargetType.COMMENT,
                 commentId,
@@ -61,10 +68,11 @@ public record NotificationEvent(
 
     /** 댓글 / 답댓글 */
     // 1. 내 피드에 댓글
-    public static NotificationEvent commentOnFeed(Long recipientUserId, Long feedId,
+    public static NotificationEvent commentOnFeed(Long recipientUserId, Long actorUserId, Long feedId,
                                                   String actorNickname, String commentContent) {
         return new NotificationEvent(
                 recipientUserId,
+                actorUserId,
                 NotificationType.COMMENT_ON_FEED,
                 TargetType.FEED,
                 feedId,
@@ -75,10 +83,11 @@ public record NotificationEvent(
     }
 
     // 2. 내 댓글에 답댓글 — parentTargetId 로 부모 피드 ID 전달
-    public static NotificationEvent replyOnComment(Long recipientUserId, Long parentCommentId, Long feedId,
+    public static NotificationEvent replyOnComment(Long recipientUserId, Long actorUserId, Long parentCommentId, Long feedId,
                                                    String actorNickname, String replyContent) {
         return new NotificationEvent(
                 recipientUserId,
+                actorUserId,
                 NotificationType.REPLY_ON_COMMENT,
                 TargetType.COMMENT,
                 parentCommentId,
@@ -94,6 +103,7 @@ public record NotificationEvent(
     public static NotificationEvent todayFeed(Long recipientUserId, Long feedId) {
         return new NotificationEvent(
                 recipientUserId,
+                null,
                 NotificationType.TODAY_FEED,
                 TargetType.FEED,
                 feedId,
@@ -107,27 +117,13 @@ public record NotificationEvent(
     public static NotificationEvent hotTopicRoom(Long recipientUserId, Long topicRoomId, String topicRoomTitle) {
         return new NotificationEvent(
                 recipientUserId,
+                null,
                 NotificationType.HOT_TOPIC_ROOM,
                 TargetType.TOPIC_ROOM,
                 topicRoomId,
                 null,
                 STORIXStatic.Notification.TITLE_TOPIC_ROOM,
                 String.format(STORIXStatic.Notification.TPL_HOT_TOPIC_ROOM, topicRoomTitle)
-        );
-    }
-
-
-    /** 마케팅/광고 (운영자 발송) */
-    // 운영자가 입력한 타이틀/본문에 고정 prefix '(광고) ' + suffix '(수신거부 : 설정)' 자동 부착
-    public static NotificationEvent marketing(Long recipientUserId, String adTitle, String adBody) {
-        return new NotificationEvent(
-                recipientUserId,
-                NotificationType.MARKETING,
-                TargetType.NONE,
-                null,
-                null,
-                String.format(STORIXStatic.Notification.TITLE_MARKETING, adTitle),
-                String.format(STORIXStatic.Notification.TPL_MARKETING, adBody)
         );
     }
 
@@ -185,7 +181,7 @@ public record NotificationEvent(
     // 운영 정책 알림 공통 빌더 (타겟 없음, 고정 title/body)
     private static NotificationEvent policyEvent(Long recipientUserId, NotificationType type,
                                                  String title, String body) {
-        return new NotificationEvent(recipientUserId, type, TargetType.NONE, null, null, title, body);
+        return new NotificationEvent(recipientUserId, null, type, TargetType.NONE, null, null, title, body);
     }
 
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/AdminNotificationBroadcastService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/AdminNotificationBroadcastService.java
@@ -85,16 +85,8 @@ public class AdminNotificationBroadcastService {
                     adminNotificationId, userIds, LocalDateTime.now().plusMinutes(RELAY_GRACE_MINUTES), chunkLastUserId);
 
             // 3. 청크 단위 발송 이벤트 발행
-            adminNotificationPublisher.publishChunk(new AdminNotificationChunkEvent(
-                    adminNotificationId,
-                    info.title(),
-                    info.content(),
-                    info.notificationType(),
-                    info.targetType(),
-                    info.eventTargetId(),
-                    info.targetLink(),
-                    userIds
-            ));
+            adminNotificationPublisher.publishChunk(
+                    AdminNotificationChunkEvent.of(adminNotificationId, info, userIds));
 
             lastUserId = chunkLastUserId;
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/FeaturedNotificationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/FeaturedNotificationService.java
@@ -1,0 +1,36 @@
+package com.storix.domain.domains.notification.service;
+
+import com.storix.domain.domains.notification.adaptor.FeaturedNotificationDedupAdaptor;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FeaturedNotificationService {
+
+    private final FeaturedNotificationDedupAdaptor dedupAdaptor;
+    private final NotificationPublisher notificationPublisher;
+
+    @Transactional
+    public void notifyTodayFeedIfFirst(Long feedId, Long authorUserId) {
+        if (!dedupAdaptor.markFeedIfFirstToday(feedId)) {
+            return;
+        }
+        notificationPublisher.publish(NotificationEvent.todayFeed(authorUserId, feedId));
+    }
+
+    @Transactional
+    public void notifyHotTopicRoomIfFirst(Long roomId, String roomName, List<Long> memberIds) {
+        if (!dedupAdaptor.markTopicRoomIfFirstToday(roomId)) {
+            return;
+        }
+        for (Long memberId : memberIds) {
+            notificationPublisher.publish(NotificationEvent.hotTopicRoom(memberId, roomId, roomName));
+        }
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
@@ -58,14 +58,7 @@ public class NotificationDispatchService {
                 .content(event.content())
                 .build());
 
-        // 3. 푸시 발송 가능한 활성 디바이스 토큰 조회 > 없으면 인앱만
-        List<String> tokens = pushDeviceAdaptor.findActiveFcmTokensByUserId(event.recipientUserId());
-        if (tokens.isEmpty()) {
-            log.debug(">>> [Notification] no active device for userId={}", event.recipientUserId());
-            return DispatchResult.inAppOnly(saved.getId());
-        }
-
-        // 4-1. [SUSPENDED 유저] 제재/신고 안내 타입만 발송 허용
+        // 3. 정지 유저는 제재/신고 안내 타입만 푸시 허용
         if (user.getAccountState() == AccountState.SUSPENDED
                 && !event.notificationType().deliverableToSuspendedUser()) {
             log.debug(">>> [Notification] push skipped (user suspended) userId={}, type={}",
@@ -73,14 +66,19 @@ public class NotificationDispatchService {
             return DispatchResult.inAppOnly(saved.getId());
         }
 
-        // 4-2. 푸시 알림 수신 동의 체크 — 제재/약관·정책(법적 필수 고지) 타입은 동의 여부와 무관하게 발송
-        if (!event.notificationType().bypassConsent()) {
-            NotificationSetting setting = notificationSettingAdaptor.getByUserId(event.recipientUserId());
-            if (!setting.acceptsType(event.notificationType())) {
-                log.debug(">>> [Notification] push skipped (type disabled) userId={}, type={}",
-                        event.recipientUserId(), event.notificationType());
-                return DispatchResult.inAppOnly(saved.getId());
-            }
+        // 4. 푸시 수신 동의 체크
+        NotificationSetting setting = notificationSettingAdaptor.getByUserId(event.recipientUserId());
+        if (!setting.acceptsType(event.notificationType())) {
+            log.debug(">>> [Notification] push skipped (type disabled) userId={}, type={}",
+                    event.recipientUserId(), event.notificationType());
+            return DispatchResult.inAppOnly(saved.getId());
+        }
+
+        // 5. 푸시 대상 확정 — 활성 디바이스 토큰 조회 > 없으면 인앱만
+        List<String> tokens = pushDeviceAdaptor.findActiveFcmTokensByUserId(event.recipientUserId());
+        if (tokens.isEmpty()) {
+            log.debug(">>> [Notification] no active device for userId={}", event.recipientUserId());
+            return DispatchResult.inAppOnly(saved.getId());
         }
 
         return DispatchResult.pushTo(saved.getId(), tokens);

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
@@ -8,6 +8,7 @@ import com.storix.domain.domains.notification.dto.DispatchResult;
 import com.storix.domain.domains.notification.event.NotificationEvent;
 import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
+import com.storix.domain.domains.user.adaptor.UserBlockAdaptor;
 import com.storix.domain.domains.user.domain.AccountState;
 import com.storix.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import java.util.List;
 public class NotificationDispatchService {
 
     private final UserAdaptor userAdaptor;
+    private final UserBlockAdaptor userBlockAdaptor;
     private final NotificationAdaptor notificationAdaptor;
     private final NotificationSettingAdaptor notificationSettingAdaptor;
 
@@ -34,6 +36,14 @@ public class NotificationDispatchService {
         User user = userAdaptor.findUserById(event.recipientUserId());
         if (user.getAccountState() == AccountState.DELETED) {
             log.debug(">>> [Notification] skipped (user deleted) userId={}", event.recipientUserId());
+            return DispatchResult.skip();
+        }
+
+        // 1-2. 수신자가 행위자를 차단했으면 전부 skip > 인앱 저장, 푸시 알림 X
+        if (event.actorUserId() != null
+                && userBlockAdaptor.isBlocked(event.recipientUserId(), event.actorUserId())) {
+            log.debug(">>> [Notification] skipped (actor blocked) userId={}, actorId={}",
+                    event.recipientUserId(), event.actorUserId());
             return DispatchResult.skip();
         }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/report/service/AdminReportCommandService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/report/service/AdminReportCommandService.java
@@ -1,8 +1,13 @@
 package com.storix.domain.domains.report.service;
 
 import com.storix.domain.domains.chat.adaptor.ChatAdaptor;
+import com.storix.domain.domains.feed.adaptor.FeedReportAdaptor;
 import com.storix.domain.domains.feed.adaptor.ReaderFeedAdaptor;
+import com.storix.domain.domains.feed.domain.FeedReplyReport;
+import com.storix.domain.domains.feed.domain.FeedReport;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
 import com.storix.domain.domains.plus.adaptor.BoardAdaptor;
 import com.storix.domain.domains.plus.adaptor.ReviewAdaptor;
 import com.storix.domain.domains.plus.dto.ReviewedWorksIdAndRatingInfo;
@@ -14,6 +19,10 @@ import com.storix.domain.domains.report.domain.TargetContentType;
 import com.storix.domain.domains.report.exception.AlreadyProcessedReportCaseException;
 import com.storix.domain.domains.report.exception.InvalidReportProcessRequestException;
 import com.storix.domain.domains.review.adaptor.ReviewLikeAdaptor;
+import com.storix.domain.domains.review.adaptor.ReviewReportAdaptor;
+import com.storix.domain.domains.review.domain.ReviewReport;
+import com.storix.domain.domains.topicroom.adaptor.TopicRoomReportAdaptor;
+import com.storix.domain.domains.topicroom.domain.TopicRoomReport;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import com.storix.domain.domains.user.adaptor.UserSanctionHistoryAdaptor;
 import com.storix.domain.domains.user.domain.User;
@@ -30,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
 @Service
@@ -40,6 +50,10 @@ public class AdminReportCommandService {
     private static final String ACCOUNT_DELETION_DETAIL = "관리자 신고 처리로 인한 계정 삭제";
 
     private final ReportCaseAdaptor reportCaseAdaptor;
+    private final FeedReportAdaptor feedReportAdaptor;
+    private final ReviewReportAdaptor reviewReportAdaptor;
+    private final TopicRoomReportAdaptor topicRoomReportAdaptor;
+    private final NotificationPublisher notificationPublisher;
     private final ChatAdaptor chatAdaptor;
     private final BoardAdaptor boardAdaptor;
     private final ReaderFeedAdaptor readerFeedAdaptor;
@@ -67,6 +81,31 @@ public class AdminReportCommandService {
         if (status == ReportStatus.COMPLETED && processAction != null) {
             executeAction(reportCase, processAction);
         }
+
+        if (status == ReportStatus.COMPLETED) {
+            notifyReporters(reportCase);
+        }
+    }
+
+    // 처리 완료된 신고 케이스의 신고자 전원에게 처리 완료 알림
+    private void notifyReporters(ReportCase reportCase) {
+        findReporterIds(reportCase).stream()
+                .distinct()
+                .forEach(reporterId -> notificationPublisher.publish(NotificationEvent.reportProcessed(reporterId)));
+    }
+
+    private List<Long> findReporterIds(ReportCase reportCase) {
+        Long caseId = reportCase.getId();
+        return switch (reportCase.getTargetType()) {
+            case FEED -> feedReportAdaptor.findFeedReportsByReportCaseId(caseId).stream()
+                    .map(FeedReport::getReporterId).toList();
+            case FEED_REPLY -> feedReportAdaptor.findFeedReplyReportsByReportCaseId(caseId).stream()
+                    .map(FeedReplyReport::getReporterId).toList();
+            case REVIEW -> reviewReportAdaptor.findAllByReportCaseId(caseId).stream()
+                    .map(ReviewReport::getReporterId).toList();
+            case TOPIC_ROOM, CHAT -> topicRoomReportAdaptor.findAllByReportCaseId(caseId).stream()
+                    .map(TopicRoomReport::getReporterId).toList();
+        };
     }
 
     private void validateRequest(ReportStatus status, ReportAction processAction) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/review/service/WorksDetailKebabService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/review/service/WorksDetailKebabService.java
@@ -1,6 +1,8 @@
 package com.storix.domain.domains.review.service;
 
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
 import com.storix.domain.domains.plus.adaptor.ReviewAdaptor;
 import com.storix.domain.domains.plus.dto.ReviewedWorksIdAndRatingInfo;
 import com.storix.domain.domains.report.adaptor.ReportCaseAdaptor;
@@ -29,6 +31,7 @@ public class WorksDetailKebabService {
     private final ReviewReportAdaptor reviewReportAdaptor;
     private final ReportCaseAdaptor reportCaseAdaptor;
     private final LibraryAdaptor libraryAdaptor;
+    private final NotificationPublisher notificationPublisher;
 
     private final LoadWorksPort loadWorksPort;
 
@@ -91,6 +94,7 @@ public class WorksDetailKebabService {
         );
 
         reviewReportAdaptor.saveReport(cmd);
+        notificationPublisher.publish(NotificationEvent.reportReceived(userId));
     }
 
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/review/service/WorksDetailReactionService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/review/service/WorksDetailReactionService.java
@@ -40,7 +40,7 @@ public class WorksDetailReactionService {
         StandardProfileInfo actor = userAdaptor.findStandardProfileInfoByUserId(actorUserId);
         notificationPublisher.publishUnlessSelf(
                 actorUserId,
-                NotificationEvent.likeReview(reviewAuthorUserId, reviewId, actor.nickName())
+                NotificationEvent.likeReview(reviewAuthorUserId, actorUserId, reviewId, actor.nickName())
         );
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomAdaptor.java
@@ -34,8 +34,8 @@ public class TopicRoomAdaptor {
         return topicRoomUserRepository.existsByUserIdAndTopicRoomId(userId, roomId);
     }
 
-    public List<TopicRoom> loadTop5PopularRooms() {
-        return topicRoomRepository.findTop5ByOrderByPopularityScoreDescLastChatTimeDesc();
+    public List<TopicRoom> loadHotTopicRooms() {
+        return topicRoomRepository.findTop15ByOrderByActivityScoreDescLastChatTimeDesc();
     }
 
     // 주어진 토픽룸 ID 목록 중 해당 유저가 참여하고 있는 방의 ID 조회

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomPersistenceAdapter.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomPersistenceAdapter.java
@@ -9,6 +9,7 @@ import com.storix.domain.domains.topicroom.domain.TopicRoom;
 import com.storix.domain.domains.topicroom.domain.TopicRoomReport;
 import com.storix.domain.domains.topicroom.domain.TopicRoomUser;
 import com.storix.domain.domains.topicroom.domain.enums.TopicRoomRole;
+import com.storix.domain.domains.topicroom.dto.RoomMember;
 import com.storix.domain.domains.topicroom.dto.TopicRoomResponseDto;
 import com.storix.domain.domains.topicroom.repository.TopicRoomReportRepository;
 import com.storix.domain.domains.topicroom.repository.TopicRoomRepository;
@@ -25,6 +26,8 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -134,6 +137,15 @@ public class TopicRoomPersistenceAdapter implements LoadTopicRoomPort, RecordTop
     @Override
     public List<Long> loadMemberIdsByRoomId(Long roomId) {
         return topicRoomUserRepository.findMemberIdsByRoomId(roomId);
+    }
+
+    @Override
+    public Map<Long, List<Long>> loadMembersByRoomIds(List<Long> roomIds) {
+        return topicRoomUserRepository.findMembersByRoomIds(roomIds).stream()
+                .collect(Collectors.groupingBy(
+                        RoomMember::roomId,
+                        Collectors.mapping(RoomMember::userId, Collectors.toList())
+                ));
     }
 
     @Override

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomPersistenceAdapter.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomPersistenceAdapter.java
@@ -147,6 +147,11 @@ public class TopicRoomPersistenceAdapter implements LoadTopicRoomPort, RecordTop
     }
 
     @Override
+    public int updateActivityScores(LocalDateTime messageSince, LocalDateTime freshnessSince) {
+        return topicRoomRepository.updateActivityScores(messageSince, freshnessSince);
+    }
+
+    @Override
     public List<TopicRoom> findAllActiveRooms() {
         return topicRoomRepository.findAllActiveRooms();
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/application/port/LoadTopicRoomUserPort.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/application/port/LoadTopicRoomUserPort.java
@@ -1,8 +1,12 @@
 package com.storix.domain.domains.topicroom.application.port;
 
 import java.util.List;
+import java.util.Map;
 
 public interface LoadTopicRoomUserPort {
     // 유저 프로필 조회용
     List<Long> loadMemberIdsByRoomId(Long roomId);
+
+    // 여러 방의 멤버를 한 번에 조회
+    Map<Long, List<Long>> loadMembersByRoomIds(List<Long> roomIds);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/application/port/UpdateTopicRoomPort.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/application/port/UpdateTopicRoomPort.java
@@ -2,6 +2,7 @@ package com.storix.domain.domains.topicroom.application.port;
 
 import com.storix.domain.domains.topicroom.domain.TopicRoom;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface UpdateTopicRoomPort {
@@ -11,4 +12,7 @@ public interface UpdateTopicRoomPort {
 
     // 여러 방의 이전 참여자 수 일괄 업데이트
     void updatePreviousActiveUserNumbers(List<TopicRoom> rooms);
+
+    // 활동 점수 DB 단일 UPDATE 로 일괄 갱신
+    int updateActivityScores(LocalDateTime messageSince, LocalDateTime freshnessSince);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/domain/TopicRoom.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/domain/TopicRoom.java
@@ -24,7 +24,8 @@ import java.time.LocalDateTime;
         indexes = {
                 @Index(name = "idx_popularity_last_chat", columnList = "popularity_score, last_chat_time"),
                 @Index(name = "idx_growth_rate", columnList = "popularity_growth_rate"),
-                @Index(name = "idx_active_user_last_chat", columnList = "active_user_number, last_chat_time")
+                @Index(name = "idx_active_user_last_chat", columnList = "active_user_number, last_chat_time"),
+                @Index(name = "idx_activity_score_last_chat", columnList = "activity_score, last_chat_time")
         }
 )
 public class TopicRoom extends BaseTimeEntity {
@@ -65,6 +66,9 @@ public class TopicRoom extends BaseTimeEntity {
     @Column(name = "popularity_growth_rate", nullable = false)
     private Double popularityGrowthRate;
 
+    @Column(name = "activity_score", nullable = false)
+    private Double activityScore;
+
     @Builder
     public TopicRoom(String topicRoomName, Long worksId) {
         this.topicRoomName = topicRoomName;
@@ -77,6 +81,7 @@ public class TopicRoom extends BaseTimeEntity {
         this.lastMessageSenderId = null;
         this.popularityScore = 0.0;
         this.popularityGrowthRate = 0.0;
+        this.activityScore = 0.0;
     }
 
     // 인기도 점수 업데이트

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/RoomMember.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/RoomMember.java
@@ -1,0 +1,4 @@
+package com.storix.domain.domains.topicroom.dto;
+
+public record RoomMember(Long roomId, Long userId) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomRankingRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomRankingRepository.java
@@ -3,6 +3,7 @@ package com.storix.domain.domains.topicroom.repository;
 import com.storix.domain.domains.topicroom.domain.TopicRoom;
 import com.storix.domain.domains.topicroom.dto.TopicRoomResponseDto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface TopicRoomRankingRepository {
@@ -12,6 +13,9 @@ public interface TopicRoomRankingRepository {
 
     // 여러 개의 방 이전 참여자 수를 한 번에 업데이트
     void bulkUpdatePreviousActiveUserNumbers(List<TopicRoom> rooms);
+
+    // 활동 점수를 DB 단일 UPDATE 로 일괄 계산·갱신
+    int updateActivityScores(LocalDateTime messageSince, LocalDateTime freshnessSince);
 
     // 충성 슬롯: 증가율 기준 상위 1개
     List<TopicRoomResponseDto> findLoyaltySlot();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomRankingRepositoryImpl.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomRankingRepositoryImpl.java
@@ -59,6 +59,29 @@ public class TopicRoomRankingRepositoryImpl implements TopicRoomRankingRepositor
                 });
     }
 
+    // 활동 점수 = 24h 메시지 수×0.5 + 참여자 수×0.3 + 신규성(생성 24h 이내 1)×0.2
+    @Override
+    @Transactional
+    public int updateActivityScores(LocalDateTime messageSince, LocalDateTime freshnessSince) {
+
+        String sql = """
+                UPDATE topic_room tr
+                LEFT JOIN (
+                    SELECT room_id, COUNT(*) AS cnt
+                    FROM chat_message
+                    WHERE created_at >= ? AND deleted = false
+                    GROUP BY room_id
+                ) c ON c.room_id = tr.topic_room_id
+                SET tr.activity_score =
+                    COALESCE(c.cnt, 0) * 0.5
+                    + tr.active_user_number * 0.3
+                    + (CASE WHEN tr.created_at >= ? THEN 1 ELSE 0 END) * 0.2
+                WHERE tr.active_user_number > 1
+                """;
+
+        return jdbcTemplate.update(sql, messageSince, freshnessSince);
+    }
+
     // 공통 필터: 참여자 2명 이상 + 최근 메시지 72시간 이내
     private BooleanBuilder commonFilter() {
         LocalDateTime now = LocalDateTime.now();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomRepository.java
@@ -68,6 +68,8 @@ public interface TopicRoomRepository extends JpaRepository<TopicRoom, Long>, Top
     // 인기도 순으로 조회
     List<TopicRoom> findTop5ByOrderByPopularityScoreDescLastChatTimeDesc();
 
+    List<TopicRoom> findTop15ByOrderByActivityScoreDescLastChatTimeDesc();
+
     boolean existsByWorksId(Long worksId);
 
     @Query("SELECT t.activeUserNumber FROM TopicRoom t WHERE t.id = :roomId")

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomUserRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomUserRepository.java
@@ -1,6 +1,7 @@
 package com.storix.domain.domains.topicroom.repository;
 
 import com.storix.domain.domains.topicroom.domain.TopicRoomUser;
+import com.storix.domain.domains.topicroom.dto.RoomMember;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -40,6 +41,12 @@ public interface TopicRoomUserRepository extends JpaRepository<TopicRoomUser, Lo
             "FROM TopicRoomUser tu " +
             "WHERE tu.topicRoom.id = :roomId")
     List<Long> findMemberIdsByRoomId(@Param("roomId") Long roomId);
+
+    // 여러 방의 멤버를 한 번에 조회
+    @Query("SELECT new com.storix.domain.domains.topicroom.dto.RoomMember(tu.topicRoom.id, tu.userId) " +
+            "FROM TopicRoomUser tu " +
+            "WHERE tu.topicRoom.id IN :roomIds")
+    List<RoomMember> findMembersByRoomIds(@Param("roomIds") List<Long> roomIds);
 
     Optional<TopicRoomUser> findByUserIdAndTopicRoomId(Long userId, Long topicRoomId);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/HotTopicRoomFeatureService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/HotTopicRoomFeatureService.java
@@ -1,0 +1,51 @@
+package com.storix.domain.domains.topicroom.service;
+
+import com.storix.domain.domains.notification.adaptor.FeaturedNotificationDedupAdaptor;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
+import com.storix.domain.domains.topicroom.adaptor.TopicRoomAdaptor;
+import com.storix.domain.domains.topicroom.application.port.LoadTopicRoomUserPort;
+import com.storix.domain.domains.topicroom.domain.TopicRoom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class HotTopicRoomFeatureService {
+
+    private final TopicRoomAdaptor topicRoomAdaptor;
+    private final LoadTopicRoomUserPort loadTopicRoomUserPort;
+    private final FeaturedNotificationDedupAdaptor dedupAdaptor;
+
+    private final NotificationPublisher notificationPublisher;
+
+    @Transactional
+    public void selectAndNotify() {
+        // 활동 점수 상위 15개 중 오늘 아직 안 보낸 방만
+        List<TopicRoom> targets = new ArrayList<>();
+        for (TopicRoom room : topicRoomAdaptor.loadHotTopicRooms()) {
+            if (dedupAdaptor.markTopicRoomIfFirstToday(room.getId())) {
+                targets.add(room);
+            }
+        }
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        List<Long> roomIds = targets.stream().map(TopicRoom::getId).toList();
+        Map<Long, List<Long>> membersByRoom = loadTopicRoomUserPort.loadMembersByRoomIds(roomIds);
+
+        for (TopicRoom room : targets) {
+            for (Long memberId : membersByRoom.getOrDefault(room.getId(), List.of())) {
+                notificationPublisher.publish(
+                        NotificationEvent.hotTopicRoom(memberId, room.getId(), room.getTopicRoomName())
+                );
+            }
+        }
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/HotTopicRoomFeatureService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/HotTopicRoomFeatureService.java
@@ -1,50 +1,40 @@
 package com.storix.domain.domains.topicroom.service;
 
-import com.storix.domain.domains.notification.adaptor.FeaturedNotificationDedupAdaptor;
-import com.storix.domain.domains.notification.event.NotificationEvent;
-import com.storix.domain.domains.notification.publisher.NotificationPublisher;
+import com.storix.domain.domains.notification.service.FeaturedNotificationService;
 import com.storix.domain.domains.topicroom.adaptor.TopicRoomAdaptor;
 import com.storix.domain.domains.topicroom.application.port.LoadTopicRoomUserPort;
 import com.storix.domain.domains.topicroom.domain.TopicRoom;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class HotTopicRoomFeatureService {
 
     private final TopicRoomAdaptor topicRoomAdaptor;
     private final LoadTopicRoomUserPort loadTopicRoomUserPort;
-    private final FeaturedNotificationDedupAdaptor dedupAdaptor;
+    private final FeaturedNotificationService featuredNotificationService;
 
-    private final NotificationPublisher notificationPublisher;
-
-    @Transactional
     public void selectAndNotify() {
-        // 활동 점수 상위 15개 중 오늘 아직 안 보낸 방만
-        List<TopicRoom> targets = new ArrayList<>();
-        for (TopicRoom room : topicRoomAdaptor.loadHotTopicRooms()) {
-            if (dedupAdaptor.markTopicRoomIfFirstToday(room.getId())) {
-                targets.add(room);
-            }
-        }
-        if (targets.isEmpty()) {
+        List<TopicRoom> rooms = topicRoomAdaptor.loadHotTopicRooms();
+        if (rooms.isEmpty()) {
             return;
         }
 
-        List<Long> roomIds = targets.stream().map(TopicRoom::getId).toList();
+        List<Long> roomIds = rooms.stream().map(TopicRoom::getId).toList();
         Map<Long, List<Long>> membersByRoom = loadTopicRoomUserPort.loadMembersByRoomIds(roomIds);
 
-        for (TopicRoom room : targets) {
-            for (Long memberId : membersByRoom.getOrDefault(room.getId(), List.of())) {
-                notificationPublisher.publish(
-                        NotificationEvent.hotTopicRoom(memberId, room.getId(), room.getTopicRoomName())
-                );
+        for (TopicRoom room : rooms) {
+            try {
+                featuredNotificationService.notifyHotTopicRoomIfFirst(room.getId(), room.getTopicRoomName(),
+                        membersByRoom.getOrDefault(room.getId(), List.of()));
+            } catch (Exception e) {
+                log.error(">>> [HotTopicRoom] 룸 선정 알림 실패 roomId={}", room.getId(), e);
             }
         }
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -2,6 +2,8 @@ package com.storix.domain.domains.topicroom.service;
 
 import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
 import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
 import com.storix.domain.domains.report.adaptor.ReportCaseAdaptor;
 import com.storix.domain.domains.report.domain.ReportCase;
 import com.storix.domain.domains.report.domain.TargetContentType;
@@ -69,6 +71,7 @@ public class TopicRoomService implements TopicRoomUseCase {
     private final TopicRoomAdaptor topicRoomAdaptor;
     private final WorksAdaptor worksAdaptor;
     private final TopicRoomActiveUserNumberPublisher activeUserNumberPublisher;
+    private final NotificationPublisher notificationPublisher;
 
     @Override
     public Slice<TopicRoomResponseDto> getMyJoinedRooms(Long userId, Pageable pageable) {
@@ -320,6 +323,7 @@ public class TopicRoomService implements TopicRoomUseCase {
         } catch (DataIntegrityViolationException e) {
             throw DuplicateTopicRoomReportException.EXCEPTION;
         }
+        notificationPublisher.publish(NotificationEvent.reportReceived(reporterId));
     }
 
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -120,7 +120,7 @@ public class TopicRoomService implements TopicRoomUseCase {
     @Override
     public List<TopicRoomPreviewResponseDto> getPopularRooms(Long userId) {
         // 1. 상위 5개 토픽룸 가져오기
-        List<TopicRoom> rooms = topicRoomAdaptor.loadTop5PopularRooms();
+        List<TopicRoom> rooms = topicRoomAdaptor.loadHotTopicRooms();
         if (rooms.isEmpty()) return Collections.emptyList();
 
         List<Long> roomIds = rooms.stream().map(TopicRoom::getId).toList();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AdminUserService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AdminUserService.java
@@ -4,6 +4,8 @@ import com.storix.domain.domains.feed.adaptor.FeedReportAdaptor;
 import com.storix.domain.domains.feed.adaptor.ReaderFeedAdaptor;
 import com.storix.domain.domains.chat.adaptor.ChatAdaptor;
 import com.storix.domain.domains.library.adaptor.LibraryAdaptor;
+import com.storix.domain.domains.notification.event.NotificationEvent;
+import com.storix.domain.domains.notification.publisher.NotificationPublisher;
 import com.storix.domain.domains.plus.adaptor.BoardAdaptor;
 import com.storix.domain.domains.plus.adaptor.ReviewAdaptor;
 import com.storix.domain.domains.plus.dto.ReviewedWorksIdAndRatingInfo;
@@ -68,6 +70,7 @@ public class AdminUserService {
     private final UserAdaptor userAdaptor;
     private final AuthService authService;
     private final UserAccessRevokedPublisher userAccessRevokedPublisher;
+    private final NotificationPublisher notificationPublisher;
     private final UserBlacklistAdaptor userBlacklistAdaptor;
     private final BoardAdaptor boardAdaptor;
     private final ReaderFeedAdaptor readerFeedAdaptor;
@@ -264,6 +267,7 @@ public class AdminUserService {
         }
         user.suspend(suspendedUntil);
         userAccessRevokedPublisher.publishSuspended(userId, suspendedUntil);
+        notificationPublisher.publish(NotificationEvent.restriction7d(userId));
         saveManualSanctionHistory(userId, adminId, UserSanctionType.SUSPENDED, now, suspendedUntil, memo);
     }
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dispatcher/AdminNotificationDispatcher.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dispatcher/AdminNotificationDispatcher.java
@@ -3,10 +3,9 @@ package com.storix.infrastructure.external.notification.dispatcher;
 import com.storix.domain.domains.notification.domain.AdminNotificationDeliveryOutcome;
 import com.storix.domain.domains.notification.domain.AdminNotificationTargetType;
 import com.storix.domain.domains.notification.dto.AdminNotificationDispatchCounts;
-import com.storix.domain.domains.notification.domain.AdminNotificationType;
 import com.storix.domain.domains.notification.domain.NotificationType;
+import com.storix.domain.domains.notification.event.AdminNotificationChunkEvent;
 import com.storix.domain.domains.notification.service.AdminNotificationDeliveryResultService;
-import com.storix.common.utils.STORIXStatic;
 import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
 import com.storix.domain.domains.pushdevice.dto.ActivePushToken;
 import com.storix.infrastructure.external.notification.dto.MulticastResult;
@@ -35,27 +34,26 @@ public class AdminNotificationDispatcher {
     private final AdminNotificationDeliveryResultService deliveryResultService;
 
     // 대상 유저에게 발송하고 결과를 로그에 반영
-    public AdminNotificationDispatchCounts dispatch(Long adminNotificationId, String title, String content,
-                                                   AdminNotificationType adminNotificationType, AdminNotificationTargetType targetType,
-                                                   Long eventTargetId, String targetLink, List<Long> userIds, LocalDateTime now
-    ) {
+    public AdminNotificationDispatchCounts dispatch(AdminNotificationChunkEvent event, LocalDateTime now) {
+        List<Long> userIds = event.userIds();
         if (userIds.isEmpty()) return AdminNotificationDispatchCounts.empty();
 
-        // 마케팅의 경우만 푸시 알림 : (광고) ~~ (수신거부 : 설정), 인앱 : 원문
-        boolean isMarketing = adminNotificationType == AdminNotificationType.MARKETING;
-        NotificationType notificationType = adminNotificationType.getNotificationType();
-        String pushTitle = isMarketing ? String.format(STORIXStatic.Notification.TITLE_MARKETING, title) : title;
-        String pushContent = isMarketing ? String.format(STORIXStatic.Notification.TPL_MARKETING, content) : content;
+        Long adminNotificationId = event.adminNotificationId();
+        AdminNotificationTargetType targetType = event.targetType();
+        Long eventTargetId = event.eventTargetId();
+        String targetLink = event.targetLink();
+        NotificationType notificationType = event.notificationType().getNotificationType();
 
         // 1. 발송 대상 인앱 알림 생성
         Map<Long, Long> notificationIdByUser = deliveryResultService.prepareBroadcastNotifications(
-                adminNotificationId, userIds, notificationType, targetType, eventTargetId, targetLink, title, content);
+                adminNotificationId, userIds, notificationType, targetType, eventTargetId, targetLink,
+                event.title(), event.content());
         if (notificationIdByUser.isEmpty()) return AdminNotificationDispatchCounts.empty();
 
         // 2. 발송 대상 활성 토큰 조회
         List<Long> targets = List.copyOf(notificationIdByUser.keySet());
-        List<ActivePushToken> activeTokens = isMarketing
-                ? pushDeviceAdaptor.findMarketingEnabledActiveTokensByUserIds(targets) // 마케팅 알림일 경우, 동의자만
+        List<ActivePushToken> activeTokens = event.isMarketing()
+                ? pushDeviceAdaptor.findMarketingEnabledActiveTokensByUserIds(targets)
                 : pushDeviceAdaptor.findActiveTokensByUserIds(targets);
         Map<Long, List<String>> tokensByUserId = activeTokens.stream()
                 .collect(Collectors.groupingBy(
@@ -75,7 +73,7 @@ public class AdminNotificationDispatcher {
             try {
                 MulticastResult result = fcmPushExecutor.sendAndApply(
                         tokens, buildData(adminNotificationId, notificationType, targetType, eventTargetId, targetLink,
-                                pushTitle, pushContent, notificationIdByUser.get(userId)));
+                                event.pushTitle(), event.pushContent(), notificationIdByUser.get(userId)));
                 if (!result.successTokens().isEmpty()) {
                     outcomes.put(userId, AdminNotificationDeliveryOutcome.SENT);
                 } else if (result.hasTransientFailure()) {

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dispatcher/AdminNotificationRetryer.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dispatcher/AdminNotificationRetryer.java
@@ -2,6 +2,7 @@ package com.storix.infrastructure.external.notification.dispatcher;
 
 import com.storix.common.utils.STORIXStatic;
 import com.storix.domain.domains.notification.dto.AdminNotificationBroadcastInfo;
+import com.storix.domain.domains.notification.event.AdminNotificationChunkEvent;
 import com.storix.domain.domains.notification.service.AdminNotificationLifecycleService;
 import com.storix.domain.domains.notification.service.AdminNotificationTargetService;
 import com.storix.domain.domains.notification.domain.AdminNotificationLog;
@@ -45,10 +46,8 @@ public class AdminNotificationRetryer {
 
             try {
                 AdminNotificationBroadcastInfo info = targetService.getBroadcastInfo(adminNotificationId);
-                adminNotificationDispatcher.dispatch(
-                        adminNotificationId, info.title(), info.content(), info.notificationType(),
-                        info.targetType(), info.eventTargetId(), info.targetLink(),
-                        entry.getValue(), now);
+                AdminNotificationChunkEvent event = AdminNotificationChunkEvent.of(adminNotificationId, info, entry.getValue());
+                adminNotificationDispatcher.dispatch(event, now);
 
                 // [AdminNotification] updatedAt 갱신
                 lifecycleService.touchProgress(adminNotificationId);

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/listener/AdminNotificationChunkListener.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/listener/AdminNotificationChunkListener.java
@@ -31,10 +31,7 @@ public class AdminNotificationChunkListener {
         Long adminNotificationId = event.adminNotificationId();
         MDC.put(MDC_KEY, String.valueOf(adminNotificationId));
         try {
-            AdminNotificationDispatchCounts result = adminNotificationDispatcher.dispatch(
-                    adminNotificationId, event.title(), event.content(), event.notificationType(),
-                    event.targetType(), event.eventTargetId(), event.targetLink(),
-                    event.userIds(), LocalDateTime.now());
+            AdminNotificationDispatchCounts result = adminNotificationDispatcher.dispatch(event, LocalDateTime.now());
 
             deliveryResultService.accumulateProgress(adminNotificationId, result.sent(), result.failed(), result.skipped());
 


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 알림 추가
- [x] 오늘의 피드 선정 -> 작성자 (TODAY_FEED)
- [x] HOT 토픽룸 선정 -> 룸 참여자 전원 (HOT_TOPIC_ROOM)
- [x] 신고 접수 -> 신고자 (피드/댓글/리뷰/토픽룸, REPORT_RECEIVED)
- [x] 신고 처리 완료 -> 해당 케이스 신고자 전원 (REPORT_PROCESSED, 반려 시 처리 알림 X)
- [x] 정지 처리(관리자 수동 제재) -> 대상 유저 (RESTRICTION_7D)

### 2. 내부 로직
**HOT 토픽룸 선정 로직 개편**
- 기존 loadTop5PopularRooms -> HOT 뱃지 스펙으로 교체
- 활동 점수 = (24h 메시지수 × 0.5) + (참여자수 × 0.3) + (신규성 × 0.2), 상위 15개 선정
스프린트 2 작업인데 누락되어있어서 진행하였습니다.

**오늘의 피드/HOT 토픽룸 선정 알림**
- Redis SETNX 일 단위 dedup
   - 키: 1_featured:feed:{yyyyMMdd}:{id}, 2_featured:topicroom:{yyyyMMdd}:{id}
   - TTL: 2일
- 하루 중 처음으로 선정되었을 경우에만 알림 나감

**차단 유저 알림 필터링**
- NotificationEvent에 actorUserId 추가, 반응(좋아요/댓글) 알림에 행위자 전달
- dispatch에서 수신자가 행위자를 차단했으면 인앱·푸시 모두 skip

**푸시 발송 정책 정리**
- 정지 여부 체크 -> 수신 동의 체크 → 토큰 조회로 재배치
- 푸시 여부를 notification_setting 기준으로 통일(bypassConsent 제거) 
   - 약관/정책/제재도 유저가 운영·정책 토글 끄면 푸시 알림은 미발송, 법적 고지는 인앱 알림함 저장으로 처리


## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #124 

## 🖇️ 기타