### PR TITLE
Feat: [관리자] 알림·팝업·앱이벤트 목록 keyword 검색 추가

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminAppEventController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminAppEventController.java
@@ -34,11 +34,12 @@ public class AdminAppEventController {
     }
 
     @GetMapping
-    @Operation(summary = "앱 이벤트 목록 조회", description = "최신순 번호형 페이지네이션. 페이지당 10개 고정이며 totalPages/totalElements 를 함께 반환합니다.")
+    @Operation(summary = "앱 이벤트 목록 조회", description = "최신순 번호형 페이지네이션. 페이지당 10개 고정이며 totalPages/totalElements 를 함께 반환합니다. 검색 시 keyword로 이벤트명을 보내주세요.")
     public CustomResponse<PageResponseWrapperDTO<AppEventResponse>> getAppEvents(
-            @RequestParam(defaultValue = "0") @Min(0) int page
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(required = false) String keyword
     ) {
-        return adminAppEventUseCase.getAppEvents(page);
+        return adminAppEventUseCase.getAppEvents(page, keyword);
     }
 
     @GetMapping("/{appEventId}")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminPopupController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminPopupController.java
@@ -37,11 +37,12 @@ public class AdminPopupController {
     }
 
     @GetMapping
-    @Operation(summary = "이벤트 팝업 목록 조회", description = "최신순 번호형 페이지네이션. 페이지당 10개 고정이며 totalPages/totalElements 를 함께 반환합니다.")
+    @Operation(summary = "이벤트 팝업 목록 조회", description = "최신순 번호형 페이지네이션. 페이지당 10개 고정이며 totalPages/totalElements 를 함께 반환합니다. 검색 시 keyword로 팝업명을 보내주세요.")
     public CustomResponse<PageResponseWrapperDTO<PopupResponse>> getPopups(
-            @RequestParam(defaultValue = "0") @Min(0) int page
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(required = false) String keyword
     ) {
-        return eventPopupUseCase.getPopups(page);
+        return eventPopupUseCase.getPopups(page, keyword);
     }
 
     @GetMapping("/{popupId}")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AdminAppEventUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AdminAppEventUseCase.java
@@ -27,9 +27,9 @@ public class AdminAppEventUseCase {
     }
 
     // 앱 이벤트 목록 조회
-    public CustomResponse<PageResponseWrapperDTO<AppEventResponse>> getAppEvents(int page) {
+    public CustomResponse<PageResponseWrapperDTO<AppEventResponse>> getAppEvents(int page, String keyword) {
 
-        PageResponseWrapperDTO<AppEventResponse> result = PageResponseWrapperDTO.from(appEventService.getAppEvents(page));
+        PageResponseWrapperDTO<AppEventResponse> result = PageResponseWrapperDTO.from(appEventService.getAppEvents(page, keyword));
         return CustomResponse.onSuccess(SuccessCode.ADMIN_APP_EVENT_LOAD_SUCCESS, result);
     }
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/PopupUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/PopupUseCase.java
@@ -48,10 +48,10 @@ public class PopupUseCase {
     }
 
     // 이벤트 팝업 목록 조회
-    public CustomResponse<PageResponseWrapperDTO<PopupResponse>> getPopups(int page) {
+    public CustomResponse<PageResponseWrapperDTO<PopupResponse>> getPopups(int page, String keyword) {
 
         PageResponseWrapperDTO<PopupResponse> result = PageResponseWrapperDTO.from(
-                eventPopupService.getPopups(page)
+                eventPopupService.getPopups(page, keyword)
                         .map(popup -> PopupResponse.from(popup).withBaseUrl(baseUrl)));
         return CustomResponse.onSuccess(SuccessCode.EVENT_POPUP_LOAD_SUCCESS, result);
     }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/AdminNotificationController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/AdminNotificationController.java
@@ -33,11 +33,12 @@ public class AdminNotificationController {
     }
 
     @GetMapping
-    @Operation(summary = "운영자 알림 목록 조회", description = "최신순 번호형 페이지네이션. 페이지당 10개 고정이며 totalPages/totalElements 를 함께 반환합니다.")
+    @Operation(summary = "운영자 알림 목록 조회", description = "최신순 번호형 페이지네이션. 페이지당 10개 고정이며 totalPages/totalElements 를 함께 반환합니다. 검색 시 keyword로 알림 제목을 보내주세요.")
     public CustomResponse<PageResponseWrapperDTO<AdminNotificationSummaryResponse>> getNotifications(
-            @RequestParam(defaultValue = "0") @Min(0) int page
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(required = false) String keyword
     ) {
-        return adminNotificationUseCase.getNotifications(page);
+        return adminNotificationUseCase.getNotifications(page, keyword);
     }
 
     @GetMapping("/{adminNotificationId}")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/AdminNotificationUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/AdminNotificationUseCase.java
@@ -44,10 +44,10 @@ public class AdminNotificationUseCase {
     }
 
     // 운영자 알림 목록 조회
-    public CustomResponse<PageResponseWrapperDTO<AdminNotificationSummaryResponse>> getNotifications(int page) {
+    public CustomResponse<PageResponseWrapperDTO<AdminNotificationSummaryResponse>> getNotifications(int page, String keyword) {
 
         PageResponseWrapperDTO<AdminNotificationSummaryResponse> result = PageResponseWrapperDTO.from(
-                adminNotificationService.getNotifications(page).map(AdminNotificationSummaryResponse::from));
+                adminNotificationService.getNotifications(page, keyword).map(AdminNotificationSummaryResponse::from));
         return CustomResponse.onSuccess(SuccessCode.ADMIN_NOTIFICATION_LOAD_SUCCESS, result);
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/AppEventAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/AppEventAdaptor.java
@@ -26,4 +26,8 @@ public class AppEventAdaptor {
     public Page<AppEvent> findAll(Pageable pageable) {
         return appEventRepository.findAllByOrderByIdDesc(pageable);
     }
+
+    public Page<AppEvent> searchByName(String keyword, Pageable pageable) {
+        return appEventRepository.searchByName(keyword, pageable);
+    }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/PopupAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/PopupAdaptor.java
@@ -32,6 +32,10 @@ public class PopupAdaptor {
         return eventPopupRepository.findAllByOrderByIdDesc(pageable);
     }
 
+    public Page<Popup> searchByTitle(String keyword, Pageable pageable) {
+        return eventPopupRepository.searchByPopupTitle(keyword, pageable);
+    }
+
     public Optional<Popup> findActivePopup(LocalDateTime now) {
         return eventPopupRepository.findActivePopup(PopupStatus.ACTIVE, now);
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/AppEventRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/AppEventRepository.java
@@ -4,8 +4,14 @@ import com.storix.domain.domains.event.domain.AppEvent;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AppEventRepository extends JpaRepository<AppEvent, Long> {
 
     Page<AppEvent> findAllByOrderByIdDesc(Pageable pageable);
+
+    // 이벤트명 검색 — keyword null이면 전체 조회
+    @Query("SELECT e FROM AppEvent e WHERE (:keyword IS NULL OR e.name LIKE %:keyword%) ORDER BY e.id DESC")
+    Page<AppEvent> searchByName(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/PopupRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/PopupRepository.java
@@ -18,6 +18,11 @@ public interface PopupRepository extends JpaRepository<Popup, Long> {
     @EntityGraph(attributePaths = "appEvent")
     Page<Popup> findAllByOrderByIdDesc(Pageable pageable);
 
+    // 팝업명 검색 — keyword null이면 전체 조회
+    @EntityGraph(attributePaths = "appEvent")
+    @Query("SELECT p FROM Popup p WHERE (:keyword IS NULL OR p.popupTitle LIKE %:keyword%) ORDER BY p.id DESC")
+    Page<Popup> searchByPopupTitle(@Param("keyword") String keyword, Pageable pageable);
+
     // 스케줄러: 노출 시작이 지난 예약 팝업
     List<Popup> findAllByStatusAndDisplayStartAtLessThanEqual(PopupStatus status, LocalDateTime now);
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -69,8 +70,9 @@ public class AppEventService {
     }
 
     @Transactional(readOnly = true)
-    public Page<AppEventResponse> getAppEvents(int page) {
-        return appEventAdaptor.findAll(PageRequest.of(page, APP_EVENT_PAGE_SIZE))
+    public Page<AppEventResponse> getAppEvents(int page, String keyword) {
+        String normalized = StringUtils.hasText(keyword) ? keyword.trim() : null;
+        return appEventAdaptor.searchByName(normalized, PageRequest.of(page, APP_EVENT_PAGE_SIZE))
                 .map(AppEventResponse::from);
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/PopupService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/PopupService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -85,8 +86,9 @@ public class PopupService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Popup> getPopups(int page) {
-        return eventPopupAdaptor.findAll(PageRequest.of(page, POPUP_PAGE_SIZE));
+    public Page<Popup> getPopups(int page, String keyword) {
+        String normalized = StringUtils.hasText(keyword) ? keyword.trim() : null;
+        return eventPopupAdaptor.searchByTitle(normalized, PageRequest.of(page, POPUP_PAGE_SIZE));
     }
 
     // objectKey 형태로 반환, baseUrl/캐시는 UseCase 담당

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/AdminNotificationAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/AdminNotificationAdaptor.java
@@ -40,6 +40,10 @@ public class AdminNotificationAdaptor {
         return adminNotificationRepository.findAllByOrderByIdDesc(pageable);
     }
 
+    public Page<AdminNotification> searchByTitle(String keyword, Pageable pageable) {
+        return adminNotificationRepository.searchByTitle(keyword, pageable);
+    }
+
     public List<AdminNotification> findDue(LocalDateTime now, Pageable pageable) {
         return adminNotificationRepository.findDueNotifications(
                 AdminNotificationStatus.SCHEDULED, now, pageable

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/repository/AdminNotificationRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/repository/AdminNotificationRepository.java
@@ -20,6 +20,10 @@ public interface AdminNotificationRepository extends JpaRepository<AdminNotifica
 
     Page<AdminNotification> findAllByOrderByIdDesc(Pageable pageable);
 
+    // 알림 제목 검색 — keyword null이면 전체 조회
+    @Query("SELECT e FROM AdminNotification e WHERE (:keyword IS NULL OR e.title LIKE %:keyword%) ORDER BY e.id DESC")
+    Page<AdminNotification> searchByTitle(@Param("keyword") String keyword, Pageable pageable);
+
     // 상태별 알림 수
     long countByStatus(AdminNotificationStatus status);
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/AdminNotificationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/AdminNotificationService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -62,9 +63,10 @@ public class AdminNotificationService {
     }
 
     @Transactional(readOnly = true)
-    public Page<AdminNotification> getNotifications(int page) {
+    public Page<AdminNotification> getNotifications(int page, String keyword) {
         int safePage = Math.max(0, page);
-        return adminNotificationAdaptor.findAll(PageRequest.of(safePage, NOTIFICATION_PAGE_SIZE));
+        String normalized = StringUtils.hasText(keyword) ? keyword.trim() : null;
+        return adminNotificationAdaptor.searchByTitle(normalized, PageRequest.of(safePage, NOTIFICATION_PAGE_SIZE));
     }
 
     @Transactional


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
- [x] 관리자 알림 목록 조회에 keyword 검색 추가 (제목 LIKE)
- [x] 이벤트 팝업 목록 조회에 keyword 검색 추가 (팝업명 LIKE)
- [x] 관리자 앱 이벤트 목록 조회에 keyword 검색 추가 (이벤트명 LIKE)
- [x] 배너 검색과 동일 패턴 — keyword 없으면 전체 조회, 최신순 페이지네이션 유지

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #155

## 🖇️ 기타