### PR TITLE
Fix: [모니터링] actuator/prometheus 인증 허용 및 서비스 대시보드 이름 변경

### DIFF
--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
@@ -107,6 +107,7 @@ public class SecurityConfig {
                         (requests) -> requests
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                 .requestMatchers("/actuator/health").permitAll()
+                                .requestMatchers("/actuator/prometheus").permitAll()
 
                                 // [Onboarding]
                                 .requestMatchers("/api/v1/onboarding/**").permitAll()

--- a/monitoring/grafana/dashboards/storix-service.json
+++ b/monitoring/grafana/dashboards/storix-service.json
@@ -1,6 +1,6 @@
 {
   "uid": "storix-service",
-  "title": "STORIX 서비스 / 부하",
+  "title": "STORIX 서비스 지표",
   "tags": ["storix"],
   "timezone": "browser",
   "schemaVersion": 39,


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
- [x] **SecurityConfig
   `/actuator/prometheus` 인증 허용**: 관리 포트(9100) 분리 후 Prometheus 스크레이프 시 401 발생→ `permitAll()` 추가
- [x] **서비스 대시보드 이름 변경**
   STORIX 서비스 / 부하` -> `STORIX 서비스 지표`

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #137 

## 🖇️ 기타
