### PR TITLE
Fix: [토픽룸] 탈퇴 시 토픽룸 유저 정리 및 실시간 채팅 수신 복구

### DIFF
--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomAdaptor.java
@@ -58,6 +58,10 @@ public class TopicRoomAdaptor {
         return topicRoomUserRepository.countByUserId(userId);
     }
 
+    public List<Long> findAllJoinedRoomIdsByUserId(Long userId) {
+        return topicRoomUserRepository.findAllJoinedRoomIdsByUserId(userId);
+    }
+
     public Integer findActiveUserNumberById(Long roomId) {
         Integer activeUserNumber = topicRoomRepository.findActiveUserNumberById(roomId);
         if (activeUserNumber == null) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/application/usecase/TopicRoomUseCase.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/application/usecase/TopicRoomUseCase.java
@@ -32,6 +32,8 @@ public interface TopicRoomUseCase {
 
     void leaveRoom(Long userId, Long roomId);
 
+    void leaveAllRooms(Long userId);
+
     void reportUser(Long reporterId, Long roomId, TopicRoomReportRequestDto request);
 
     List<TopicRoomPreviewResponseDto> getPopularRooms(Long userId);

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/listener/TopicRoomWithdrawListener.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/listener/TopicRoomWithdrawListener.java
@@ -1,0 +1,26 @@
+package com.storix.domain.domains.topicroom.listener;
+
+import com.storix.domain.domains.topicroom.application.usecase.TopicRoomUseCase;
+import com.storix.domain.domains.user.event.UserAccessRevokedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TopicRoomWithdrawListener {
+
+    private final TopicRoomUseCase topicRoomUseCase;
+
+    // 탈퇴 커밋 후 참여 중인 토픽룸 전체 나가기
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(UserAccessRevokedEvent event) {
+        if (event.type() != UserAccessRevokedEvent.UserAccessRevokedType.WITHDRAWN) {
+            return;
+        }
+        topicRoomUseCase.leaveAllRooms(event.userId());
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -277,14 +277,28 @@ public class TopicRoomService implements TopicRoomUseCase {
 
         try {
             TopicRoom room = loadTopicRoomPort.findById(roomId);
-            publishActiveUserNumberChanged(room.getId(), room.getActiveUserNumber());
-
-            // 인원수가 0 이하면 방 삭제 로직 실행
             if (room.getActiveUserNumber() <= 0) {
                 recordTopicRoomPort.deleteRoom(roomId);
+            } else {
+                publishActiveUserNumberChanged(room.getId(), room.getActiveUserNumber());
             }
         } catch (UnknownTopicRoomException e) {
             log.info("[leaveRoom] 다른 스레드에 의해 이미 지워진 토픽룸 {}번", roomId);
+        }
+    }
+
+    // 탈퇴 유저가 참여 중인 방 전체 나가기 — 방별 try/catch로 한 방 실패가 나머지를 막지 않게
+    @Override
+    @Transactional
+    public void leaveAllRooms(Long userId) {
+        List<Long> roomIds = topicRoomAdaptor.findAllJoinedRoomIdsByUserId(userId);
+        for (Long roomId : roomIds) {
+            try {
+                leaveRoom(userId, roomId);
+            } catch (Exception e) {
+                log.warn(">>> [TopicRoom] 탈퇴 유저 방 나가기 실패 userId={}, roomId={}, cause={}",
+                        userId, roomId, e.getMessage());
+            }
         }
     }
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/WebSocketConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/WebSocketConfig.java
@@ -3,11 +3,14 @@ package com.storix.infrastructure.config;
 import com.storix.infrastructure.external.chat.StompHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.*;
 import org.springframework.web.socket.server.HandshakeInterceptor;
@@ -24,8 +27,19 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/sub");
+        registry.enableSimpleBroker("/sub")
+                .setHeartbeatValue(new long[]{10000, 10000})
+                .setTaskScheduler(webSocketHeartbeatScheduler());
         registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Bean
+    public TaskScheduler webSocketHeartbeatScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("ws-heartbeat-");
+        scheduler.initialize();
+        return scheduler;
     }
 
     @Override
@@ -36,10 +50,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 "https://api.storix.kr",
                 "http://localhost:3000",
                 "http://localhost:5173",
-                "capacitor://localhost",
-                "https://localhost",
-                "https://storix-fe-git-develop-kim-yunseongs-projects.vercel.app",
-                "https://storix-fe-git-main-kim-yunseongs-projects.vercel.app"
+                "https://localhost"
         ).addInterceptors(new HandshakeInterceptor() {
             @Override
             public boolean beforeHandshake(


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 회원 탈퇴 시 토픽룸 전체 나가기 처리
탈퇴해도 참여 중이던 토픽룸에 그대로 남아 활성 인원수·방 상태 정합성이 깨지던 문제를 처리했습니다.

- 탈퇴 이벤트
  - UserAccessRevokedEvent(WITHDRAWN) -> TopicRoomWithdrawListener (AFTER_COMMIT)
- 전체 나가기 로직
  - TopicRoomUseCase.leaveAllRooms(userId) 추가, TopicRoomService에 구현
  - findAllJoinedRoomIdsByUserId로 참여 방 조회 후 방별로 leaveRoom 호출
  - 방별 try/catch로 격리 -> 예외 터져도 나머지 방 나가기를 막지 않음
- leaveRoom 활성 인원수
  - 활성 인원수 0 이하 -> 방 삭제, 그 외 -> 활성 인원수 변경 발행

### 2. STOMP 하트비트 활성화로 실시간 수신 복구
방에 있는 동안 소켓이 조용히 끊겨도 서버가 감지하지 못하고 죽은 세션으로 계속 발송 -> 실시간 채팅 수신 누락
방을 나갔다 들어와야만 복구되던 문제를 해결했습니다.

- SimpleBroker 하트비트 설정
  - enableSimpleBroker에 setHeartbeatValue(10000, 10000) + 전용 TaskScheduler(ThreadPoolTaskScheduler) 주입

=> 서버·클라 양쪽이 ~10초 내 끊김 감지-> 죽은 세션/구독 정리 + 클라 자동 재연결·재구독 -> 방 재진입 없이 실시간 수신 복구


### 3. 기타
- 사용하지 않는 웹소켓 허용 오리진 제거


## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #128 

## 🖇️ 기타