### PR TITLE
Feat: [관리자] 관리자 요청 진입·완료 INFO 로깅 추가

### DIFF
--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/MdcContextFilter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/MdcContextFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -13,11 +14,14 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+@Slf4j
 @Component
 public class MdcContextFilter extends OncePerRequestFilter {
 
     private static final String TRACE_ID_HEADER = "X-Trace-Id";
     private static final Pattern TRACE_ID_PATTERN = Pattern.compile("[A-Za-z0-9_-]{1,64}");
+    private static final String ADMIN_URI_PREFIX = "/api/v1/admin";
+    private static final String ADMIN_AUTH_URI_PREFIX = "/api/v1/auth/admin";
 
     @Override
     protected void doFilterInternal(
@@ -29,14 +33,26 @@ public class MdcContextFilter extends OncePerRequestFilter {
         MDC.put(STORIXStatic.Mdc.TRACE_ID, traceId);
         MDC.put(STORIXStatic.Mdc.ENDPOINT, request.getRequestURI());
         MDC.put(STORIXStatic.Mdc.HTTP_METHOD, request.getMethod());
+
+        boolean admin = isAdminRequest(request.getRequestURI());
+        if (admin) {
+            log.info(">>> [Admin] 요청 진입 query={}", request.getQueryString());
+        }
         try {
             filterChain.doFilter(request, response);
         } finally {
+            if (admin) {
+                log.info(">>> [Admin] 요청 완료 status={}", response.getStatus());
+            }
             MDC.remove(STORIXStatic.Mdc.TRACE_ID);
             MDC.remove(STORIXStatic.Mdc.ENDPOINT);
             MDC.remove(STORIXStatic.Mdc.HTTP_METHOD);
             MDC.remove(STORIXStatic.Mdc.USER_ID);
         }
+    }
+
+    private boolean isAdminRequest(String uri) {
+        return uri.startsWith(ADMIN_URI_PREFIX) || uri.startsWith(ADMIN_AUTH_URI_PREFIX);
     }
 
     private String resolveTraceId(String fromHeader) {


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] `MdcContextFilter`에 관리자 경로 게이팅 진입/완료 INFO 로그 추가
> - [x] MDC(`endpoint`/`http_method`/`user_id`/`trace_id`)는 JSON 필드로 자동 첨부 → 메시지엔 `query`/`status`만
> - [x] 완료 로그는 `MDC.remove` 전에 찍어 필드 유지
> - [x] 게이트: `/api/v1/admin/**`, `/api/v1/auth/admin/**`

## 📸 작업 화면 (스크린샷)
\`\`\`json
{"message":">>> [Admin] 요청 진입 query=page=0","endpoint":"/api/v1/admin/app-events","http_method":"GET","level":"INFO","app":"storix-api"}
{"message":">>> [Admin] 요청 완료 status=400","endpoint":"/api/v1/admin/app-events","level":"INFO","app":"storix-api"}
\`\`\`

## 💬 리뷰 요구사항(선택)
- 필터체인 최선두라 인증 실패 관리자 요청도 잡힘. 실패 스택은 기존 `GlobalExceptionHandler` WARN에 같은 `trace_id`로 연결.

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #162

## 🖇️ 기타