### PR TITLE
Fix: [채팅] message_type NULL 저장 방지

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/chat/controller/ChatController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/chat/controller/ChatController.java
@@ -3,6 +3,7 @@ package com.storix.api.domain.chat.controller;
 import com.storix.api.domain.chat.usecase.ChatUseCase;
 import com.storix.domain.domains.chat.dto.ChatMessageRequestDto;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.*;
@@ -18,7 +19,7 @@ public class ChatController {
     private final ChatUseCase chatUseCase;
 
     @MessageMapping("/chat/message")
-    public void message(@Payload ChatMessageRequestDto request, SimpMessageHeaderAccessor accessor) {
+    public void message(@Valid @Payload ChatMessageRequestDto request, SimpMessageHeaderAccessor accessor) {
         Authentication auth = (Authentication) accessor.getUser();
 
         if (auth == null) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/domain/ChatMessage.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/domain/ChatMessage.java
@@ -37,6 +37,7 @@ public class ChatMessage extends BaseTimeEntity {
     private String message;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private MessageType messageType;
 
     @Builder.Default

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/dto/ChatMessageRequestDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/dto/ChatMessageRequestDto.java
@@ -2,11 +2,12 @@ package com.storix.domain.domains.chat.dto;
 
 import com.storix.domain.domains.chat.domain.ChatMessage;
 import com.storix.domain.domains.chat.domain.MessageType;
+import jakarta.validation.constraints.NotNull;
 
 public record ChatMessageRequestDto(
-        Long roomId,
-        String message,
-        MessageType messageType
+        @NotNull Long roomId,
+        @NotNull String message,
+        @NotNull MessageType messageType
 ) {
     public ChatMessage toEntity(Long senderId) {
         return ChatMessage.builder()


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] `ChatMessage.messageType`에 not null 제약 추가
> - [x] `ChatMessageRequestDto` 필드에 `@NotNull` 추가
> - [x] STOMP 핸들러(`ChatController`)에 `@Valid` 적용

클라이언트가 STOMP 페이로드에 `type` 키로 값을 보냈고, DTO 필드명은 `messageType`이라 Jackson이 매핑하지 못하고 버렸습니다. 엔티티에 제약이 없고 DTO에도 검증이 없어 NULL이 그대로 저장되었습니다.

`message_type`이 NULL이면 삭제 쿼리 조건(`AND m.messageType = :messageType`)에 걸리지 않아 0건이 반환되고, 신고 처리 시 `REPORT_ERROR_002`가 발생합니다. 상세 조회에는 타입 조건이 없어 관리자 화면에는 메시지가 정상적으로 보이는데 삭제만 실패합니다.

| 시점 | 내용 |
| --- | --- |
| 2026-04-13 ~ 07-13 | NULL로 331건 저장 |
| 2026-07-03 | 삭제 쿼리에 `messageType` 조건 추가 → 해당 건 삭제 불가 |
| 2026-07-12 | 클라이언트가 필드명 수정 → 이후 정상 저장 |

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #172

## 🖇️ 기타
기존에 messageType=null로 저장된 컬럼값은 messageType=TALK로 변경해두었습니다.

별도 DB 제약 (nullable=false)를 걸어두어야 합니다.
```sql
ALTER TABLE chat_message MODIFY COLUMN message_type VARCHAR(255) NOT NULL;
```
