### PR TITLE
Fix: [관리자] @ElementCollection 지연 컬렉션 직렬화 LazyInitializationException 방지

### DIFF
--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
@@ -48,7 +48,7 @@ public record AppEventResponse(
                 .endAt(appEvent.getEndAt())
                 .status(AppEventStatus.resolve(appEvent.getStartAt(), appEvent.getEndAt(), LocalDateTime.now()))
                 .hasWinner(appEvent.isHasWinner())
-                .promotionTypes(appEvent.getPromotionTypes())
+                .promotionTypes(Set.copyOf(appEvent.getPromotionTypes()))
                 .createdAt(appEvent.getCreatedAt())
                 .updatedAt(appEvent.getUpdatedAt())
                 .build();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/report/dto/AdminReportListResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/report/dto/AdminReportListResponse.java
@@ -33,7 +33,7 @@ public record AdminReportListResponse(
                 reportCase.getStatus(),
                 reportCount,
                 reportCase.getProcessedByAdminId(),
-                reportCase.getProcessActions(),
+                Set.copyOf(reportCase.getProcessActions()),
                 reportCase.getCreatedAt(),
                 reportCase.getProcessedAt(),
                 reportCase.hasPreviousProcessHistory()

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/report/service/AdminReportQueryService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/report/service/AdminReportQueryService.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -416,7 +417,7 @@ public class AdminReportQueryService {
                 reportCase.getStatus(),
                 reportCase.getProcessedByAdminId(),
                 reportCase.getProcessMemo(),
-                reportCase.getProcessActions(),
+                Set.copyOf(reportCase.getProcessActions()),
                 reportCase.getCreatedAt(),
                 reportCase.getProcessedAt(),
                 reportCase.hasPreviousProcessHistory(),


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
- [x] `AppEventResponse.from` — `promotionTypes`를 `Set.copyOf`로 tx 내 초기화
- [x] `AdminReportListResponse.from` — `processActions`를 `Set.copyOf`로 tx 내 초기화
- [x] `AdminReportQueryService`(AdminReportDetailResponse) — `processActions` 동일 처리

OSIV(open-in-view)=false 환경에서 응답 DTO가 `@ElementCollection` 지연 컬렉션을 raw로 담아, Jackson 직렬화(세션 종료 후) 시 `LazyInitializationException`이 발생하던 문제. 트랜잭션 안에서 `Set.copyOf`로 materialize하여 해결한다. (OSIV는 false 유지 — 커넥션 효율/N+1 회피)

관리자 리포트 목록·상세, 앱 이벤트 목록 조회 500 해소.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #160

## 🖇️ 기타