### PR TITLE
Feat: [모니터링] Prometheus/Loki/Grafana 스택 및 배포 구성 추가

### DIFF
--- a/.github/workflows/cd-monitoring.yml
+++ b/.github/workflows/cd-monitoring.yml
@@ -1,14 +1,5 @@
 name: STORIX CD - Deploy Monitoring Stack
 
-# 모니터링 설정(알림 룰 포함)이 바뀔 때만 돈다. 앱 배포와 완전히 분리.
-# self-hosted runner 를 쓰지 않는다(public 레포 보안). GitHub 러너가 OIDC 로 AWS 에 붙어
-# SSM send-command 로 모니터링 EC2 에서 배포를 실행한다. 박스엔 러너가 없다.
-#
-# 사전 준비
-#   - 모니터링 EC2 에 레포가 /home/ubuntu/storix-monitoring 에 클론, .env 존재
-#   - EC2 IAM: AmazonSSMManagedInstanceCore (SSM 에이전트) + Loki S3 / ec2:DescribeInstances
-#   - GitHub Secrets: MONITORING_DEPLOY_ROLE_ARN, MONITORING_INSTANCE_ID
-
 on:
   push:
     branches:
@@ -19,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write   # OIDC 로 AWS 역할 assume
+  id-token: write
   contents: read
 
 jobs:
@@ -39,7 +30,6 @@ jobs:
 
       - name: Deploy via SSM
         run: |
-          # $LOKI_USER 등은 러너가 아니라 EC2 셸이 .env 로드 후 치환해야 하므로 quoted heredoc
           cat > /tmp/params.json << 'JSON'
           {
             "commands": [
@@ -49,12 +39,12 @@ jobs:
               "git fetch --prune origin",
               "git reset --hard origin/develop",
               "set -a && . ./.env && set +a",
-              "docker run --rm httpd:2.4-alpine htpasswd -nbB \"$LOKI_USER\" \"$LOKI_PASSWORD\" > monitoring/nginx/.htpasswd",
+              "printf '%s' \"$LOKI_PASSWORD\" | docker run --rm -i httpd:2.4-alpine htpasswd -niB \"$LOKI_USER\" > monitoring/nginx/.htpasswd",
               "chmod 600 monitoring/nginx/.htpasswd",
               "cd monitoring",
               "docker compose -f compose-monitoring.yml config -q",
               "docker compose -f compose-monitoring.yml up -d",
-              "curl -sf -X POST http://localhost:9090/-/reload",
+              "for i in $(seq 1 10); do if curl -sf -X POST http://localhost:9090/-/reload; then break; fi; if [ $i -eq 10 ]; then echo 'prometheus reload failed'; exit 1; fi; sleep 3; done",
               "docker compose -f compose-monitoring.yml restart grafana",
               "chown -R ubuntu:ubuntu /home/ubuntu/storix-monitoring"
             ]
@@ -69,7 +59,6 @@ jobs:
             --query "Command.CommandId" --output text)
           echo "CommandId: $CMD_ID"
 
-          # SSM 은 비동기 — 결과를 안 기다리면 실패해도 초록불. 완료까지 대기 후 상태 확인.
           aws ssm wait command-executed --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" || true
 
           echo "===== STDOUT ====="

--- a/.github/workflows/cd-monitoring.yml
+++ b/.github/workflows/cd-monitoring.yml
@@ -1,0 +1,82 @@
+name: STORIX CD - Deploy Monitoring Stack
+
+# 모니터링 설정(알림 룰 포함)이 바뀔 때만 돈다. 앱 배포와 완전히 분리.
+# self-hosted runner 를 쓰지 않는다(public 레포 보안). GitHub 러너가 OIDC 로 AWS 에 붙어
+# SSM send-command 로 모니터링 EC2 에서 배포를 실행한다. 박스엔 러너가 없다.
+#
+# 사전 준비
+#   - 모니터링 EC2 에 레포가 /home/ubuntu/storix-monitoring 에 클론, .env 존재
+#   - EC2 IAM: AmazonSSMManagedInstanceCore (SSM 에이전트) + Loki S3 / ec2:DescribeInstances
+#   - GitHub Secrets: MONITORING_DEPLOY_ROLE_ARN, MONITORING_INSTANCE_ID
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'monitoring/**'
+      - '.github/workflows/cd-monitoring.yml'
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # OIDC 로 AWS 역할 assume
+  contents: read
+
+jobs:
+  deploy-monitoring:
+    name: Deploy Monitoring Stack (via SSM)
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ap-northeast-2
+      INSTANCE_ID: ${{ secrets.MONITORING_INSTANCE_ID }}
+
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.MONITORING_DEPLOY_ROLE_ARN }}
+          aws-region: ap-northeast-2
+
+      - name: Deploy via SSM
+        run: |
+          # $LOKI_USER 등은 러너가 아니라 EC2 셸이 .env 로드 후 치환해야 하므로 quoted heredoc
+          cat > /tmp/params.json << 'JSON'
+          {
+            "commands": [
+              "set -euo pipefail",
+              "git config --global --add safe.directory /home/ubuntu/storix-monitoring",
+              "cd /home/ubuntu/storix-monitoring",
+              "git fetch --prune origin",
+              "git reset --hard origin/develop",
+              "set -a && . ./.env && set +a",
+              "docker run --rm httpd:2.4-alpine htpasswd -nbB \"$LOKI_USER\" \"$LOKI_PASSWORD\" > monitoring/nginx/.htpasswd",
+              "chmod 600 monitoring/nginx/.htpasswd",
+              "cd monitoring",
+              "docker compose -f compose-monitoring.yml config -q",
+              "docker compose -f compose-monitoring.yml up -d",
+              "curl -sf -X POST http://localhost:9090/-/reload",
+              "docker compose -f compose-monitoring.yml restart grafana",
+              "chown -R ubuntu:ubuntu /home/ubuntu/storix-monitoring"
+            ]
+          }
+          JSON
+
+          CMD_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name AWS-RunShellScript \
+            --comment "Deploy monitoring stack" \
+            --parameters file:///tmp/params.json \
+            --query "Command.CommandId" --output text)
+          echo "CommandId: $CMD_ID"
+
+          # SSM 은 비동기 — 결과를 안 기다리면 실패해도 초록불. 완료까지 대기 후 상태 확인.
+          aws ssm wait command-executed --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" || true
+
+          echo "===== STDOUT ====="
+          aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" --query StandardOutputContent --output text
+          echo "===== STDERR ====="
+          aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" --query StandardErrorContent --output text
+
+          STATUS=$(aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" --query Status --output text)
+          echo "Status: $STATUS"
+          [ "$STATUS" = "Success" ] || { echo "배포 실패"; exit 1; }

--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,8 @@ out/
 *.env
 
 ### 추가가 필요한 파일은 예외로 추가하기 ###
-*.yml
-!ci.yml
-!cd.yml
-*application.yml
+application.yml
+application-*.yml
 *.properties
 
 !gradle/wrapper/gradle-wrapper.jar
@@ -55,3 +53,8 @@ out/
 .claude
 /tools
 *.sql
+
+/docker-compose.yml
+
+### nginx basic auth
+monitoring/nginx/.htpasswd

--- a/monitoring/compose-monitoring.yml
+++ b/monitoring/compose-monitoring.yml
@@ -1,0 +1,72 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: prometheus
+    mem_limit: 512m
+    environment:
+      - GOMEMLIMIT=460MiB
+
+    restart: unless-stopped
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=15d'
+      - '--web.enable-lifecycle'
+    ports:
+      - "127.0.0.1:9090:9090"
+
+  loki:
+    image: grafana/loki:3.1.1
+    container_name: loki
+    mem_limit: 384m
+    restart: unless-stopped
+    command:
+      - '-config.file=/etc/loki/loki.yml'
+      - '-config.expand-env=true'
+    environment:
+      - LOKI_S3_BUCKET=${LOKI_S3_BUCKET:?set LOKI_S3_BUCKET}
+      - AWS_REGION=${AWS_REGION:-ap-northeast-2}
+      - GOMEMLIMIT=340MiB
+    volumes:
+      - ./loki/loki.yml:/etc/loki/loki.yml:ro
+      - loki-data:/loki
+
+  # 앱 EC2의 Alloy 가 여기로 로그를 push 한다 (basic auth).
+  loki-proxy:
+    image: nginx:1.27-alpine
+    container_name: loki-proxy
+    mem_limit: 32m
+    restart: unless-stopped
+    volumes:
+      - ./nginx/loki.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/.htpasswd:/etc/nginx/.htpasswd:ro
+    ports:
+      - "3100:3100"
+    depends_on:
+      - loki
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: grafana
+    mem_limit: 384m
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL:?set SLACK_WEBHOOK_URL}
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/etc/grafana/dashboards:ro
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on:
+      - prometheus
+      - loki
+
+volumes:
+  prometheus-data:
+  grafana-data:
+  loki-data:

--- a/monitoring/grafana/dashboards/storix-service.json
+++ b/monitoring/grafana/dashboards/storix-service.json
@@ -1,0 +1,120 @@
+{
+  "uid": "storix-service",
+  "title": "STORIX 서비스 / 부하",
+  "tags": ["storix"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "editable": true,
+  "refresh": "10s",
+  "time": { "from": "now-30m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "application",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": { "query": "label_values(http_server_requests_seconds_count, application)", "refId": "app" },
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "env",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": { "query": "label_values(http_server_requests_seconds_count, env)", "refId": "env" },
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "요청 처리량 (RPS)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(http_server_requests_seconds_count{application=~\"$application\", env=~\"$env\"}[1m]))", "legendFormat": "total" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (uri) (rate(http_server_requests_seconds_count{application=~\"$application\", env=~\"$env\"}[1m]))", "legendFormat": "{{uri}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "응답시간 (p50 / p95 / p99)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{application=~\"$application\", env=~\"$env\"}[5m])))", "legendFormat": "p50" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{application=~\"$application\", env=~\"$env\"}[5m])))", "legendFormat": "p95" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{application=~\"$application\", env=~\"$env\"}[5m])))", "legendFormat": "p99" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "5xx 에러율",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0 }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\", application=~\"$application\", env=~\"$env\"}[1m])) / sum(rate(http_server_requests_seconds_count{application=~\"$application\", env=~\"$env\"}[1m]))", "legendFormat": "5xx rate" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "상태코드별 처리량",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (status) (rate(http_server_requests_seconds_count{application=~\"$application\", env=~\"$env\"}[1m]))", "legendFormat": "{{status}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "JVM 힙 사용률",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (application, instance_id) (jvm_memory_used_bytes{area=\"heap\", application=~\"$application\", env=~\"$env\"}) / sum by (application, instance_id) (jvm_memory_max_bytes{area=\"heap\", application=~\"$application\", env=~\"$env\"})", "legendFormat": "{{application}} {{instance_id}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "GC 시간 비율 (rate of pause)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0 }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (application, instance_id) (rate(jvm_gc_pause_seconds_sum{application=~\"$application\", env=~\"$env\"}[5m]))", "legendFormat": "{{application}} {{instance_id}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "DB 커넥션 풀 (HikariCP)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (application) (hikaricp_connections_active{application=~\"$application\", env=~\"$env\"})", "legendFormat": "active" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (application) (hikaricp_connections_idle{application=~\"$application\", env=~\"$env\"})", "legendFormat": "idle" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (application) (hikaricp_connections_pending{application=~\"$application\", env=~\"$env\"})", "legendFormat": "pending (대기)" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU 사용률",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "system_cpu_usage{application=~\"$application\", env=~\"$env\"}", "legendFormat": "system {{instance_id}}" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "process_cpu_usage{application=~\"$application\", env=~\"$env\"}", "legendFormat": "process {{instance_id}}" }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/alerting/contact-points.yml
+++ b/monitoring/grafana/provisioning/alerting/contact-points.yml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: slack
+    receivers:
+      - uid: slack-storix
+        type: slack
+        settings:
+          url: ${SLACK_WEBHOOK_URL}
+          title: '{{ if eq .Status "firing" }}🔥{{ else }}✅{{ end }} [{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
+          text: |-
+            {{ range .Alerts }}
+            *{{ .Labels.severity }}* | env=`{{ .Labels.env }}` app=`{{ .Labels.application }}`
+            {{ .Annotations.summary }}
+            {{ if .Annotations.runbook }}→ {{ .Annotations.runbook }}{{ end }}
+            {{ end }}

--- a/monitoring/grafana/provisioning/alerting/notification-policies.yml
+++ b/monitoring/grafana/provisioning/alerting/notification-policies.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: slack
+    group_by: [alertname, env]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 12h
+    routes:
+      - receiver: slack
+        object_matchers:
+          - ['severity', '=', 'critical']
+        repeat_interval: 1h

--- a/monitoring/grafana/provisioning/alerting/rules.yml
+++ b/monitoring/grafana/provisioning/alerting/rules.yml
@@ -43,7 +43,7 @@ groups:
           severity: warning
         annotations:
           summary: '힙 사용률이 85%를 넘겼습니다. 메모리 누수 또는 Full GC 로 인한 응답 지연이 임박했습니다.'
-        noDataState: NoData
+        noDataState: OK
         execErrState: Alerting
         data:
           - refId: A
@@ -73,7 +73,7 @@ groups:
         annotations:
           summary: '전체 시간의 20% 이상을 GC 로 보내고 있습니다. 응답이 사실상 멈춥니다.'
           runbook: '힙 덤프 확보 -> 메모리 누수 의심'
-        noDataState: NoData
+        noDataState: OK
         execErrState: Alerting
         data:
           - refId: A
@@ -103,7 +103,7 @@ groups:
           severity: warning
         annotations:
           summary: 'Full GC 가 분당 1회를 넘습니다. 곧 스레싱으로 번집니다.'
-        noDataState: NoData
+        noDataState: OK
         execErrState: Alerting
         data:
           - refId: A
@@ -133,7 +133,7 @@ groups:
           severity: warning
         annotations:
           summary: 'CPU 가 1분 이상 90%를 넘겼습니다. 순간 피크가 아니라 과부하입니다.'
-        noDataState: NoData
+        noDataState: OK
         execErrState: Alerting
         data:
           - refId: A
@@ -161,7 +161,7 @@ groups:
         annotations:
           summary: 'HikariCP 활성 커넥션이 90%를 넘겼습니다. 곧 요청이 커넥션을 기다리며 밀립니다.'
           runbook: '느린 쿼리 / 트랜잭션 누수 / OSIV 확인'
-        noDataState: NoData
+        noDataState: OK
         execErrState: Alerting
         data:
           - refId: A
@@ -195,7 +195,7 @@ groups:
         annotations:
           summary: '서버 에러율이 1%를 넘겼습니다.'
           runbook: 'Loki: {job="storix"} | json | level="ERROR"'
-        noDataState: NoData
+        noDataState: OK
         execErrState: Alerting
         data:
           - refId: A
@@ -229,7 +229,7 @@ groups:
         annotations:
           summary: '상위 1% 요청의 응답시간이 1초를 넘습니다.'
           runbook: 'application.yml 에 percentiles-histogram 설정이 있어야 이 지표가 나온다'
-        noDataState: NoData
+        noDataState: OK
         execErrState: Alerting
         data:
           - refId: A

--- a/monitoring/grafana/provisioning/alerting/rules.yml
+++ b/monitoring/grafana/provisioning/alerting/rules.yml
@@ -1,0 +1,408 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: storix-infra
+    folder: STORIX
+    interval: 1m
+    rules:
+
+      - uid: storix-app-down
+        title: '서비스 다운'
+        condition: B
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: '{{ $labels.application }} 인스턴스가 스크랩되지 않습니다 (다운 또는 네트워크 단절).'
+          runbook: 'EC2 상태 / 보안그룹(9100·9101) / docker ps 확인'
+        noDataState: Alerting
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: 'up{job=~"storix-.*"}'
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+
+      - uid: storix-jvm-heap
+        title: 'JVM 힙 사용률 85% 초과'
+        condition: B
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: '힙 사용률이 85%를 넘겼습니다. 메모리 누수 또는 Full GC 로 인한 응답 지연이 임박했습니다.'
+        noDataState: NoData
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: |
+                sum by (env, application, instance_id) (jvm_memory_used_bytes{area="heap"})
+                / sum by (env, application, instance_id) (jvm_memory_max_bytes{area="heap"})
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.85] }
+
+      - uid: storix-gc-thrashing
+        title: 'GC 스레싱'
+        condition: B
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: '전체 시간의 20% 이상을 GC 로 보내고 있습니다. 응답이 사실상 멈춥니다.'
+          runbook: '힙 덤프 확보 -> 메모리 누수 의심'
+        noDataState: NoData
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: |
+                sum by (env, application, instance_id) (
+                  rate(jvm_gc_pause_seconds_sum{job=~"storix-.*"}[5m])
+                )
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.2] }
+
+      - uid: storix-full-gc-frequent
+        title: 'Full GC 가 분당 1회 넘게 발생'
+        condition: B
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Full GC 가 분당 1회를 넘습니다. 곧 스레싱으로 번집니다.'
+        noDataState: NoData
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: |
+                sum by (env, application, instance_id) (
+                  rate(jvm_gc_pause_seconds_count{job=~"storix-.*", action="end of major GC"}[5m])
+                ) * 60
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [1] }
+
+      - uid: storix-cpu-high
+        title: 'CPU 사용률 90% 초과'
+        condition: B
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'CPU 가 1분 이상 90%를 넘겼습니다. 순간 피크가 아니라 과부하입니다.'
+        noDataState: NoData
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: 'system_cpu_usage{job=~"storix-.*"}'
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.9] }
+
+      - uid: storix-db-pool
+        title: 'DB 커넥션 풀 90% 초과'
+        condition: B
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'HikariCP 활성 커넥션이 90%를 넘겼습니다. 곧 요청이 커넥션을 기다리며 밀립니다.'
+          runbook: '느린 쿼리 / 트랜잭션 누수 / OSIV 확인'
+        noDataState: NoData
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: 'hikaricp_connections_active / hikaricp_connections_max'
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.9] }
+
+  - orgId: 1
+    name: storix-service
+    folder: STORIX
+    interval: 1m
+    rules:
+
+      - uid: storix-5xx-rate
+        title: '5xx 에러율 1% 초과'
+        condition: B
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: '서버 에러율이 1%를 넘겼습니다.'
+          runbook: 'Loki: {job="storix"} | json | level="ERROR"'
+        noDataState: NoData
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: |
+                (
+                  sum by (env, application) (rate(http_server_requests_seconds_count{status=~"5.."}[5m]))
+                  / sum by (env, application) (rate(http_server_requests_seconds_count[5m]))
+                )
+                and
+                (sum by (env, application) (rate(http_server_requests_seconds_count[5m])) > 0.05)
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.01] }
+
+      - uid: storix-latency-p99
+        title: 'p99 응답시간 1초 초과'
+        condition: B
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: '상위 1% 요청의 응답시간이 1초를 넘습니다.'
+          runbook: 'application.yml 에 percentiles-histogram 설정이 있어야 이 지표가 나온다'
+        noDataState: NoData
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: |
+                histogram_quantile(
+                  0.99,
+                  sum by (le, env, application) (rate(http_server_requests_seconds_bucket[5m]))
+                )
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [1] }
+
+  - orgId: 1
+    name: storix-notification
+    folder: STORIX
+    interval: 1m
+    rules:
+
+      - uid: storix-executor-rejected
+        title: '알림 작업이 큐에서 버려짐'
+        condition: B
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: '비동기 큐가 꽉 차 작업이 거부됐습니다. 알림이 실제로 유실됩니다. executor={{ $labels.executor }}'
+          runbook: 'AsyncConfig 의 풀/큐 크기 확인. Loki: {job="storix"} | json | level="ERROR"'
+        noDataState: OK
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: 'sum by (env, executor) (increase(notification_executor_rejected_total[5m]))'
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
+      - uid: storix-notification-force-finalize
+        title: '알림 발송이 정체돼 강제 종료됨'
+        condition: B
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: '발송이 끝나지 않아 배치가 강제 마감했습니다. 정상 운영이면 0이어야 합니다.'
+          runbook: 'Loki: {job="storix"} | json | adminNotificationId != ""'
+        noDataState: OK
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 3600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: 'sum by (env) (increase(admin_notification_force_finalize_total[1h]))'
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
+      - uid: storix-notification-sending-stuck
+        title: 'SENDING 상태 알림이 쌓임'
+        condition: B
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'SENDING 인 알림이 30분 넘게 5건 이상 남아 있습니다. 발송이 안 끝나고 정체 중입니다.'
+        noDataState: OK
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 1800, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: 'max by (env) (admin_notification_sending_inflight)'
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [5] }
+
+      - uid: storix-fcm-failure-spike
+        title: 'FCM 발송 실패 급증'
+        condition: B
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'FCM 실패가 10분간 50건을 넘었습니다. code={{ $labels.code }}'
+          runbook: '토큰 만료(UNREGISTERED/INVALID_ARGUMENT)는 정상이라 제외돼 있다. 그 외 코드면 설정·인증 문제일 수 있다.'
+        noDataState: OK
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              # 만료 토큰 정리는 정상 동작이므로 알림 대상에서 제
+              expr: |
+                sum by (env, code) (
+                  increase(fcm_send_failure_total{code!~"UNREGISTERED|INVALID_ARGUMENT"}[10m])
+                )
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [50] }
+
+  - orgId: 1
+    name: storix-logs
+    folder: STORIX
+    interval: 1m
+    rules:
+
+      - uid: storix-error-log-spike
+        title: 'ERROR 로그 급증'
+        condition: B
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'ERROR 로그가 5분간 10건을 넘었습니다.'
+          runbook: 'Loki: {job="storix"} | json | level="ERROR"'
+        noDataState: OK
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: loki
+            model:
+              refId: A
+              queryType: instant
+              expr: 'sum by (env) (count_over_time({job="storix"} | json | level="ERROR" [5m]))'
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [10] }

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -6,7 +6,7 @@ providers:
     folder: STORIX
     type: file
     disableDeletion: false
-    editable: true
+    allowUiUpdates: true
     updateIntervalSeconds: 30
     options:
       path: /etc/grafana/dashboards

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: storix
+    orgId: 1
+    folder: STORIX
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true

--- a/monitoring/loki/loki.yml
+++ b/monitoring/loki/loki.yml
@@ -1,0 +1,43 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    s3:
+      bucketnames: ${LOKI_S3_BUCKET}
+      region: ${AWS_REGION}
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+
+limits_config:
+  retention_period: 90d
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  max_label_names_per_series: 15
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: s3

--- a/monitoring/nginx/loki.conf
+++ b/monitoring/nginx/loki.conf
@@ -1,0 +1,16 @@
+server {
+    listen 3100;
+
+    auth_basic           "STORIX Loki";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
+    client_max_body_size 16m;
+
+    location / {
+        proxy_pass http://loki:3100;
+
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,42 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  external_labels:
+    monitor: storix
+
+scrape_configs:
+  - job_name: storix-api
+    metrics_path: /actuator/prometheus
+    ec2_sd_configs:
+      - region: ap-northeast-2
+        port: 9100
+        filters:
+          - name: tag:Service
+            values: [storix-api]
+          - name: instance-state-name
+            values: [running]
+    relabel_configs:
+      - source_labels: [__meta_ec2_tag_Env]
+        target_label: env
+      - source_labels: [__meta_ec2_instance_id]
+        target_label: instance_id
+      - target_label: application
+        replacement: storix-api
+
+  - job_name: storix-batch
+    metrics_path: /actuator/prometheus
+    ec2_sd_configs:
+      - region: ap-northeast-2
+        port: 9101
+        filters:
+          - name: tag:Service
+            values: [storix-batch]
+          - name: instance-state-name
+            values: [running]
+    relabel_configs:
+      - source_labels: [__meta_ec2_tag_Env]
+        target_label: env
+      - source_labels: [__meta_ec2_instance_id]
+        target_label: instance_id
+      - target_label: application
+        replacement: storix-batch


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 1. 모니터링 스택 구성
- [x] Prometheus / Loki / Grafana / nginx 4개 컨테이너
- [x] t3.small(2GB) 메모리 > `mem_limit` + Go 서비스 `GOMEMLIMIT`
- [x] 포트 `127.0.0.1` 바인딩, SSM 접속

### 2. 지표 수집 (Prometheus)
- [x] `ec2_sd_configs` 자동탐색 - `Service` 태그(storix-api/batch) 기반, ASG 스케일링 대응 (IP 고정 X)
- [x] relabel 로 `env` / `instance_id` / `application` 라벨링
- [x] 15초 스크레이프, 15일 보관

### 3. 로그 수집 (Loki)
- [x] S3 청크 저장 - IAM 인스턴스 프로파일 인증, 90일 보관
- [x] nginx basic auth 로 push 보호 > SG + auth

### 4. Grafana 프로비저닝
**데이터소스** > Prometheus/Loki 부팅 시 자동 등록

**알림 룰** (`rules.yml`)
- [x] `critical` : 서비스 다운, GC 스레싱, 5xx 1% 초과, 알림 큐 유실
- [x] `warning` : JVM 힙 85%, Full GC, CPU 90%, DB풀 90%, p99 1s, 알림 강제종료, SENDING 정체, FCM 실패 급증, ERROR 로그 급증

**알림 채널** - Slack 연동 (critical 1시간 / 기본 12시간 재알림)

**대시보드** - 서비스/부하 (`storix-service.json`, 8패널)
- [x] RPS · 응답시간(p50/p95/p99) · 5xx 에러율 · 상태코드별 처리량
- [x] JVM 힙 · GC 시간비율 · HikariCP · CPU

### 5. 배포 (CD)
- [x] `cd-monitoring.yml` : develop push 시 `monitoring/**` 변경만 배포 
- [x] htpasswd 생성 -> 기동 -> Prometheus 리로드 -> Grafana 재시작 -> 알림 룰 등록 검증

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #131 

## 🖇️ 기타