### PR TITLE
Chore: [배포] dev/prod CI·CD 환경 분리

### DIFF
--- a/.github/workflows/cd-monitoring.yml
+++ b/.github/workflows/cd-monitoring.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.MONITORING_DEPLOY_ROLE_ARN }}
           aws-region: ap-northeast-2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Configure AWS credentials (OIDC)
         if: ${{ steps.target.outputs.deploy == 'true' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.APP_DEPLOY_ROLE_ARN }}
           aws-region: ap-northeast-2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,29 +27,48 @@ jobs:
           if [ "$BRANCH" = "main" ]; then
             echo "instance_id=${{ secrets.PROD_INSTANCE_ID }}" >> "$GITHUB_OUTPUT"
             echo "pull_batch=true" >> "$GITHUB_OUTPUT"
+            echo "env_tag=prod" >> "$GITHUB_OUTPUT"
             echo "deploy=true" >> "$GITHUB_OUTPUT"
           elif [ "$BRANCH" = "develop" ]; then
             echo "instance_id=${{ secrets.DEV_INSTANCE_ID }}" >> "$GITHUB_OUTPUT"
             echo "pull_batch=false" >> "$GITHUB_OUTPUT"
+            echo "env_tag=dev" >> "$GITHUB_OUTPUT"
             echo "deploy=true" >> "$GITHUB_OUTPUT"
           else
             echo "deploy=false" >> "$GITHUB_OUTPUT"
             echo "Not a deploy branch: $BRANCH — skipping."
           fi
 
-      - name: Configure AWS credentials (OIDC)
+      - name: Skip if superseded by a newer commit
+        id: fresh
         if: ${{ steps.target.outputs.deploy == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          LATEST=$(gh api "repos/${{ github.repository }}/commits/${BRANCH}" --jq .sha)
+          if [ "$LATEST" != "$SHA" ]; then
+            echo "Superseded: branch tip=$LATEST, this run=$SHA — skipping stale deploy."
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        if: ${{ steps.target.outputs.deploy == 'true' && steps.fresh.outputs.stale != 'true' }}
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.APP_DEPLOY_ROLE_ARN }}
           aws-region: ap-northeast-2
 
       - name: Deploy via SSM
-        if: ${{ steps.target.outputs.deploy == 'true' }}
+        if: ${{ steps.target.outputs.deploy == 'true' && steps.fresh.outputs.stale != 'true' }}
         env:
           INSTANCE_ID: ${{ steps.target.outputs.instance_id }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
           SHA: ${{ github.event.workflow_run.head_sha }}
+          ENV_TAG: ${{ steps.target.outputs.env_tag }}
           PULL_BATCH: ${{ steps.target.outputs.pull_batch }}
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
         run: |
@@ -61,6 +80,7 @@ jobs:
             "commands": [
               "set -eu",
               "export HOME=/root",
+              "export IMAGE_TAG=${ENV_TAG}-${SHA}",
               "cd /home/ubuntu/storix",
               "test -f docker-compose.yml || { echo 'compose missing'; exit 1; }",
               "test -f .env || { echo 'env missing'; exit 1; }",

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,38 +7,88 @@ on:
     types:
       - completed
 
-jobs:
-  deploy-to-ec2:
-    name: Deploy to EC2
-    runs-on: self-hosted
-    env:
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-      ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+permissions:
+  id-token: write
+  contents: read
 
+jobs:
+  deploy:
+    name: Deploy to EC2 (via SSM)
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    env:
+      AWS_REGION: ap-northeast-2
 
     steps:
-      - name: Deploy on EC2 Instance
+      - name: Resolve target by branch
+        id: target
         run: |
-          cd ~/storix
-          test -f docker-compose.yml || { echo "ERROR: docker-compose.yml not found"; exit 1; }
-          test -f .env || { echo "ERROR: .env not found"; exit 1; }
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          if [ "$BRANCH" = "main" ]; then
+            echo "instance_id=${{ secrets.PROD_INSTANCE_ID }}" >> "$GITHUB_OUTPUT"
+            echo "pull_batch=true" >> "$GITHUB_OUTPUT"
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          elif [ "$BRANCH" = "develop" ]; then
+            echo "instance_id=${{ secrets.DEV_INSTANCE_ID }}" >> "$GITHUB_OUTPUT"
+            echo "pull_batch=false" >> "$GITHUB_OUTPUT"
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "Not a deploy branch: $BRANCH — skipping."
+          fi
 
-          echo ">>> Logging in to ECR..."
-          aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_REGISTRY
+      - name: Configure AWS credentials (OIDC)
+        if: ${{ steps.target.outputs.deploy == 'true' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.APP_DEPLOY_ROLE_ARN }}
+          aws-region: ap-northeast-2
 
-          echo ">>> Pulling latest images from ECR..."
-          docker compose pull app
-          docker compose pull batch
+      - name: Deploy via SSM
+        if: ${{ steps.target.outputs.deploy == 'true' }}
+        env:
+          INSTANCE_ID: ${{ steps.target.outputs.instance_id }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PULL_BATCH: ${{ steps.target.outputs.pull_batch }}
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+        run: |
+          BATCH_LINE="true"
+          if [ "$PULL_BATCH" = "true" ]; then BATCH_LINE="docker compose pull batch"; fi
 
-          echo ">>> Fetching config.alloy..."
-          mkdir -p alloy
-          curl -sfL https://raw.githubusercontent.com/Team-STORIX/STORIX-BE-2.0/develop/monitoring/app-side/config.alloy -o alloy/config.alloy
+          cat > /tmp/params.json << JSON
+          {
+            "commands": [
+              "set -eu",
+              "export HOME=/root",
+              "cd /home/ubuntu/storix",
+              "test -f docker-compose.yml || { echo 'compose missing'; exit 1; }",
+              "test -f .env || { echo 'env missing'; exit 1; }",
+              "aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}",
+              "mkdir -p alloy",
+              "curl -sfL https://raw.githubusercontent.com/Team-STORIX/STORIX-BE-2.0/${BRANCH}/monitoring/app-side/config.alloy -o alloy/config.alloy",
+              "docker compose pull app",
+              "${BATCH_LINE}",
+              "docker compose up -d",
+              "docker image prune -af"
+            ]
+          }
+          JSON
 
-          echo ">>> Starting new containers..."
-          docker compose up -d
+          CMD_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name AWS-RunShellScript \
+            --comment "Deploy app ($BRANCH)" \
+            --parameters file:///tmp/params.json \
+            --query "Command.CommandId" --output text)
+          echo "CommandId: $CMD_ID"
 
-          echo ">>> Pruning old images..."
-          docker image prune -af
+          aws ssm wait command-executed --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" || true
 
-          echo "✅ Deployment successful!"
+          echo "===== STDOUT ====="
+          aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" --query StandardOutputContent --output text
+          echo "===== STDERR ====="
+          aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" --query StandardErrorContent --output text
+
+          STATUS=$(aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" --query Status --output text)
+          echo "Status: $STATUS"
+          [ "$STATUS" = "Success" ] || { echo "deploy failed"; exit 1; }

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,7 @@ jobs:
         env:
           INSTANCE_ID: ${{ steps.target.outputs.instance_id }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
           PULL_BATCH: ${{ steps.target.outputs.pull_batch }}
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
         run: |
@@ -65,7 +66,7 @@ jobs:
               "test -f .env || { echo 'env missing'; exit 1; }",
               "aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}",
               "mkdir -p alloy",
-              "curl -sfL https://raw.githubusercontent.com/Team-STORIX/STORIX-BE-2.0/${BRANCH}/monitoring/app-side/config.alloy -o alloy/config.alloy",
+              "curl -sfL https://raw.githubusercontent.com/Team-STORIX/STORIX-BE-2.0/${SHA}/monitoring/app-side/config.alloy -o alloy/config.alloy",
               "docker compose pull app",
               "${BATCH_LINE}",
               "docker compose up -d",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,16 @@ jobs:
 
     steps:
       - name: Checkout GitHub repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.gradle/caches
@@ -46,7 +46,7 @@ jobs:
         run: ./gradlew :STORIX-Api:bootJar :STORIX-Batch:bootJar -x test --no-daemon
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Login to AWS ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
       - name: Build & push storix-api image to ECR
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - main
     paths-ignore:
       - 'monitoring/**'
       - '.github/workflows/cd-monitoring.yml'
@@ -33,6 +34,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Resolve env tag (develop=dev, main=prod)
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "ENV_TAG=prod" >> "$GITHUB_ENV"
+          else
+            echo "ENV_TAG=dev" >> "$GITHUB_ENV"
+          fi
+
       - name: Build bootJar (Api + Batch)
         run: ./gradlew :STORIX-Api:bootJar :STORIX-Batch:bootJar -x test --no-daemon
 
@@ -50,21 +59,15 @@ jobs:
       - name: Build & push storix-api image to ECR
         env:
           IMAGE_NAME: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_API_REPOSITORY }}
-          IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -f STORIX-Api/Dockerfile -t $IMAGE_NAME:$IMAGE_TAG .
-          docker push $IMAGE_NAME:$IMAGE_TAG
-
-          docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_NAME:latest
-          docker push $IMAGE_NAME:latest
+          docker build -f STORIX-Api/Dockerfile -t $IMAGE_NAME:$ENV_TAG -t $IMAGE_NAME:$ENV_TAG-${{ github.sha }} .
+          docker push $IMAGE_NAME:$ENV_TAG
+          docker push $IMAGE_NAME:$ENV_TAG-${{ github.sha }}
 
       - name: Build & push storix-batch image to ECR
         env:
           IMAGE_NAME: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_BATCH_REPOSITORY }}
-          IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -f STORIX-Batch/Dockerfile -t $IMAGE_NAME:$IMAGE_TAG .
-          docker push $IMAGE_NAME:$IMAGE_TAG
-
-          docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_NAME:latest
-          docker push $IMAGE_NAME:latest
+          docker build -f STORIX-Batch/Dockerfile -t $IMAGE_NAME:$ENV_TAG -t $IMAGE_NAME:$ENV_TAG-${{ github.sha }} .
+          docker push $IMAGE_NAME:$ENV_TAG
+          docker push $IMAGE_NAME:$ENV_TAG-${{ github.sha }}

--- a/STORIX-Api/src/main/resources/logback-spring.xml
+++ b/STORIX-Api/src/main/resources/logback-spring.xml
@@ -2,16 +2,16 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <!-- !prod: 일반 콘솔 로깅 출력 -->
-    <springProfile name="!prod">
+    <!-- 로컬: 일반 콘솔 로깅 출력 -->
+    <springProfile name="!prod &amp; !dev">
         <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
 
-    <!-- prod: JSON 구조화 로깅 출력 -->
-    <springProfile name="prod">
+    <!-- dev·prod: JSON 구조화 로깅 출력 -->
+    <springProfile name="prod,dev">
         <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <timeZone>Asia/Seoul</timeZone>

--- a/STORIX-Batch/src/main/resources/logback-spring.xml
+++ b/STORIX-Batch/src/main/resources/logback-spring.xml
@@ -2,16 +2,16 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <!-- !prod: 일반 콘솔 로깅 출력 -->
-    <springProfile name="!prod">
+    <!-- 로컬: 일반 콘솔 로깅 출력 -->
+    <springProfile name="!prod &amp; !dev">
         <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
 
-    <!-- prod: JSON 구조화 로깅 출력 -->
-    <springProfile name="prod">
+    <!-- dev·prod: JSON 구조화 로깅 출력 -->
+    <springProfile name="prod,dev">
         <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <timeZone>Asia/Seoul</timeZone>

--- a/monitoring/app-side/config.alloy
+++ b/monitoring/app-side/config.alloy
@@ -37,6 +37,18 @@ discovery.relabel "storix" {
 loki.source.docker "storix" {
   host       = "unix:///var/run/docker.sock"
   targets    = discovery.relabel.storix.output
+  forward_to = [loki.process.storix.receiver]
+}
+
+loki.process "storix" {
+  stage.json {
+    expressions = { level = "level" }
+  }
+
+  stage.labels {
+    values = { level = "" }
+  }
+
   forward_to = [loki.write.monitoring.receiver]
 }
 

--- a/monitoring/grafana/dashboards/storix-service.json
+++ b/monitoring/grafana/dashboards/storix-service.json
@@ -13,7 +13,7 @@
         "name": "application",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": { "query": "label_values(http_server_requests_seconds_count, application)", "refId": "app" },
+        "query": { "query": "label_values(up, application)", "refId": "app" },
         "includeAll": true,
         "multi": true,
         "current": { "text": "All", "value": "$__all" }
@@ -22,7 +22,7 @@
         "name": "env",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": { "query": "label_values(http_server_requests_seconds_count, env)", "refId": "env" },
+        "query": { "query": "label_values(up, env)", "refId": "env" },
         "includeAll": true,
         "multi": true,
         "current": { "text": "All", "value": "$__all" }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
 **CI/CD 환경 분리**
 - [x] `ci.yml`: develop=`:dev`, main=`:prod` 이미지 태그 분리 (`:latest` 중단, api·batch 공통)
 - [x] `cd.yml`: self-hosted 러너 → OIDC + SSM 방식으로 전환, 브랜치별 배포 대상 라우팅
   - develop → dev 박스 (app만)
   - main → prod 박스 (app + batch)
 - [x] `cd.yml`: `config.alloy`를 트리거 커밋(head_sha)에서 fetch

 **모니터링/로깅**
 - [x] Grafana 대시보드 템플릿 변수 소스를 `up` 메트릭으로 변경
 - [x] logback(Api·Batch): dev도 JSON 로깅 적용 (`prod,dev`)
 - [x] `config.alloy`: JSON `level` 필드를 라벨로 승격 → Grafana 로그 레벨 색칠을 `level` 필드로 고정

 **보안**
 - [x] GitHub Actions `uses`를 태그 → full commit SHA로 고정

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #137

## 🖇️ 기타