### PR TITLE
Feat: [모니터링] 호스트 OOM 알림 룰 추가

### DIFF
--- a/monitoring/grafana/provisioning/alerting/rules.yml
+++ b/monitoring/grafana/provisioning/alerting/rules.yml
@@ -63,6 +63,34 @@ groups:
               conditions:
                 - evaluator: { type: gt, params: [0] }
 
+      - uid: storix-host-oom
+        title: '호스트 OOM 발생'
+        condition: B
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: '{{ $labels.instance_id }} 호스트가 메모리 고갈로 프로세스를 OOM 종료했습니다.'
+          runbook: '박스 메모리 오버서브. dmesg | grep -i oom 확인 후 mem_limit 하향 또는 인스턴스 상향'
+        noDataState: OK
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: 'sum by (env, instance_id) (increase(node_vmstat_oom_kill[5m]))'
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
       - uid: storix-jvm-heap
         title: 'JVM 힙 사용률 85% 초과'
         condition: B


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] `storix-host-oom` 알림 룰 추가 (`monitoring/grafana/provisioning/alerting/rules.yml`)

컨테이너 OOM 알림(`storix-container-oom`)은 적용돼 있으나 호스트 레벨 OOM Killer 동작은 감지하지 못했습니다. 호스트 메모리가 고갈되면 컨테이너가 아닌 임의의 프로세스가 종료될 수 있어 별도 룰이 필요합니다.

```
expr: sum by (env, instance_id) (increase(node_vmstat_oom_kill[5m]))
condition: > 0
severity: critical
for: 0m
```

## 📸 작업 화면 (스크린샷)
YAML 파싱과 룰 목록을 확인했습니다. 총 15개 룰이며 `storix-container-oom` 다음에 배치됩니다.

```
storix-app-down          서비스 다운               critical
storix-container-oom     컨테이너 OOM 발생          critical
storix-host-oom          호스트 OOM 발생            critical   ← 추가
storix-jvm-heap          JVM 힙 사용률 85% 초과      warning
```

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #167

## 🖇️ 기타
`node_vmstat_oom_kill` 메트릭은 node exporter가 노출합니다. 알림이 동작하려면 해당 exporter가 수집 대상에 포함돼 있어야 합니다.
