### PR TITLE
Chore: [배포] dev 환경 batch 컨테이너 배포 활성화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
             echo "deploy=true" >> "$GITHUB_OUTPUT"
           elif [ "$BRANCH" = "develop" ]; then
             echo "instance_id=${{ secrets.DEV_INSTANCE_ID }}" >> "$GITHUB_OUTPUT"
-            echo "pull_batch=false" >> "$GITHUB_OUTPUT"
+            echo "pull_batch=true" >> "$GITHUB_OUTPUT"
             echo "env_tag=dev" >> "$GITHUB_OUTPUT"
             echo "deploy=true" >> "$GITHUB_OUTPUT"
           else

--- a/STORIX-Batch/src/main/java/com/storix/StorixBatchApplication.java
+++ b/STORIX-Batch/src/main/java/com/storix/StorixBatchApplication.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import com.storix.infrastructure.config.SecurityConfig;
+import com.storix.infrastructure.config.WebSocketConfig;
 
 import java.util.TimeZone;
 
@@ -15,7 +16,10 @@ import java.util.TimeZone;
 @SpringBootApplication
 @ComponentScan(
         basePackages = "com.storix",
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = { SecurityConfig.class, WebSocketConfig.class }
+        )
 )
 public class StorixBatchApplication {
 


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
- [x] dev 브랜치 배포 시 batch 컨테이너도 pull/기동하도록 활성화 (`cd.yml`: develop `pull_batch=true`)

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)
- 온박스 선행 필요: dev `~/storix/docker-compose.yml`에 `batch` 서비스 블록 추가 + env(`SPRING_DATASOURCE_*`, Redis, `AWS_S3_BUCKET_NAME`=dev 버킷) 설정.
- dev 박스(t3.small 2GB) 메모리 여유 확인 필요 (app + batch + alloy).

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요? (base: develop)
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #137 

## 🖇️ 기타
