### PR TITLE
Fix: [피드] 작품 미선택 시 worksId 정규화 및 조회 게이팅

### DIFF
--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/domain/ReaderBoard.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/domain/ReaderBoard.java
@@ -57,7 +57,7 @@ public class ReaderBoard extends Board {
                        Long worksId, boolean isSpoiler, String spoilerScript, String content, BoardTheme theme) {
         this.userId = userId;
         this.isWorksSelected = isWorksSelected;
-        this.worksId = worksId;
+        this.worksId = isWorksSelected ? worksId : null;
         this.isSpoiler = isSpoiler;
         this.spoilerScript = isSpoiler ? spoilerScript : null;
         this.content = content;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReaderBoardHelper.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/plus/service/ReaderBoardHelper.java
@@ -201,8 +201,9 @@ public class ReaderBoardHelper {
             }
 
             Long worksId = boardInfo.worksId();
-            WorksInfo works = worksId == null ? null : worksMap.get(worksId);
-            if (worksId != null && works == null) {
+            boolean useWorks = Boolean.TRUE.equals(boardInfo.isWorksSelected()) && worksId != null;
+            WorksInfo works = useWorks ? worksMap.get(worksId) : null;
+            if (useWorks && works == null) {
                 log.atError()
                         .addKeyValue("worksId", worksId)
                         .addKeyValue("boardId", boardInfo.boardId())
@@ -213,7 +214,7 @@ public class ReaderBoardHelper {
                     boardInfo,
                     imageMap.getOrDefault(boardInfo.boardId(), List.of()),
                     works,
-                    worksId == null ? List.of() : hashtagMap.getOrDefault(worksId, List.of())
+                    useWorks ? hashtagMap.getOrDefault(worksId, List.of()) : List.of()
             );
         });
     }
@@ -234,7 +235,7 @@ public class ReaderBoardHelper {
         WorksInfo works = null;
         List<String> hashtags = List.of();
 
-        if (worksId != null) {
+        if (Boolean.TRUE.equals(boardInfo.isWorksSelected()) && worksId != null) {
             works = loadWorksPort.findAllWorksInfoByWorksIds(List.of(worksId)).get(worksId);
             if (works == null) {
                 log.atError()


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
- [x] 작품 미선택 시 worksId 정규화 (`ReaderBoard`: `isWorksSelected ? worksId : null`)
- [x] 조회를 `isWorksSelected` 기준으로 게이팅 (`ReaderBoardHelper`) — 미선택 글은 works 조회 자체를 안 함
- [x] 기존 `works_id = 0` 데이터는 마이그레이션으로 NULL 보정 (별도 실행)

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요? (컴파일 확인 / 런타임 QA 필요)
- [x] 머지할 브랜치를 확인하셨나요? (base: develop)
- [x] 관련 label을 선택하셨나요? (🐛 bug)

## ⭐ 관련 이슈 번호
- #149

## 🖇️ 기타
