### PR TITLE
Fix: [알림] 미활동 디바이스 판정 기준을 마지막 sync 시각으로 변경

### DIFF
--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/domain/PushDevice.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/domain/PushDevice.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
                 // 한 기기의 다른 유저 활성 행 정리용
                 @Index(name = "idx_push_device_installation", columnList = "installation_id, is_active"),
                 // 장기 미활동 디바이스 비활성화 배치 스캔용
-                @Index(name = "idx_push_device_active_updated", columnList = "is_active, updated_at")
+                @Index(name = "idx_push_device_active_synced", columnList = "is_active, last_synced_at")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -69,6 +69,9 @@ public class PushDevice extends BaseTimeEntity {
     @Column(name = "last_success_at")
     private LocalDateTime lastSuccessAt;
 
+    @Column(name = "last_synced_at")
+    private LocalDateTime lastSyncedAt;
+
 
     /** 생성자 메서드 */
     @Builder
@@ -87,6 +90,7 @@ public class PushDevice extends BaseTimeEntity {
         this.osVersion = osVersion;
         this.deviceModel = deviceModel;
         this.isActive = true;
+        this.lastSyncedAt = LocalDateTime.now();
     }
 
     public static PushDevice from(Long userId, SyncDeviceCommand cmd) {
@@ -109,11 +113,13 @@ public class PushDevice extends BaseTimeEntity {
         this.appVersion = cmd.appVersion();
         this.osVersion = cmd.osVersion();
         this.isActive = true;
+        this.lastSyncedAt = LocalDateTime.now();
     }
 
     // 2. FCM 토큰 갱신
     public void refreshFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
         this.isActive = true;
+        this.lastSyncedAt = LocalDateTime.now();
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
@@ -87,7 +87,7 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     @Query("""
         UPDATE PushDevice d SET d.isActive = false
         WHERE d.isActive = true
-          AND d.updatedAt < :threshold
+          AND d.lastSyncedAt < :threshold
     """)
     int deactivateStaleDevices(@Param("threshold") LocalDateTime threshold);
 }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] `PushDevice`에 `last_synced_at` 추가하고 등록·동기화·FCM 토큰 갱신 시 기록
> - [x] 미활동 디바이스 비활성화 배치 기준을 `updated_at` → `last_synced_at`으로 변경
> - [x] 배치 스캔 인덱스를 `(is_active, last_synced_at)`으로 교체

`StalePushDeviceScheduler`는 `updated_at`이 29일 이전인 활성 디바이스를 비활성화합니다. 그런데 `updated_at`을 갱신하는 경로가 실제 앱 사용을 반영하지 못했습니다.

**1. sync를 호출해도 값이 같으면 UPDATE가 발생하지 않습니다**

`refresh()`가 세팅하는 값(`fcmToken`, `appVersion`, `osVersion`, `isActive`)이 이전과 모두 같으면 Hibernate dirty checking에 걸리지 않아 UPDATE SQL이 생성되지 않습니다. `@LastModifiedDate`는 `@PreUpdate` 콜백이므로 `updated_at`도 갱신되지 않습니다. 앱 릴리스와 OS 업데이트, FCM 토큰 회전이 없는 기간에는 sync를 아무리 호출해도 DB에 변화가 없습니다.

**2. 푸시 발송 성공도 `updated_at`을 갱신하지 않습니다**

`markFcmTokensSuccess`는 JPQL 벌크 UPDATE라 엔티티 리스너를 타지 않으며 `last_success_at`만 갱신합니다.

결과적으로 앱을 매일 사용하고 푸시도 정상 수신하는 기기가 29일 뒤 비활성화될 수 있습니다. `last_synced_at`은 매번 값이 바뀌므로 dirty checking에도 자연히 걸립니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #171

## 🖇️ 기타
**배포 전 컬럼 추가와 백필이 필요합니다.**

```sql
-- 1. 컬럼 추가
ALTER TABLE push_devices
    ADD COLUMN last_synced_at DATETIME(6) NULL AFTER last_success_at;

-- 2. 백필 — 활성 기기는 현재 시각으로 리셋
UPDATE push_devices SET last_synced_at = NOW(6) WHERE is_active = 1;
UPDATE push_devices SET last_synced_at = updated_at WHERE is_active = 0;

-- 3. 인덱스 교체
ALTER TABLE push_devices ADD INDEX idx_push_device_active_synced (is_active, last_synced_at);
ALTER TABLE push_devices DROP INDEX idx_push_device_active_updated;
```

2번에서 활성 기기를 `updated_at`으로 승계하지 않고 현재 시각으로 리셋하는 이유는, 기존 `updated_at`이 실제 활동을 반영하지 못하는 값이기 때문입니다. 그대로 승계하면 배포 직후 첫 배치(04:40)에서 정상 사용 중인 기기가 대량으로 비활성화됩니다.

비활성화된 기기는 다음 sync에서 `isActive`가 false → true로 바뀌며 복구되지만, 그 사이 기간에는 푸시를 받지 못합니다.
