### PR TITLE
Feat: [앱버전] 앱 버전 게이팅 API 추가 (#164)

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/appversion/controller/AppVersionController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/appversion/controller/AppVersionController.java
@@ -1,0 +1,31 @@
+package com.storix.api.domain.appversion.controller;
+
+import com.storix.api.domain.appversion.controller.dto.AppVersionCheckResponse;
+import com.storix.api.domain.appversion.usecase.AppVersionUseCase;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.pushdevice.domain.OSPlatform;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/app-version")
+@RequiredArgsConstructor
+@Tag(name = "앱 버전", description = "앱 버전 게이팅 API")
+public class AppVersionController {
+
+    private final AppVersionUseCase appVersionUseCase;
+
+    @GetMapping("/check")
+    @Operation(summary = "앱 버전 확인", description = "설치된 네이티브 버전을 기준으로 강제/권장 업데이트 여부를 판정합니다. status: LATEST / UPDATE_AVAILABLE / UPDATE_REQUIRED")
+    public CustomResponse<AppVersionCheckResponse> check(
+            @RequestParam OSPlatform platform,
+            @RequestParam String version
+    ) {
+        return appVersionUseCase.check(platform, version);
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/appversion/controller/dto/AppVersionCheckResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/appversion/controller/dto/AppVersionCheckResponse.java
@@ -1,0 +1,25 @@
+package com.storix.api.domain.appversion.controller.dto;
+
+import com.storix.domain.domains.appversion.domain.VersionStatus;
+import com.storix.domain.domains.appversion.dto.AppVersionCheck;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AppVersionCheckResponse(
+
+        @Schema(description = "버전 판정 상태", example = "UPDATE_REQUIRED")
+        VersionStatus status,
+
+        @Schema(description = "최신 스토어 버전", example = "1.0.0")
+        String latestVersion,
+
+        @Schema(description = "최소 지원 버전 (미만이면 강제 업데이트)", example = "1.0.0")
+        String minSupportedVersion
+) {
+    public static AppVersionCheckResponse from(AppVersionCheck check) {
+        return new AppVersionCheckResponse(
+                check.status(),
+                check.latestVersion(),
+                check.minSupportedVersion()
+        );
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/appversion/usecase/AppVersionUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/appversion/usecase/AppVersionUseCase.java
@@ -1,0 +1,22 @@
+package com.storix.api.domain.appversion.usecase;
+
+import com.storix.api.domain.appversion.controller.dto.AppVersionCheckResponse;
+import com.storix.common.code.SuccessCode;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.appversion.service.AppVersionService;
+import com.storix.domain.domains.pushdevice.domain.OSPlatform;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AppVersionUseCase {
+
+    private final AppVersionService appVersionService;
+
+    public CustomResponse<AppVersionCheckResponse> check(OSPlatform platform, String version) {
+        return CustomResponse.onSuccess(
+                SuccessCode.APP_VERSION_CHECK_SUCCESS,
+                AppVersionCheckResponse.from(appVersionService.check(platform, version)));
+    }
+}

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -228,7 +228,10 @@ public enum ErrorCode {
     // Banned Word error
     BANNED_WORD_NOT_FOUND(HttpStatus.NOT_FOUND, "BANNED_WORD_ERROR_001", "해당 금칙어를 찾을 수 없습니다."),
     DUPLICATE_BANNED_WORD(HttpStatus.CONFLICT, "BANNED_WORD_ERROR_002", "이미 등록된 금칙어입니다."),
-    BANNED_WORD_CSV_PARSE_ERROR(HttpStatus.BAD_REQUEST, "BANNED_WORD_ERROR_003", "금칙어 CSV 파일을 읽을 수 없습니다.");
+    BANNED_WORD_CSV_PARSE_ERROR(HttpStatus.BAD_REQUEST, "BANNED_WORD_ERROR_003", "금칙어 CSV 파일을 읽을 수 없습니다."),
+
+    // App version error
+    INVALID_APP_VERSION_FORMAT(HttpStatus.BAD_REQUEST, "APP_VERSION_ERROR_002", "앱 버전 형식이 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -131,7 +131,10 @@ public enum SuccessCode {
     LIBRARY_RECENT_REMOVE_SUCCESS(HttpStatus.OK, "LIBRARY_SUCCESS_004", "서재 최근 검색어 삭제에 성공했습니다."),
 
     // Block success
-    USER_BLOCK_SUCCESS(HttpStatus.CREATED, "BLOCK_SUCCESS_001", "사용자 차단에 성공했습니다.");
+    USER_BLOCK_SUCCESS(HttpStatus.CREATED, "BLOCK_SUCCESS_001", "사용자 차단에 성공했습니다."),
+
+    // App version success
+    APP_VERSION_CHECK_SUCCESS(HttpStatus.OK, "APP_VERSION_SUCCESS_001", "앱 버전 확인에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/STORIX-Common/src/main/java/com/storix/common/property/AppVersionConfig.java
+++ b/STORIX-Common/src/main/java/com/storix/common/property/AppVersionConfig.java
@@ -1,0 +1,9 @@
+package com.storix.common.property;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AppVersionProperties.class)
+public class AppVersionConfig {
+}

--- a/STORIX-Common/src/main/java/com/storix/common/property/AppVersionProperties.java
+++ b/STORIX-Common/src/main/java/com/storix/common/property/AppVersionProperties.java
@@ -1,0 +1,28 @@
+package com.storix.common.property;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "app-version")
+public class AppVersionProperties {
+
+    private final Platform ios;
+    private final Platform android;
+
+    public AppVersionProperties(Platform ios, Platform android) {
+        this.ios = ios;
+        this.android = android;
+    }
+
+    @Getter
+    public static class Platform {
+        private final String minSupported;
+        private final String latest;
+
+        public Platform(String minSupported, String latest) {
+            this.minSupported = minSupported;
+            this.latest = latest;
+        }
+    }
+}

--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -57,6 +57,7 @@ public class STORIXStatic {
 
     // JWT 인증 필터를 타지 않는 URI
     public static final List<String> PERMIT_ALL_URI = List.of(
+            "/api/v1/app-version/",
             "/api/v1/onboarding/",
             "/api/v1/auth/oauth/",
             "/api/v1/auth/nickname/valid",

--- a/STORIX-Domain/build.gradle
+++ b/STORIX-Domain/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'org.ahocorasick:ahocorasick:0.6.3'
+    implementation 'org.semver4j:semver4j:5.3.0'
 
     compileOnly 'io.swagger.core.v3:swagger-annotations-jakarta:2.2.22'
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/appversion/domain/VersionStatus.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/appversion/domain/VersionStatus.java
@@ -1,0 +1,15 @@
+package com.storix.domain.domains.appversion.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum VersionStatus {
+
+    LATEST("최신 버전"),
+    UPDATE_AVAILABLE("업데이트 권장"),
+    UPDATE_REQUIRED("업데이트 필요");
+
+    private final String description;
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/appversion/dto/AppVersionCheck.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/appversion/dto/AppVersionCheck.java
@@ -1,0 +1,10 @@
+package com.storix.domain.domains.appversion.dto;
+
+import com.storix.domain.domains.appversion.domain.VersionStatus;
+
+public record AppVersionCheck(
+        VersionStatus status,
+        String latestVersion,
+        String minSupportedVersion
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/appversion/exception/InvalidAppVersionException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/appversion/exception/InvalidAppVersionException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.appversion.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class InvalidAppVersionException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new InvalidAppVersionException();
+
+    private InvalidAppVersionException() { super(ErrorCode.INVALID_APP_VERSION_FORMAT); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/appversion/service/AppVersionService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/appversion/service/AppVersionService.java
@@ -1,0 +1,40 @@
+package com.storix.domain.domains.appversion.service;
+
+import com.storix.common.property.AppVersionProperties;
+import com.storix.domain.domains.appversion.domain.VersionStatus;
+import com.storix.domain.domains.appversion.dto.AppVersionCheck;
+import com.storix.domain.domains.appversion.exception.InvalidAppVersionException;
+import com.storix.domain.domains.pushdevice.domain.OSPlatform;
+import lombok.RequiredArgsConstructor;
+import org.semver4j.Semver;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AppVersionService {
+
+    private final AppVersionProperties appVersionProperties;
+
+    public AppVersionCheck check(OSPlatform platform, String clientVersion) {
+        AppVersionProperties.Platform cfg = platform == OSPlatform.IOS
+                ? appVersionProperties.getIos()
+                : appVersionProperties.getAndroid();
+
+        VersionStatus status = resolveStatus(parse(clientVersion), cfg);
+        return new AppVersionCheck(status, cfg.getLatest(), cfg.getMinSupported());
+    }
+
+    private VersionStatus resolveStatus(Semver client, AppVersionProperties.Platform cfg) {
+        if (client.isLowerThan(parse(cfg.getMinSupported()))) return VersionStatus.UPDATE_REQUIRED;
+        if (client.isLowerThan(parse(cfg.getLatest()))) return VersionStatus.UPDATE_AVAILABLE;
+        return VersionStatus.LATEST;
+    }
+
+    private Semver parse(String version) {
+        Semver semver = Semver.coerce(version);
+        if (semver == null) {
+            throw InvalidAppVersionException.EXCEPTION;
+        }
+        return semver;
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
@@ -109,6 +109,9 @@ public class SecurityConfig {
                                 .requestMatchers("/actuator/health").permitAll()
                                 .requestMatchers("/actuator/prometheus").permitAll()
 
+                                // [App Version]
+                                .requestMatchers("/api/v1/app-version/**").permitAll()
+
                                 // [Onboarding]
                                 .requestMatchers("/api/v1/onboarding/**").permitAll()
 


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] `GET /api/v1/app-version/check` 추가 — 쿼리 파라미터 `platform`(IOS/ANDROID), `version`
> - [x] `AppVersionService` — semver4j로 클라이언트 버전을 파싱해 정책과 비교, `LATEST` / `UPDATE_AVAILABLE` / `UPDATE_REQUIRED` 판정
> - [x] `AppVersionProperties` — 플랫폼별 `min-supported`, `latest`를 환경변수에서 주입
> - [x] 파싱 불가한 버전 문자열은 `INVALID_APP_VERSION_FORMAT`(400) 처리
> - [x] 로그인 이전에 호출되는 API이므로 `SecurityConfig`, `STORIXStatic.PERMIT_ALL_URI`에 permit-all 등록
> - [x] `APP_VERSION_CHECK_SUCCESS` 성공 코드 추가

판정 기준입니다.

| 조건 | status |
| --- | --- |
| `version < min-supported` | `UPDATE_REQUIRED` (강제) |
| `version < latest` | `UPDATE_AVAILABLE` (권장) |
| 그 외 | `LATEST` |

## 📸 작업 화면 (스크린샷)
```json
GET /api/v1/app-version/check?platform=IOS&version=1.0.0

{
  "isSuccess": true,
  "code": "APP_VERSION_SUCCESS_001",
  "message": "앱 버전 확인에 성공했습니다.",
  "result": {
    "status": "LATEST",
    "latestVersion": "1.0.0",
    "minSupportedVersion": "1.0.0"
  }
}
```

## 💬 리뷰 요구사항(선택)
**1. 배포 전 환경변수 4개 주입이 필요합니다.** `application.yml`이 gitignore 대상이라 설정 블록이 이 PR에 포함되지 않습니다. 기본값이 없어 미설정 시 애플리케이션이 기동되지 않습니다.

```
APP_VERSION_IOS_MIN_SUPPORTED
APP_VERSION_IOS_LATEST
APP_VERSION_ANDROID_MIN_SUPPORTED
APP_VERSION_ANDROID_LATEST
```

**2. 정책값을 올리는 시점 주의가 필요합니다.** 스토어 심사 승인과 릴리스 완료 이후에 올려야 합니다. 릴리스 전에 `LATEST`를 올리면 아직 스토어에 없는 버전으로 업데이트하라는 안내가 노출되고, `MIN_SUPPORTED`를 먼저 올리면 전체 사용자가 앱에 진입하지 못합니다. iOS와 Android는 승인 시점이 다를 수 있어 env를 플랫폼별로 분리해 두었습니다.

**3. 응답에 `minSupportedVersion`을 포함할지 논의가 필요합니다.** 판정 결과가 `status`에 이미 담기므로 클라이언트가 이 값을 직접 쓸 일은 없습니다. 우선 내려주는 쪽으로 두었는데, 불필요하다고 판단되면 제거해도 무방합니다.

**4. `version` 파라미터는 형식 검증만 합니다.** `Semver.coerce`가 관대해서 빌드 번호(`"21"`)를 보내면 `21.0.0`으로 파싱되어 항상 `LATEST`가 됩니다. 클라이언트가 반드시 앱 버전(`expo.version` / `nativeApplicationVersion`)을 보내야 하며, 빌드 번호(`buildNumber` / `versionCode`)를 보내면 게이팅이 조용히 무력화됩니다. 프론트 연동 시 확인이 필요한 부분입니다.

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#164]
## 🖇️ 기타
`ErrorCode`의 앱 버전 코드가 `APP_VERSION_ERROR_002`부터 시작합니다. `001`은 사용처가 없어 비어 있는데, 번호를 당길지 그대로 둘지 알려주시면 반영하겠습니다.
