### PR TITLE
Chore: [인프라] JVM 메모리 한도 준수 및 CI/모니터링 배포 정리

### DIFF
--- a/.github/workflows/cd-monitoring.yml
+++ b/.github/workflows/cd-monitoring.yml
@@ -41,7 +41,7 @@ jobs:
               "git reset --hard origin/develop",
               "set -a && . ./.env && set +a",
               "printf '%s' \"$LOKI_PASSWORD\" | docker run --rm -i httpd:2.4-alpine htpasswd -niB \"$LOKI_USER\" > monitoring/nginx/.htpasswd",
-              "chmod 600 monitoring/nginx/.htpasswd",
+              "chmod 644 monitoring/nginx/.htpasswd",
               "cd monitoring",
               "docker compose -f compose-monitoring.yml config -q",
               "docker compose -f compose-monitoring.yml up -d",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - develop
+    paths-ignore:
+      - 'monitoring/**'
+      - '.github/workflows/cd-monitoring.yml'
 
 jobs:
   build-and-push:

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ application-*.yml
 
 .omc/state
 /storix-db-tunnel.sh
+/storix-grafana-tunnel.sh
 .claude
 /tools
 *.sql

--- a/STORIX-Api/Dockerfile
+++ b/STORIX-Api/Dockerfile
@@ -3,6 +3,8 @@ FROM eclipse-temurin:17-jre-alpine
 ENV TZ=Asia/Seoul
 WORKDIR /app
 
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
+
 COPY STORIX-Api/build/libs/*.jar app.jar
 
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -Duser.timezone=Asia/Seoul -jar app.jar"]

--- a/STORIX-Batch/Dockerfile
+++ b/STORIX-Batch/Dockerfile
@@ -3,6 +3,8 @@ FROM eclipse-temurin:17-jre
 ENV TZ=Asia/Seoul
 WORKDIR /app
 
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
+
 COPY STORIX-Batch/build/libs/*.jar app.jar
 
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -Duser.timezone=Asia/Seoul -jar app.jar"]


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
- [x] **Dockerfile JVM MaxRAMPercentage=70**
   컨테이너 `mem_limit`의 70%를 힙으로 사용하도록 설정
- [x] **ci.yml paths-ignore**
   `monitoring/**`·`cd-monitoring.yml`만 바뀐 develop 푸시는 앱 CI/CD 제외
- [x] **cd-monitoring.yml htpasswd 권한 644**
  nginx 워커가 `.htpasswd`를 못 읽어 발생하던 로그 push 500 에러 해결

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요? (→ develop)
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #137 

## 🖇️ 기타
