### PR TITLE
Fix: [작품/피드] 작품·프로필 누락 NPE 방지 및 avg_rating 정합성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,13 @@ application-*.yml
 !gradle/wrapper/gradle-wrapper.properties
 
 .omc/state
+
+# 서버 관련 작업 스크립트
 /storix-db-tunnel.sh
 /storix-grafana-tunnel.sh
+/storix-maintenance.sh
+/.maintenance-silence-id
+
 .claude
 /tools
 *.sql

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/service/FeedService.java
@@ -17,6 +17,7 @@ import com.storix.domain.domains.user.dto.StandardProfileInfo;
 import com.storix.domain.domains.works.application.port.LoadWorksPort;
 import com.storix.domain.domains.works.dto.SlicedWorksInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -31,6 +32,7 @@ import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class FeedService {
 
     private final UserAdaptor userAdaptor;
@@ -189,7 +191,11 @@ public class FeedService {
         return filtered.stream()
                 .map(board -> {
                     StandardProfileInfo profile = profileMap.get(board.userId());
-                    if (profile == null) return null;
+                    if (profile == null) {
+                        log.atWarn().addKeyValue("userId", board.userId())
+                                .log(">>> [Feed] 프로필 정보 없음");
+                        return null;
+                    }
                     return SlicedReaderBoardWithProfileInfo.of(profile, board);
                 })
                 .filter(Objects::nonNull)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/library/service/LibraryService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/library/service/LibraryService.java
@@ -8,6 +8,7 @@ import com.storix.domain.domains.works.adaptor.WorksPersistenceAdaptor;
 import com.storix.domain.domains.works.application.helper.ArtistNameParseHelper;
 import com.storix.domain.domains.works.dto.LibraryWorksInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -20,6 +21,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LibraryService {
@@ -63,7 +65,12 @@ public class LibraryService {
         List<StandardLibraryWorksInfo> content = reviewInfo.stream()
                 .map(r -> {
                     LibraryWorksInfo works = worksMap.get(r.worksId());
-                    if (works == null) return null;
+                    if (works == null) {
+                        log.atError()
+                                .addKeyValue("worksId", r.worksId())
+                                .log(">>> [Library] 리뷰작품 works 정보 없음");
+                        return null;
+                    }
 
                     String artistName = artistNameParseHelper
                             .buildArtistName(works.originalAuthor(), works.author(), works.illustrator());
@@ -101,7 +108,12 @@ public class LibraryService {
         List<StandardLibraryWorksInfo> content = worksSlice.getContent().stream()
                 .map(w -> {
                     ReviewedWorksIdAndRatingInfo r = reviewMap.get(w.worksId());
-                    if (r == null) return null;
+                    if (r == null) {
+                        log.atError()
+                                .addKeyValue("worksId", w.worksId())
+                                .log(">>> [Library] 검색 작품의 리뷰 정보 없음");
+                        return null;
+                    }
 
                     String artistName = artistNameParseHelper
                             .buildArtistName(w.originalAuthor(), w.author(), w.illustrator());

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReaderBoardHelper.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReaderBoardHelper.java
@@ -19,6 +19,7 @@ import com.storix.domain.domains.user.dto.StandardProfileInfo;
 import com.storix.domain.domains.works.application.port.LoadWorksPort;
 import com.storix.domain.domains.works.dto.WorksInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -28,6 +29,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.Function;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReaderBoardHelper {
@@ -193,13 +195,24 @@ public class ReaderBoardHelper {
         // 최종 매핑
         return boards.map(boardInfo -> {
             StandardProfileInfo profile = profileResolver.apply(boardInfo);
+            if (profile == null) {
+                log.atWarn().addKeyValue("userId", boardInfo.userId()).addKeyValue("boardId", boardInfo.boardId())
+                        .log(">>> [ReaderBoard] 프로필 정보 없음");
+            }
 
             Long worksId = boardInfo.worksId();
+            WorksInfo works = worksId == null ? null : worksMap.get(worksId);
+            if (worksId != null && works == null) {
+                log.atError()
+                        .addKeyValue("worksId", worksId)
+                        .addKeyValue("boardId", boardInfo.boardId())
+                        .log(">>> [ReaderBoard] 게시물 참조 works 정보 없음");
+            }
             return ReaderBoardWithProfileInfo.of(
                     profile,
                     boardInfo,
                     imageMap.getOrDefault(boardInfo.boardId(), List.of()),
-                    worksId == null ? null : worksMap.get(worksId),
+                    works,
                     worksId == null ? List.of() : hashtagMap.getOrDefault(worksId, List.of())
             );
         });
@@ -223,6 +236,12 @@ public class ReaderBoardHelper {
 
         if (worksId != null) {
             works = loadWorksPort.findAllWorksInfoByWorksIds(List.of(worksId)).get(worksId);
+            if (works == null) {
+                log.atError()
+                        .addKeyValue("worksId", worksId)
+                        .addKeyValue("boardId", boardId)
+                        .log(">>> [ReaderBoard] 게시물 참조 works 정보 없음");
+            }
             hashtags = hashTagAdaptor.findHashTagsByWorksIds(List.of(worksId))
                     .getOrDefault(worksId, List.of());
         }
@@ -288,7 +307,11 @@ public class ReaderBoardHelper {
         // 4) 최종 매핑 (답댓글 embed, 차단 유저 답댓글 제외)
         return replies.map(reply -> {
             StandardProfileInfo profile = profileMap.get(reply.getUserId());
-            if (profile == null) return null;
+            if (profile == null) {
+                log.atWarn().addKeyValue("userId", reply.getUserId()).addKeyValue("replyId", reply.getId())
+                        .log(">>> [ReaderBoard] 프로필 정보 없음");
+                return null;
+            }
 
             ReaderBoardReplyInfo replyInfo = ReaderBoardReplyInfo.from(reply);
             boolean isLiked = likedReplyIds.contains(reply.getId());
@@ -299,7 +322,11 @@ public class ReaderBoardHelper {
                     .sorted(Comparator.comparing(ReaderBoardReply::getCreatedAt))
                     .map(child -> {
                         StandardProfileInfo childProfile = profileMap.get(child.getUserId());
-                        if (childProfile == null) return null;
+                        if (childProfile == null) {
+                            log.atWarn().addKeyValue("userId", child.getUserId()).addKeyValue("replyId", child.getId())
+                                    .log(">>> [ReaderBoard] 프로필 정보 없음");
+                            return null;
+                        }
 
                         ReaderBoardReplyInfo childInfo = ReaderBoardReplyInfo.from(child);
                         boolean childIsLiked = likedReplyIds.contains(child.getId());

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReviewService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReviewService.java
@@ -23,6 +23,7 @@ import com.storix.domain.domains.works.application.port.LoadWorksPort;
 import com.storix.domain.domains.works.dto.StandardWorksInfo;
 import com.storix.domain.domains.works.dto.WorksInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -35,6 +36,7 @@ import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ReviewService {
 
     private final UserAdaptor userAdaptor;
@@ -125,7 +127,11 @@ public class ReviewService {
         List<SliceReviewInfoWithProfile> content = reviews.getContent().stream()
                 .map(review -> {
                     StandardProfileInfo profile = profileMap.get(review.userId());
-                    if (profile == null) return null;
+                    if (profile == null) {
+                        log.atWarn().addKeyValue("userId", review.userId())
+                                .log(">>> [Review] 프로필 정보 없음");
+                        return null;
+                    }
                     return SliceReviewInfoWithProfile.of(
                             StandardSliceReviewInfo.from(review),
                             profile

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileActivityService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileActivityService.java
@@ -8,6 +8,7 @@ import com.storix.domain.domains.profile.dto.ReaderBoardWithProfileInfo;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import com.storix.domain.domains.user.dto.StandardProfileInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -20,6 +21,7 @@ import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ProfileActivityService {
 
     private final UserAdaptor userAdaptor;
@@ -85,7 +87,14 @@ public class ProfileActivityService {
 
         // 3-1) 프로필이 없을 경우 필터링
         List<ReaderBoardInfo> filtered = content.stream()
-                .filter(b -> profileMap.get(b.userId()) != null)
+                .filter(b -> {
+                    if (profileMap.get(b.userId()) == null) {
+                        log.atWarn().addKeyValue("userId", b.userId())
+                                .log(">>> [ProfileActivity] 프로필 정보 없음");
+                        return false;
+                    }
+                    return true;
+                })
                 .toList();
 
         Slice<ReaderBoardInfo> filteredBoards =

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileFavoriteService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileFavoriteService.java
@@ -13,6 +13,7 @@ import com.storix.domain.domains.works.application.port.LoadWorksPort;
 import com.storix.domain.domains.works.domain.Genre;
 import com.storix.domain.domains.works.dto.WorksInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -23,6 +24,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProfileFavoriteService {
@@ -70,7 +72,13 @@ public class ProfileFavoriteService {
         List<FavoriteWorksWithReviewInfo> ordered = worksIds.stream()
                 .map(worksId -> {
                     WorksInfo worksInfo = worksMap.get(worksId);
-                    if (worksInfo == null) return null;
+                    if (worksInfo == null) {
+                        log.atError()
+                                .addKeyValue("worksId", worksId)
+                                .addKeyValue("userId", userId)
+                                .log(">>> [Favorite] 관심작품 works 정보 없음");
+                        return null;
+                    }
 
                     Rating ratingEnum = ratingMap.get(worksId);
                     boolean isReviewed = ratingEnum != null;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/search/service/SearchService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/search/service/SearchService.java
@@ -76,7 +76,7 @@ public class SearchService {
                 .artistName(works.getArtistName())
                 .thumbnailUrl(works.getThumbnailUrl())
                 .reviewsCount(works.getReviewsCount() != null ? works.getReviewsCount() : 0L)
-                .avgRating(works.getAvgRating() != null ? roundAvgRating(works.getAvgRating()) : 0.0)
+                .avgRating(roundAvgRating(works.getAvgRating()))
                 .worksType(works.getWorksType() != null ? works.getWorksType().getDbValue() : null)
                 .build();
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -44,6 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -88,12 +89,20 @@ public class TopicRoomService implements TopicRoomUseCase {
         // works 정보를 한 번에 조회하여 Map으로 변환
         Map<Long, TopicRoomWorksInfo> worksMap = worksAdaptor.loadWorksMapByIds(worksIds);
 
-        return participations.map(participation -> {
-            TopicRoom room = participation.getTopicRoom();
-            TopicRoomWorksInfo worksInfo = worksMap.get(room.getWorksId());
+        List<TopicRoomResponseDto> content = participations.getContent().stream()
+                .map(participation -> {
+                    TopicRoom room = participation.getTopicRoom();
+                    TopicRoomWorksInfo worksInfo = worksMap.get(room.getWorksId());
+                    if (worksInfo == null) {
+                        logMissingWorksInfo(room);
+                        return null;
+                    }
+                    return TopicRoomResponseDto.from(room, worksInfo, true);
+                })
+                .filter(Objects::nonNull)
+                .toList();
 
-            return TopicRoomResponseDto.from(room, worksInfo, true);
-        });
+        return new SliceImpl<>(content, pageable, participations.hasNext());
     }
 
 
@@ -146,11 +155,16 @@ public class TopicRoomService implements TopicRoomUseCase {
         return rooms.stream()
                 .map(room -> {
                     TopicRoomWorksInfo worksInfo = worksMap.get(room.getWorksId());
+                    if (worksInfo == null) {
+                        logMissingWorksInfo(room);
+                        return null;
+                    }
                     boolean isJoined = joinedRoomIds.contains(room.getId());
                     String lastMessageSenderNickname = nicknameMap.get(room.getLastMessageSenderId());
 
                     return TopicRoomPreviewResponseDto.from(room, worksInfo, lastMessageSenderNickname, isJoined);
                 })
+                .filter(Objects::nonNull)
                 .toList();
     }
 
@@ -360,5 +374,13 @@ public class TopicRoomService implements TopicRoomUseCase {
 
     private void publishActiveUserNumberChanged(Long roomId, Integer activeUserNumber) {
         activeUserNumberPublisher.publish(roomId, activeUserNumber);
+    }
+
+    // 참조 작품이 사라진 토픽룸은 응답에서 제외하고 관련 id를 KV로 남긴다
+    private void logMissingWorksInfo(TopicRoom room) {
+        log.atError()
+                .addKeyValue("worksId", room.getWorksId())
+                .addKeyValue("topicRoomId", room.getId())
+                .log(">>> [TopicRoom] works 정보 없음");
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/domain/Works.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/domain/Works.java
@@ -3,6 +3,7 @@ package com.storix.domain.domains.works.domain;
 import com.storix.domain.domains.hashtag.domain.Hashtag;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -63,8 +64,9 @@ public class Works {
     @Column(name = "reviews_count")
     private Integer reviewsCount;
 
-    @Column(name = "avg_rating")
-    private Double avgRating;
+    @Column(name = "avg_rating", nullable = false)
+    @ColumnDefault("0")
+    private double avgRating;
 
     @Column(name = "works_type", nullable = false)
     private WorksType worksType;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/dto/WorksDetailResponseDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/dto/WorksDetailResponseDto.java
@@ -42,7 +42,7 @@ public record WorksDetailResponseDto(
                         .map(wp -> wp.getPlatform().getDbValue())
                         .toList())
                 .ageClassification(works.getAgeClassification().getDbValue())
-                .avgRating(works.getAvgRating() != null ? roundAvgRating(works.getAvgRating()) : 0.0)
+                .avgRating(roundAvgRating(works.getAvgRating()))
                 .reviewCount(reviewCount)
                 .description(works.getDescription())
                 .hashtags(works.getHashtags().stream()

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/repository/WorksRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/repository/WorksRepository.java
@@ -71,7 +71,7 @@ public interface WorksRepository extends JpaRepository<Works, Long>, WorksReposi
         SET
           w.avgRating =
             CASE
-              WHEN COALESCE(w.reviewsCount, 0) <= 1 THEN NULL
+              WHEN COALESCE(w.reviewsCount, 0) <= 1 THEN 0.0
               ELSE
                 (COALESCE(w.avgRating, 0.0) * COALESCE(w.reviewsCount, 0) - :deletedRating)
                 / (COALESCE(w.reviewsCount, 0) - 1)


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
**작품·프로필 누락 NPE 방지**
- [x] 삭제된 작품 참조 토픽룸 조회(/topic-rooms/me) NPE 방지
- [x] 조회 시 작품·프로필 누락 지점 진단 로그 추가 (관심작품/서재/피드/리뷰/게시물/토픽룸)
  - 작품 누락 = ERROR, 프로필 누락 = WARN
  - worksId·userId·boardId·replyId KV 구조화 필드

**avg_rating 정합성**
- [x] avg_rating 원시 double + not-null(@ColumnDefault("0")) 정합화
- [x] 리뷰 0개 시 avg_rating NULL→0 저장

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #146 

## 🖇️ 기타