### PR TITLE
Feat: 보유기간 경과 데이터 파기 스케줄러 및 탈퇴 시 개인정보 파기 개편

### DIFF
--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/HardDeleteScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/HardDeleteScheduler.java
@@ -4,7 +4,6 @@ import com.storix.domain.domains.chat.adaptor.ChatAdaptor;
 import com.storix.domain.domains.feed.adaptor.ReaderFeedAdaptor;
 import com.storix.domain.domains.plus.adaptor.BoardAdaptor;
 import com.storix.domain.domains.plus.adaptor.ReviewAdaptor;
-import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -24,11 +23,10 @@ public class HardDeleteScheduler {
     private final ReaderFeedAdaptor readerFeedAdaptor;
     private final ReviewAdaptor reviewAdaptor;
     private final ChatAdaptor chatAdaptor;
-    private final UserAdaptor userAdaptor;
 
     /**
      * 매일 새벽 4시 실행.
-     * soft-delete 후 5년이 경과한 레코드를 테이블별로 순차 hard-delete 한다.
+     * soft-delete 후 5년이 경과한 콘텐츠 레코드를 테이블별로 순차 hard-delete 한다.
      * 댓글(자식) → 게시물(부모) 순서로 삭제해 FK 위반을 방지한다.
      */
     @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
@@ -41,9 +39,8 @@ public class HardDeleteScheduler {
         int boards   = boardAdaptor.hardDeleteBefore(cutoff);
         int reviews  = reviewAdaptor.hardDeleteBefore(cutoff);
         int messages = chatAdaptor.hardDeleteBefore(cutoff);
-        int users    = userAdaptor.hardDeleteBefore(cutoff);
 
-        log.info(">>>> [HardDeleteScheduler] 완료 — 댓글: {}건, 게시물: {}건, 리뷰: {}건, 채팅: {}건, 유저: {}건",
-                replies, boards, reviews, messages, users);
+        log.info(">>>> [HardDeleteScheduler] 완료 — 댓글: {}건, 게시물: {}건, 리뷰: {}건, 채팅: {}건",
+                replies, boards, reviews, messages);
     }
 }

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/PrivacyRetentionScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/PrivacyRetentionScheduler.java
@@ -1,0 +1,58 @@
+package com.storix.batch.scheduler;
+
+import com.storix.domain.domains.report.adaptor.ReportRetentionAdaptor;
+import com.storix.domain.domains.user.adaptor.UserAdaptor;
+import com.storix.domain.domains.user.adaptor.UserSanctionHistoryAdaptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PrivacyRetentionScheduler {
+
+    private static final int OAUTH_OID_RETENTION_YEARS = 1;
+    private static final int REPORT_RETENTION_YEARS = 3;
+    private static final int SANCTION_RETENTION_YEARS = 1;
+
+    private final UserAdaptor userAdaptor;
+    private final ReportRetentionAdaptor reportRetentionAdaptor;
+    private final UserSanctionHistoryAdaptor userSanctionHistoryAdaptor;
+
+    // 탈퇴 후 1년 경과한 소셜 식별자 파기
+    @Scheduled(cron = "0 10 4 * * *")
+    @Transactional
+    public void purgeExpiredOauthOid() {
+        LocalDateTime cutoff = LocalDateTime.now().minusYears(OAUTH_OID_RETENTION_YEARS);
+        int purged = userAdaptor.purgeOauthOidBefore(cutoff);
+        if (purged > 0) {
+            log.info(">>>> [PrivacyRetentionScheduler] 소셜 식별자 파기 count={}, cutoff={}", purged, cutoff);
+        }
+    }
+
+    // 처리 완료 후 3년 경과한 신고 기록 파기
+    @Scheduled(cron = "0 20 4 * * *")
+    public void purgeExpiredReports() {
+        LocalDateTime cutoff = LocalDateTime.now().minusYears(REPORT_RETENTION_YEARS);
+        int purged = reportRetentionAdaptor.purgeProcessedBefore(cutoff);
+        if (purged > 0) {
+            log.info(">>>> [PrivacyRetentionScheduler] 신고 기록 파기 count={}, cutoff={}", purged, cutoff);
+        }
+    }
+
+    // 제재 종료 또는 탈퇴 후 1년 경과한 제재 기록 파기
+    @Scheduled(cron = "0 30 4 * * *")
+    @Transactional
+    public void purgeExpiredSanctions() {
+        LocalDateTime cutoff = LocalDateTime.now().minusYears(SANCTION_RETENTION_YEARS);
+        int purged = userSanctionHistoryAdaptor.deleteExpiredBefore(cutoff);
+        if (purged > 0) {
+            log.info(">>>> [PrivacyRetentionScheduler] 제재 기록 파기 count={}, cutoff={}", purged, cutoff);
+        }
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/repository/FeedReplyReportRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/repository/FeedReplyReportRepository.java
@@ -3,6 +3,7 @@ package com.storix.domain.domains.feed.repository;
 import com.storix.domain.domains.feed.domain.FeedReplyReport;
 import com.storix.domain.domains.report.repository.ReportedUserCountProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -33,4 +34,8 @@ public interface FeedReplyReportRepository extends JpaRepository<FeedReplyReport
             GROUP BY report.reportedUserId
             """)
     List<ReportedUserCountProjection> countByReportedUserIds(@Param("reportedUserIds") List<Long> reportedUserIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM FeedReplyReport report WHERE report.reportCaseId IN :reportCaseIds")
+    int deleteByReportCaseIdIn(@Param("reportCaseIds") List<Long> reportCaseIds);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/repository/FeedReportRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/repository/FeedReportRepository.java
@@ -3,6 +3,7 @@ package com.storix.domain.domains.feed.repository;
 import com.storix.domain.domains.feed.domain.FeedReport;
 import com.storix.domain.domains.report.repository.ReportedUserCountProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -33,4 +34,8 @@ public interface FeedReportRepository extends JpaRepository<FeedReport, Long> {
             GROUP BY report.reportedUserId
             """)
     List<ReportedUserCountProjection> countByReportedUserIds(@Param("reportedUserIds") List<Long> reportedUserIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM FeedReport report WHERE report.reportCaseId IN :reportCaseIds")
+    int deleteByReportCaseIdIn(@Param("reportCaseIds") List<Long> reportCaseIds);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
@@ -72,9 +72,9 @@ public class PushDeviceAdaptor {
         return pushDeviceRepository.deactivateByUserIdAndInstallationId(userId, installationId);
     }
 
-    // [PushDevice] 유저 탈퇴 시 모든 디바이스 일괄 비활성화
-    public void deactivateAllByUserId(Long userId) {
-        pushDeviceRepository.deactivateAllByUserId(userId);
+    // [PushDevice] 유저 탈퇴 시 모든 디바이스 물리 삭제
+    public void deleteAllByUserId(Long userId) {
+        pushDeviceRepository.deleteAllByUserId(userId);
     }
 
     // [PushDispatch] FCM invalid 토큰 일괄 비활성화

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
@@ -72,10 +72,10 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     int deactivateOtherUsersOnDevice(@Param("userId") Long userId,
                                      @Param("installationId") String installationId);
 
-    // 유저 탈퇴 시 해당 유저의 모든 활성 디바이스 일괄 비활성화
+    // 유저 탈퇴 시 모든 디바이스 물리 삭제 — 방침상 탈퇴 시 지체 없이 파기
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE PushDevice d SET d.isActive = false WHERE d.userId = :userId AND d.isActive = true")
-    void deactivateAllByUserId(@Param("userId") Long userId);
+    @Query("DELETE FROM PushDevice d WHERE d.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 
     // 발송 성공한 토큰들의 lastSuccessAt 갱신
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/report/adaptor/ReportRetentionAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/report/adaptor/ReportRetentionAdaptor.java
@@ -1,0 +1,41 @@
+package com.storix.domain.domains.report.adaptor;
+
+import com.storix.domain.domains.feed.repository.FeedReplyReportRepository;
+import com.storix.domain.domains.feed.repository.FeedReportRepository;
+import com.storix.domain.domains.report.domain.ReportStatus;
+import com.storix.domain.domains.report.repository.ReportCaseRepository;
+import com.storix.domain.domains.review.repository.ReviewReportRepository;
+import com.storix.domain.domains.topicroom.repository.TopicRoomReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ReportRetentionAdaptor {
+
+    private static final List<ReportStatus> PROCESSED_STATUSES =
+            List.of(ReportStatus.COMPLETED, ReportStatus.REJECTED);
+
+    private final ReportCaseRepository reportCaseRepository;
+    private final FeedReportRepository feedReportRepository;
+    private final FeedReplyReportRepository feedReplyReportRepository;
+    private final ReviewReportRepository reviewReportRepository;
+    private final TopicRoomReportRepository topicRoomReportRepository;
+
+    @Transactional
+    public int purgeProcessedBefore(LocalDateTime cutoff) {
+        List<Long> caseIds = reportCaseRepository.findIdsByProcessedAtBeforeAndStatusIn(cutoff, PROCESSED_STATUSES);
+        if (caseIds.isEmpty()) {
+            return 0;
+        }
+        feedReportRepository.deleteByReportCaseIdIn(caseIds);
+        feedReplyReportRepository.deleteByReportCaseIdIn(caseIds);
+        reviewReportRepository.deleteByReportCaseIdIn(caseIds);
+        topicRoomReportRepository.deleteByReportCaseIdIn(caseIds);
+        return reportCaseRepository.deleteByIdIn(caseIds);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/report/repository/ReportCaseRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/report/repository/ReportCaseRepository.java
@@ -6,9 +6,11 @@ import com.storix.domain.domains.report.domain.TargetContentType;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,4 +35,13 @@ public interface ReportCaseRepository extends JpaRepository<ReportCase, Long>, R
             GROUP BY r.status
             """)
     List<StatusCountProjection> countGroupByStatusAndReportedUserId(@Param("userId") Long userId);
+
+    // 처리 완료 후 보유기간 경과한 신고 케이스 id 조회
+    @Query("SELECT r.id FROM ReportCase r WHERE r.processedAt < :cutoff AND r.status IN :statuses")
+    List<Long> findIdsByProcessedAtBeforeAndStatusIn(@Param("cutoff") LocalDateTime cutoff,
+                                                      @Param("statuses") List<ReportStatus> statuses);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ReportCase r WHERE r.id IN :ids")
+    int deleteByIdIn(@Param("ids") List<Long> ids);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/review/repository/ReviewReportRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/review/repository/ReviewReportRepository.java
@@ -3,6 +3,7 @@ package com.storix.domain.domains.review.repository;
 import com.storix.domain.domains.review.domain.ReviewReport;
 import com.storix.domain.domains.report.repository.ReportedUserCountProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -33,4 +34,8 @@ public interface ReviewReportRepository extends JpaRepository<ReviewReport, Long
             GROUP BY report.reportedUserId
             """)
     List<ReportedUserCountProjection> countByReportedUserIds(@Param("reportedUserIds") List<Long> reportedUserIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ReviewReport report WHERE report.reportCaseId IN :reportCaseIds")
+    int deleteByReportCaseIdIn(@Param("reportCaseIds") List<Long> reportCaseIds);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomReportRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomReportRepository.java
@@ -3,6 +3,7 @@ package com.storix.domain.domains.topicroom.repository;
 import com.storix.domain.domains.topicroom.domain.TopicRoomReport;
 import com.storix.domain.domains.report.repository.ReportedUserCountProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,4 +36,8 @@ public interface TopicRoomReportRepository extends JpaRepository<TopicRoomReport
             GROUP BY report.reportedUserId
             """)
     List<ReportedUserCountProjection> countByReportedUserIds(@Param("reportedUserIds") List<Long> reportedUserIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM TopicRoomReport report WHERE report.reportCaseId IN :reportCaseIds")
+    int deleteByReportCaseIdIn(@Param("reportCaseIds") List<Long> reportCaseIds);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserAdaptor.java
@@ -149,8 +149,8 @@ public class UserAdaptor {
         return userRepository.restoreExpiredSuspensions(AccountState.SUSPENDED, now);
     }
 
-    public int hardDeleteBefore(LocalDateTime cutoff) {
-        return userRepository.hardDeleteBefore(cutoff);
+    public int purgeOauthOidBefore(LocalDateTime cutoff) {
+        return userRepository.purgeOauthOidBefore(cutoff);
     }
 
     public Map<Long, String> findNicknameMapByUserIds(List<Long> userIds) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserSanctionHistoryAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/UserSanctionHistoryAdaptor.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
@@ -25,5 +26,9 @@ public class UserSanctionHistoryAdaptor {
 
     public Page<UserSanctionHistory> findPageByUserId(Long userId, Pageable pageable) {
         return userSanctionHistoryRepository.findPageByUserIdOrderByCreatedAtDesc(userId, pageable);
+    }
+
+    public int deleteExpiredBefore(LocalDateTime cutoff) {
+        return userSanctionHistoryRepository.deleteExpiredBefore(cutoff);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/User.java
@@ -207,6 +207,7 @@ public class User extends BaseTimeEntity {
         accountState = AccountState.DELETED;
         favoriteGenreList = null;
         profileObjectKey = null;
+        profileDescription = null;
         nickName = STORIXStatic.WITHDRAW_PREFIX + UUID.randomUUID() + ":" + nickName;
         oauthInfo = oauthInfo.withDrawOauthInfo();
         ageOver14 = null;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserRepository.java
@@ -102,9 +102,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "WHERE u.id IN :userIds")
     List<UserNicknameInfo> findNicknameInfoByUserIds(@Param("userIds") List<Long> userIds);
 
+    // 탈퇴 1년 경과 유저의 소셜 식별자 파기
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("DELETE FROM User u WHERE u.accountState = com.storix.domain.domains.user.domain.AccountState.DELETED AND u.deletedAt < :cutoff")
-    int hardDeleteBefore(@Param("cutoff") LocalDateTime cutoff);
+    @Query("UPDATE User u SET u.oauthInfo.oid = null " +
+            "WHERE u.accountState = com.storix.domain.domains.user.domain.AccountState.DELETED " +
+            "AND u.deletedAt < :cutoff AND u.oauthInfo.oid IS NOT NULL")
+    int purgeOauthOidBefore(@Param("cutoff") LocalDateTime cutoff);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE User u SET u.title = null")

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserSanctionHistoryRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/repository/UserSanctionHistoryRepository.java
@@ -4,7 +4,11 @@ import com.storix.domain.domains.user.domain.UserSanctionHistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface UserSanctionHistoryRepository extends JpaRepository<UserSanctionHistory, Long> {
@@ -12,4 +16,9 @@ public interface UserSanctionHistoryRepository extends JpaRepository<UserSanctio
     List<UserSanctionHistory> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 
     Page<UserSanctionHistory> findPageByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    // 제재 종료일 기준 파기
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM UserSanctionHistory h WHERE COALESCE(h.endedAt, h.startedAt) < :cutoff")
+    int deleteExpiredBefore(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -181,8 +181,8 @@ public class AuthService {
         favoriteWorksAdaptor.deleteFavoriteWorks(userId);
         libraryAdaptor.deleteLibrary(userId);
 
-        // 3. 푸시 알림 디바이스 일괄 비활성화
-        pushDeviceAdaptor.deactivateAllByUserId(userId);
+        // 3. 푸시 알림 토큰 물리 삭제
+        pushDeviceAdaptor.deleteAllByUserId(userId);
 
         // 4. 알림 설정 삭제 (재가입 시 새 row 생성됨)
         notificationSettingAdaptor.deleteByUserId(userId);


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 보유기간 경과 데이터 파기 스케줄러
- [x] PrivacyRetentionScheduler : 소셜 식별자(oid) 1년, 신고 기록 3년, 제재 기록 1년 경과분 파기

### 2. 회원 탈퇴 시 개인정보 파기
- [x] 탈퇴 시 FCM 토큰 물리 삭제, profileDescription 파기
- [x] HardDeleteScheduler: 탈퇴 유저 row 삭제 제거 (익명 tombstone 영구 보존)

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #123 

## 🖇️ 기타
STORIX 개인정보 처리 방침 약관을 따릅니다.