### PR TITLE
Refactor: [모니터링] 컨테이너 OOM·다운 알림 추가

### DIFF
--- a/STORIX-Batch/src/main/java/com/storix/StorixBatchApplication.java
+++ b/STORIX-Batch/src/main/java/com/storix/StorixBatchApplication.java
@@ -9,6 +9,9 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import com.storix.infrastructure.config.SecurityConfig;
 import com.storix.infrastructure.config.WebSocketConfig;
+import com.storix.infrastructure.external.chat.RedisSubscriber;
+import com.storix.infrastructure.external.chat.StompHandler;
+import com.storix.infrastructure.external.topicroom.TopicRoomActiveUserNumberRedisSubscriber;
 
 import java.util.TimeZone;
 
@@ -18,7 +21,13 @@ import java.util.TimeZone;
         basePackages = "com.storix",
         excludeFilters = @ComponentScan.Filter(
                 type = FilterType.ASSIGNABLE_TYPE,
-                classes = { SecurityConfig.class, WebSocketConfig.class }
+                classes = {
+                        SecurityConfig.class,
+                        WebSocketConfig.class,
+                        StompHandler.class,
+                        RedisSubscriber.class,
+                        TopicRoomActiveUserNumberRedisSubscriber.class
+                }
         )
 )
 public class StorixBatchApplication {

--- a/monitoring/app-side/config.alloy
+++ b/monitoring/app-side/config.alloy
@@ -62,3 +62,35 @@ loki.write "monitoring" {
     }
   }
 }
+
+
+prometheus.exporter.cadvisor "storix" {
+  docker_host = "unix:///var/run/docker.sock"
+}
+
+prometheus.exporter.unix "storix" { }
+
+prometheus.scrape "infra" {
+  targets = concat(
+    prometheus.exporter.cadvisor.storix.targets,
+    prometheus.exporter.unix.storix.targets,
+  )
+  scrape_interval = "15s"
+  forward_to      = [prometheus.remote_write.monitoring.receiver]
+}
+
+prometheus.remote_write "monitoring" {
+  external_labels = {
+    env         = sys.env("ENV"),
+    instance_id = sys.env("INSTANCE_ID"),
+  }
+
+  endpoint {
+    url = "http://" + sys.env("MONITORING_HOST") + ":9091/api/v1/write"
+
+    basic_auth {
+      username = sys.env("LOKI_USER")
+      password = sys.env("LOKI_PASSWORD")
+    }
+  }
+}

--- a/monitoring/compose-monitoring.yml
+++ b/monitoring/compose-monitoring.yml
@@ -14,6 +14,7 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=15d'
       - '--web.enable-lifecycle'
+      - '--web.enable-remote-write-receiver'
     ports:
       - "127.0.0.1:9090:9090"
 
@@ -41,11 +42,14 @@ services:
     restart: unless-stopped
     volumes:
       - ./nginx/loki.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/prometheus.conf:/etc/nginx/conf.d/prometheus.conf:ro
       - ./nginx/.htpasswd:/etc/nginx/.htpasswd:ro
     ports:
       - "3100:3100"
+      - "9091:9091"
     depends_on:
       - loki
+      - prometheus
 
   grafana:
     image: grafana/grafana:11.2.0

--- a/monitoring/grafana/provisioning/alerting/rules.yml
+++ b/monitoring/grafana/provisioning/alerting/rules.yml
@@ -35,6 +35,34 @@ groups:
               conditions:
                 - evaluator: { type: lt, params: [1] }
 
+      - uid: storix-container-oom
+        title: '컨테이너 OOM 발생'
+        condition: B
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: '{{ $labels.name }} 컨테이너가 OOM 으로 종료되었습니다.'
+          runbook: 'mem_limit 상향 또는 힙/컨텍스트 축소. docker inspect <name> 로 OOMKilled 확인'
+        noDataState: OK
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: 'sum by (env, name, instance_id) (increase(container_oom_events_total{name=~"storix-.*"}[5m]))'
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
       - uid: storix-jvm-heap
         title: 'JVM 힙 사용률 85% 초과'
         condition: B

--- a/monitoring/nginx/prometheus.conf
+++ b/monitoring/nginx/prometheus.conf
@@ -1,0 +1,16 @@
+server {
+    listen 9091;
+
+    auth_basic           "STORIX Prometheus RW";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
+    client_max_body_size 16m;
+
+    location /api/v1/write {
+        proxy_pass http://prometheus:9090;
+
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
- [x] 앱 EC2의 Alloy에 cAdvisor·node exporter 추가, 컨테이너/호스트 메트릭을 Prometheus로 remote_write
- [x] Prometheus remote-write receiver 활성화, nginx(9091)로 basic auth 프록시 노출
- [x] `container_oom_events_total > 0` 알림 룰 추가
- [x] 배치 기동 실패 수정 — chat·topicroom 웹소켓 빈(SimpMessagingTemplate 의존)을 배치 컴포넌트 스캔에서 제외

배치 등 non-web 컨테이너는 `/actuator/prometheus`가 없어 스크레이프가 안 되고, 로그(Loki)는 SIGKILL(OOM)을 못 잡아 조용히 죽었음. 컨테이너/호스트 레벨 메트릭을 수집해 OOM·다운을 알림으로 잡는다.
WebSocketConfig 스캔 제외 이후 `SimpMessagingTemplate` 빈이 없어 chat/topicroom subscriber가 기동을 막던 문제도 함께 제외 처리했다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)
- 온박스 선행: 앱 박스 Alloy에 rootfs 마운트(`/`, `/sys`, `/var/lib/docker`) 추가, 모니터링 박스 SG 9091 인바운드 허용, 모니터링 박스 재기동 필요

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 
- #152

## 🖇️ 기타