### PR TITLE
Refactor: [공통] Redis 키를 RedisKeyStatic으로 통합

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AdminAppEventUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AdminAppEventUseCase.java
@@ -4,7 +4,7 @@ import com.storix.api.domain.event.controller.dto.AppEventRequest;
 import com.storix.common.payload.PageResponseWrapperDTO;
 import com.storix.common.code.SuccessCode;
 import com.storix.common.payload.CustomResponse;
-import com.storix.common.utils.STORIXStatic;
+import com.storix.common.utils.RedisKeyStatic;
 import com.storix.domain.domains.event.dto.AppEventResponse;
 import com.storix.domain.domains.event.service.AppEventService;
 import com.storix.domain.domains.event.service.EventContentCacheHelper;
@@ -47,8 +47,8 @@ public class AdminAppEventUseCase {
         AppEventResponse result = appEventService.update(appEventId, req.toCommand());
 
         // 2. 소속 팝업·배너 노출기간도 함께 바뀌므로 캐시 무효화
-        eventContentCacheHelper.evict(STORIXStatic.ACTIVE_POPUP_KEY);
-        eventContentCacheHelper.evict(STORIXStatic.ACTIVE_BANNER_KEY);
+        eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
+        eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
         return CustomResponse.onSuccess(SuccessCode.ADMIN_APP_EVENT_UPDATE_SUCCESS, result);
     }
 
@@ -59,8 +59,8 @@ public class AdminAppEventUseCase {
         AppEventResponse result = appEventService.cancel(appEventId);
 
         // 2. 소속 팝업·배너도 함께 종료되므로 캐시 무효화
-        eventContentCacheHelper.evict(STORIXStatic.ACTIVE_POPUP_KEY);
-        eventContentCacheHelper.evict(STORIXStatic.ACTIVE_BANNER_KEY);
+        eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
+        eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
         return CustomResponse.onSuccess(SuccessCode.ADMIN_APP_EVENT_CANCEL_SUCCESS, result);
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AppEventUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AppEventUseCase.java
@@ -2,7 +2,7 @@ package com.storix.api.domain.event.usecase;
 
 import com.storix.common.code.SuccessCode;
 import com.storix.common.payload.CustomResponse;
-import com.storix.common.utils.STORIXStatic;
+import com.storix.common.utils.RedisKeyStatic;
 import com.storix.domain.domains.event.dto.BannerResponse;
 import com.storix.domain.domains.event.dto.OneTimeAppEventResponse;
 import com.storix.domain.domains.event.dto.PopupResponse;
@@ -37,7 +37,7 @@ public class AppEventUseCase {
     public CustomResponse<PopupResponse> getActivePopup(Long userId) {
 
         LocalDate today = LocalDate.now();
-        PopupResponse popup = eventContentCacheHelper.getActive(STORIXStatic.ACTIVE_POPUP_KEY, PopupResponse.class,
+        PopupResponse popup = eventContentCacheHelper.getActive(RedisKeyStatic.Event.ACTIVE_POPUP, PopupResponse.class,
                         () -> eventPopupService.findActivePopup(LocalDateTime.now()), PopupResponse::displayEndAt)
                 .filter(p -> !popupDismissService.isSuppressed(userId, p.id(), p.exposurePolicy(), today))
                 .map(p -> p.withBaseUrl(baseUrl))
@@ -59,7 +59,7 @@ public class AppEventUseCase {
     // 노출 중인 배너 조회
     public CustomResponse<List<BannerResponse>> getActiveBanner() {
 
-        List<BannerResponse> banners = eventContentCacheHelper.getActiveList(STORIXStatic.ACTIVE_BANNER_KEY, BannerResponse.class,
+        List<BannerResponse> banners = eventContentCacheHelper.getActiveList(RedisKeyStatic.Event.ACTIVE_BANNER, BannerResponse.class,
                         () -> eventBannerService.findActiveBanners(LocalDateTime.now()), BannerResponse::displayEndAt)
                 .stream()
                 .map(b -> b.withBaseUrl(baseUrl))

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/BannerUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/BannerUseCase.java
@@ -2,7 +2,7 @@ package com.storix.api.domain.event.usecase;
 
 import com.storix.common.code.SuccessCode;
 import com.storix.common.payload.CustomResponse;
-import com.storix.common.utils.STORIXStatic;
+import com.storix.common.utils.RedisKeyStatic;
 import com.storix.api.domain.event.controller.dto.BannerRequest;
 import com.storix.common.payload.PageResponseWrapperDTO;
 import com.storix.api.domain.image.helper.S3UploadHelper;
@@ -43,7 +43,7 @@ public class BannerUseCase {
         }
 
         // 3. 이벤트 배너 캐시 무효화
-        eventContentCacheHelper.evict(STORIXStatic.ACTIVE_BANNER_KEY);
+        eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
         return CustomResponse.onSuccess(SuccessCode.EVENT_BANNER_CREATE_SUCCESS, BannerResponse.from(banner).withBaseUrl(baseUrl));
     }
 
@@ -84,7 +84,7 @@ public class BannerUseCase {
 
         // 3. 교체 성공 시 옛 이미지 정리 + 캐시 무효화
         if (replaceImage) s3UploadHelper.delete(oldImageObjectKey);
-        eventContentCacheHelper.evict(STORIXStatic.ACTIVE_BANNER_KEY);
+        eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
         return CustomResponse.onSuccess(SuccessCode.EVENT_BANNER_UPDATE_SUCCESS, BannerResponse.from(banner).withBaseUrl(baseUrl));
     }
 
@@ -95,7 +95,7 @@ public class BannerUseCase {
         Banner banner = eventBannerService.cancel(bannerId);
 
         // 2. 이벤트 배너 캐시 무효화
-        eventContentCacheHelper.evict(STORIXStatic.ACTIVE_BANNER_KEY);
+        eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
         return CustomResponse.onSuccess(SuccessCode.EVENT_BANNER_CANCEL_SUCCESS, BannerResponse.from(banner).withBaseUrl(baseUrl));
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/PopupUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/PopupUseCase.java
@@ -2,7 +2,7 @@ package com.storix.api.domain.event.usecase;
 
 import com.storix.common.code.SuccessCode;
 import com.storix.common.payload.CustomResponse;
-import com.storix.common.utils.STORIXStatic;
+import com.storix.common.utils.RedisKeyStatic;
 import com.storix.common.payload.PageResponseWrapperDTO;
 import com.storix.api.domain.event.controller.dto.PopupRequest;
 import com.storix.api.domain.image.helper.S3UploadHelper;
@@ -43,7 +43,7 @@ public class PopupUseCase {
         }
 
         // 3. 이벤트 팝업 캐시 무효화
-        eventContentCacheHelper.evict(STORIXStatic.ACTIVE_POPUP_KEY);
+        eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
         return CustomResponse.onSuccess(SuccessCode.EVENT_POPUP_CREATE_SUCCESS, PopupResponse.from(popup).withBaseUrl(baseUrl));
     }
 
@@ -84,7 +84,7 @@ public class PopupUseCase {
 
         // 3. 교체 성공 시 옛 이미지 정리 + 캐시 무효화
         if (replaceImage) s3UploadHelper.delete(oldImageObjectKey);
-        eventContentCacheHelper.evict(STORIXStatic.ACTIVE_POPUP_KEY);
+        eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
         return CustomResponse.onSuccess(SuccessCode.EVENT_POPUP_UPDATE_SUCCESS, PopupResponse.from(popup).withBaseUrl(baseUrl));
     }
 
@@ -95,7 +95,7 @@ public class PopupUseCase {
         Popup popup = eventPopupService.cancel(popupId);
 
         // 2. 이벤트 팝업 캐시 무효화
-        eventContentCacheHelper.evict(STORIXStatic.ACTIVE_POPUP_KEY);
+        eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
         return CustomResponse.onSuccess(SuccessCode.EVENT_POPUP_CANCEL_SUCCESS, PopupResponse.from(popup).withBaseUrl(baseUrl));
     }
 }

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/EventDisplayScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/EventDisplayScheduler.java
@@ -1,6 +1,6 @@
 package com.storix.batch.scheduler;
 
-import com.storix.common.utils.STORIXStatic;
+import com.storix.common.utils.RedisKeyStatic;
 import com.storix.domain.domains.event.service.BannerService;
 import com.storix.domain.domains.event.service.EventContentCacheHelper;
 import com.storix.domain.domains.event.service.PopupService;
@@ -43,7 +43,7 @@ public class EventDisplayScheduler {
         } finally {
             // 앞 단계가 커밋됐으면 뒤 단계가 실패해도 캐시는 무효화
             if (changed) {
-                eventContentCacheHelper.evict(STORIXStatic.ACTIVE_POPUP_KEY);
+                eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
             }
         }
     }
@@ -62,7 +62,7 @@ public class EventDisplayScheduler {
             log.error(">>> [EventDisplayScheduler] banner 전환 실패", e);
         } finally {
             if (changed) {
-                eventContentCacheHelper.evict(STORIXStatic.ACTIVE_BANNER_KEY);
+                eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
             }
         }
     }

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/TrendingKeywordScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/TrendingKeywordScheduler.java
@@ -1,8 +1,9 @@
 package com.storix.batch.scheduler;
 
-import static com.storix.common.utils.STORIXStatic.TRENDING_AGGREGATED_KEY;
-import static com.storix.common.utils.STORIXStatic.TRENDING_PREV_AGGREGATED_KEY;
+import static com.storix.common.utils.RedisKeyStatic.Search.TRENDING_AGGREGATED;
+import static com.storix.common.utils.RedisKeyStatic.Search.TRENDING_PREV_AGGREGATED;
 
+import com.storix.common.utils.RedisKeyStatic;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -21,7 +22,7 @@ public class TrendingKeywordScheduler {
 
     private final StringRedisTemplate redisTemplate;
 
-    private static final String TRENDING_KEY_PREFIX = "search:trending:";
+    private static final String TRENDING_KEY_PREFIX = RedisKeyStatic.Search.TRENDING_PREFIX;
 
     /** 최근 3일 합산 키 갱신 (20분 주기) — 오늘 + 이전 합산(어제+그저께) */
     @Scheduled(cron = "0 */20 * * * *")
@@ -31,8 +32,8 @@ public class TrendingKeywordScheduler {
         LocalDate now = LocalDate.now();
         String todayKey = TRENDING_KEY_PREFIX + now.format(DateTimeFormatter.BASIC_ISO_DATE);
 
-        redisTemplate.opsForZSet().unionAndStore(todayKey, List.of(TRENDING_PREV_AGGREGATED_KEY), TRENDING_AGGREGATED_KEY);
-        redisTemplate.expire(TRENDING_AGGREGATED_KEY, 2, TimeUnit.DAYS);
+        redisTemplate.opsForZSet().unionAndStore(todayKey, List.of(TRENDING_PREV_AGGREGATED), TRENDING_AGGREGATED);
+        redisTemplate.expire(TRENDING_AGGREGATED, 2, TimeUnit.DAYS);
 
         log.info(">>>> [Scheduler] 인기 검색어 합산 키 갱신 완료");
     }
@@ -48,8 +49,8 @@ public class TrendingKeywordScheduler {
         String yesterdayKey = TRENDING_KEY_PREFIX + now.minusDays(1).format(fmt);
         String twoDaysAgoKey = TRENDING_KEY_PREFIX + now.minusDays(2).format(fmt);
 
-        redisTemplate.opsForZSet().unionAndStore(yesterdayKey, List.of(twoDaysAgoKey), TRENDING_PREV_AGGREGATED_KEY);
-        redisTemplate.expire(TRENDING_PREV_AGGREGATED_KEY, 2, TimeUnit.DAYS);
+        redisTemplate.opsForZSet().unionAndStore(yesterdayKey, List.of(twoDaysAgoKey), TRENDING_PREV_AGGREGATED);
+        redisTemplate.expire(TRENDING_PREV_AGGREGATED, 2, TimeUnit.DAYS);
 
         log.info(">>>> [Scheduler] 이전 비교 기준 합산 키 갱신 완료");
     }

--- a/STORIX-Common/src/main/java/com/storix/common/utils/RedisKeyStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/RedisKeyStatic.java
@@ -1,0 +1,97 @@
+package com.storix.common.utils;
+
+public final class RedisKeyStatic {
+
+    private RedisKeyStatic() {
+    }
+
+    // @RedisHash 엔티티 키스페이스
+    public static final class Hash {
+        public static final String REFRESH_TOKEN = "refreshToken";
+        public static final String ONBOARDING_TOKEN = "onboardingToken";
+        public static final String ADMIN_SIGNUP_PENDING = "adminSignupPending";
+        public static final String TESTER_SIGNUP_PENDING = "testerSignupPending";
+        public static final String USER_BLACKLIST = "userBlacklist";
+
+        private Hash() {
+        }
+    }
+
+    public static final class Search {
+        public static final String TRENDING_PREFIX = "search:trending:";
+        public static final String TRENDING_AGGREGATED = "search:trending:aggregated";
+        public static final String TRENDING_PREV_AGGREGATED = "search:trending:aggregated:prev";
+        public static final String RECENT_PREFIX = "search:recent:";
+
+        private Search() {
+        }
+    }
+
+    public static final class Event {
+        public static final String ACTIVE_POPUP = "event::activePopup::v1";
+        public static final String ACTIVE_BANNER = "event::activeBanner::v1";
+        public static final String PENDING_APP_EVENTS_PREFIX = "event::pendingAppEvents::v1::";
+
+        private Event() {
+        }
+    }
+
+    // 선정 알림 dedup — {prefix}{yyyyMMdd}:{id}
+    public static final class Notification {
+        public static final String FEATURED_FEED_PREFIX = "featured:feed:";
+        public static final String FEATURED_TOPIC_ROOM_PREFIX = "featured:topicroom:";
+
+        private Notification() {
+        }
+    }
+
+    public static final class Library {
+        public static final String RECENT_PREFIX = "library:recent";
+
+        private Library() {
+        }
+    }
+
+    public static final class Hashtag {
+        public static final String TOTAL_WORKS = "hashtag:meta:total_works";
+        public static final String DF = "hashtag:df";
+
+        private Hashtag() {
+        }
+    }
+
+    public static final class Image {
+        public static final String BOARD_PREFIX = "image:public:board:";
+        public static final String PROFILE_PREFIX = "image:public:profile:";
+
+        private Image() {
+        }
+    }
+
+    public static final class Onboarding {
+        public static final String WORKS_LIST = "onboarding::onboardingWorksList::v1";
+
+        private Onboarding() {
+        }
+    }
+
+    public static final class Exploration {
+        public static final String CHART_PREFIX = "exploration::chart::total::";
+        public static final String DONE_PREFIX = "exploration::done::today::";
+        public static final String PENDING_PREFIX = "exploration::pending::detail::";
+        public static final String GLOBAL_QUEUE = "exploration::queue";
+        public static final String DAILY_COUNT_PREFIX = "exploration::count::today::";
+
+        private Exploration() {
+        }
+    }
+
+    // pub/sub 채널
+    public static final class Channel {
+        public static final String CHAT_ROOM_PREFIX = "room:";
+        public static final String TOPIC_ROOM_ACTIVE_USERS_PREFIX = "topic-room:active-users:";
+
+        private Channel() {
+        }
+    }
+}

--- a/STORIX-Common/src/main/java/com/storix/common/utils/RedisKeyStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/RedisKeyStatic.java
@@ -46,7 +46,7 @@ public final class RedisKeyStatic {
     }
 
     public static final class Library {
-        public static final String RECENT_PREFIX = "library:recent";
+        public static final String RECENT_PREFIX = "library:recent:";
 
         private Library() {
         }

--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -42,15 +42,6 @@ public class STORIXStatic {
     // S3 DeleteObjects API 요청당 최대 키 수 (고정 한도가 1000)
     public static final int S3_MAX_KEYS_PER_DELETE_REQUEST = 1000;
 
-    // 인기 검색어 Redis 합산 키
-    public static final String TRENDING_AGGREGATED_KEY = "search:trending:aggregated";
-    public static final String TRENDING_PREV_AGGREGATED_KEY = "search:trending:aggregated:prev";
-
-    // 이벤트 활성 콘텐츠 Redis 캐시 키
-    public static final String ACTIVE_POPUP_KEY = "event::activePopup::v1";
-    public static final String ACTIVE_BANNER_KEY = "event::activeBanner::v1";
-    public static final String PENDING_APP_EVENTS_KEY_PREFIX = "event::pendingAppEvents::v1::";
-
     public static final List<String> SWAGGER_URI= List.of(
             new String[]{"/swagger-resources/", "/swagger-ui/", "/v3/api-docs"}
     );
@@ -138,10 +129,6 @@ public class STORIXStatic {
         // 댓글 본문 미리보기 — 10자 노출 후 ...
         public static final int CONTENT_PREVIEW_MAX = 10;
         public static final String CONTENT_PREVIEW_SUFFIX = "...";
-
-        // 선정 알림 dedup Redis 키 prefix — {prefix}{yyyyMMdd}:{id}
-        public static final String FEATURED_FEED_KEY_PREFIX = "featured:feed:";
-        public static final String FEATURED_TOPIC_ROOM_KEY_PREFIX = "featured:topicroom:";
     }
 
     // 사용자 이력 — 마케팅 동의/거부 모달 표시 문구

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/UserAppEventCacheHelper.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/UserAppEventCacheHelper.java
@@ -2,7 +2,7 @@ package com.storix.domain.domains.event.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.storix.common.utils.STORIXStatic;
+import com.storix.common.utils.RedisKeyStatic;
 import com.storix.domain.domains.event.dto.OneTimeAppEventResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -53,6 +53,6 @@ public class UserAppEventCacheHelper {
     }
 
     private String key(Long userId) {
-        return STORIXStatic.PENDING_APP_EVENTS_KEY_PREFIX + userId;
+        return RedisKeyStatic.Event.PENDING_APP_EVENTS_PREFIX + userId;
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/hashtag/service/HashtagCacheHelper.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/hashtag/service/HashtagCacheHelper.java
@@ -1,4 +1,5 @@
 package com.storix.domain.domains.hashtag.service;
+import com.storix.common.utils.RedisKeyStatic;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +19,8 @@ public class HashtagCacheHelper {
 
     private final StringRedisTemplate redisTemplate;
 
-    private static final String TOTAL_WORKS_KEY = "hashtag:meta:total_works";
-    private static final String DF_HASH_KEY = "hashtag:df";
+    private static final String TOTAL_WORKS_KEY = RedisKeyStatic.Hashtag.TOTAL_WORKS;
+    private static final String DF_HASH_KEY = RedisKeyStatic.Hashtag.DF;
     private static final Duration META_TTL = Duration.ofDays(7);
 
     public long getOrLoadTotalWorksCount(Supplier<Long> loader) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/image/service/S3CacheHelper.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/image/service/S3CacheHelper.java
@@ -1,4 +1,5 @@
 package com.storix.domain.domains.image.service;
+import com.storix.common.utils.RedisKeyStatic;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +19,8 @@ public class S3CacheHelper {
 
     private final StringRedisTemplate redisTemplate;
 
-    private static final String BOARD_KEY_PREFIX = "image:public:board:";
-    private static final String PROFILE_KEY_PREFIX = "image:public:profile:";
+    private static final String BOARD_KEY_PREFIX = RedisKeyStatic.Image.BOARD_PREFIX;
+    private static final String PROFILE_KEY_PREFIX = RedisKeyStatic.Image.PROFILE_PREFIX;
 
     private static final long IMAGE_KEY_TTL_MINUTE = 20;
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/FeaturedNotificationDedupAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/FeaturedNotificationDedupAdaptor.java
@@ -1,6 +1,6 @@
 package com.storix.domain.domains.notification.adaptor;
 
-import com.storix.common.utils.STORIXStatic;
+import com.storix.common.utils.RedisKeyStatic;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
@@ -19,11 +19,11 @@ public class FeaturedNotificationDedupAdaptor {
     private final StringRedisTemplate redisTemplate;
 
     public boolean markFeedIfFirstToday(Long feedId) {
-        return markIfFirstToday(STORIXStatic.Notification.FEATURED_FEED_KEY_PREFIX, feedId);
+        return markIfFirstToday(RedisKeyStatic.Notification.FEATURED_FEED_PREFIX, feedId);
     }
 
     public boolean markTopicRoomIfFirstToday(Long topicRoomId) {
-        return markIfFirstToday(STORIXStatic.Notification.FEATURED_TOPIC_ROOM_KEY_PREFIX, topicRoomId);
+        return markIfFirstToday(RedisKeyStatic.Notification.FEATURED_TOPIC_ROOM_PREFIX, topicRoomId);
     }
 
     // SETNX + TTL 원자 연산 -> 오늘 첫 선정이면 true, 이미 보냈으면 false

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/onboarding/service/OnboardingWorksHelper.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/onboarding/service/OnboardingWorksHelper.java
@@ -1,4 +1,5 @@
 package com.storix.domain.domains.onboarding.service;
+import com.storix.common.utils.RedisKeyStatic;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,7 +24,7 @@ import java.util.*;
 @RequiredArgsConstructor
 public class OnboardingWorksHelper {
 
-    private static final String KEY = "onboarding::onboardingWorksList::v1";
+    private static final String KEY = RedisKeyStatic.Onboarding.WORKS_LIST;
     private static final Duration TTL = Duration.ofDays(7);
 
     private final RedisTemplate<String, Object> redisTemplate;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationCacheHelper.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/preference/service/ExplorationCacheHelper.java
@@ -1,4 +1,5 @@
 package com.storix.domain.domains.preference.service;
+import com.storix.common.utils.RedisKeyStatic;
 
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -30,11 +31,11 @@ public class ExplorationCacheHelper {
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
 
-    private static final String CHART_KEY_PREFIX = "exploration::chart::total::";
-    private static final String DONE_KEY_PREFIX = "exploration::done::today::";
-    private static final String PENDING_LIST_PREFIX = "exploration::pending::detail::";
-    private static final String GLOBAL_QUEUE_KEY = "exploration::queue";
-    private static final String DAILY_COUNT_KEY_PREFIX = "exploration::count::today::";
+    private static final String CHART_KEY_PREFIX = RedisKeyStatic.Exploration.CHART_PREFIX;
+    private static final String DONE_KEY_PREFIX = RedisKeyStatic.Exploration.DONE_PREFIX;
+    private static final String PENDING_LIST_PREFIX = RedisKeyStatic.Exploration.PENDING_PREFIX;
+    private static final String GLOBAL_QUEUE_KEY = RedisKeyStatic.Exploration.GLOBAL_QUEUE;
+    private static final String DAILY_COUNT_KEY_PREFIX = RedisKeyStatic.Exploration.DAILY_COUNT_PREFIX;
     private static final int MAX_QUEUE_SIZE = 10000;
 
     private static final String SUBMIT_SCRIPT =

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/search/service/SearchHistoryService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/search/service/SearchHistoryService.java
@@ -1,7 +1,8 @@
 package com.storix.domain.domains.search.service;
+import com.storix.common.utils.RedisKeyStatic;
 
-import static com.storix.common.utils.STORIXStatic.TRENDING_AGGREGATED_KEY;
-import static com.storix.common.utils.STORIXStatic.TRENDING_PREV_AGGREGATED_KEY;
+import static com.storix.common.utils.RedisKeyStatic.Search.TRENDING_AGGREGATED;
+import static com.storix.common.utils.RedisKeyStatic.Search.TRENDING_PREV_AGGREGATED;
 
 import com.storix.domain.domains.search.dto.TrendingItem;
 import lombok.RequiredArgsConstructor;
@@ -26,9 +27,9 @@ public class SearchHistoryService {
     private final StringRedisTemplate redisTemplate;
 
     // 날짜별 키 접두사
-    private static final String TRENDING_KEY_PREFIX = "search:trending:";
-    private static final String RECENT_KEY_PREFIX = "search:recent:";
-    private static final String LIBRARY_RECENT_KEY_PREFIX = "library:recent";
+    private static final String TRENDING_KEY_PREFIX = RedisKeyStatic.Search.TRENDING_PREFIX;
+    private static final String RECENT_KEY_PREFIX = RedisKeyStatic.Search.RECENT_PREFIX;
+    private static final String LIBRARY_RECENT_KEY_PREFIX = RedisKeyStatic.Library.RECENT_PREFIX;
 
     // 최근 검색어 개수 (10)
     private static final int MAX_RECENT_SIZE = 10;
@@ -96,7 +97,7 @@ public class SearchHistoryService {
 
         // 합산 키에서 Top 10 조회
         Set<ZSetOperations.TypedTuple<String>> currentKeywordsWithScores =
-                redisTemplate.opsForZSet().reverseRangeWithScores(TRENDING_AGGREGATED_KEY, 0, 9);
+                redisTemplate.opsForZSet().reverseRangeWithScores(TRENDING_AGGREGATED, 0, 9);
 
         if (currentKeywordsWithScores == null || currentKeywordsWithScores.isEmpty()) {
             return List.of();
@@ -114,7 +115,7 @@ public class SearchHistoryService {
                 break;
             }
 
-            Long prevRankIndex = redisTemplate.opsForZSet().reverseRank(TRENDING_PREV_AGGREGATED_KEY, keyword);
+            Long prevRankIndex = redisTemplate.opsForZSet().reverseRank(TRENDING_PREV_AGGREGATED, keyword);
 
             String status = "SAME";
 
@@ -168,7 +169,7 @@ public class SearchHistoryService {
     public String getFallbackRecommendation() {
 
         try {
-            Set<String> rank11to20 = redisTemplate.opsForZSet().reverseRange(TRENDING_AGGREGATED_KEY, 10, 19);
+            Set<String> rank11to20 = redisTemplate.opsForZSet().reverseRange(TRENDING_AGGREGATED, 10, 19);
 
             if (rank11to20 == null || rank11to20.isEmpty()) {
                 return null;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/AdminSignupPending.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/AdminSignupPending.java
@@ -1,4 +1,5 @@
 package com.storix.domain.domains.user.domain;
+import com.storix.common.utils.RedisKeyStatic;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -6,7 +7,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
-@RedisHash(value = "adminSignupPending")
+@RedisHash(value = RedisKeyStatic.Hash.ADMIN_SIGNUP_PENDING)
 @Getter
 public class AdminSignupPending {
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OnboardingToken.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/OnboardingToken.java
@@ -1,4 +1,5 @@
 package com.storix.domain.domains.user.domain;
+import com.storix.common.utils.RedisKeyStatic;
 
 
 import lombok.Builder;
@@ -8,7 +9,7 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
-@RedisHash(value = "onboardingToken")
+@RedisHash(value = RedisKeyStatic.Hash.ONBOARDING_TOKEN)
 @Getter
 public class OnboardingToken {
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/RefreshToken.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/RefreshToken.java
@@ -1,4 +1,5 @@
 package com.storix.domain.domains.user.domain;
+import com.storix.common.utils.RedisKeyStatic;
 
 import jakarta.persistence.Id;
 import lombok.Builder;
@@ -7,7 +8,7 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
-@RedisHash(value = "refreshToken")
+@RedisHash(value = RedisKeyStatic.Hash.REFRESH_TOKEN)
 @Getter
 public class RefreshToken {
     @Id

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/TesterSignupPending.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/TesterSignupPending.java
@@ -1,4 +1,5 @@
 package com.storix.domain.domains.user.domain;
+import com.storix.common.utils.RedisKeyStatic;
 
 import com.storix.domain.domains.works.domain.Genre;
 import lombok.Builder;
@@ -9,7 +10,7 @@ import org.springframework.data.redis.core.TimeToLive;
 
 import java.util.Set;
 
-@RedisHash(value = "testerSignupPending")
+@RedisHash(value = RedisKeyStatic.Hash.TESTER_SIGNUP_PENDING)
 @Getter
 public class TesterSignupPending {
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserBlacklist.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/domain/UserBlacklist.java
@@ -1,4 +1,5 @@
 package com.storix.domain.domains.user.domain;
+import com.storix.common.utils.RedisKeyStatic;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -6,7 +7,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
-@RedisHash(value = "userBlacklist")
+@RedisHash(value = RedisKeyStatic.Hash.USER_BLACKLIST)
 @Getter
 public class UserBlacklist {
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/RedisChatAdapter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/RedisChatAdapter.java
@@ -1,4 +1,5 @@
 package com.storix.infrastructure.external.chat;
+import com.storix.common.utils.RedisKeyStatic;
 
 import com.storix.domain.domains.chat.application.port.PublishChatPort;
 import com.storix.domain.domains.chat.dto.ChatMessageResponseDto;
@@ -25,7 +26,7 @@ public class RedisChatAdapter implements PublishChatPort {
 
         try {
             // "room:1" 형식으로 메시지 전송
-            jsonRedisTemplate.convertAndSend("room:" + response.roomId(), response);
+            jsonRedisTemplate.convertAndSend(RedisKeyStatic.Channel.CHAT_ROOM_PREFIX + response.roomId(), response);
         } catch (RedisConnectionFailureException e) {
 
             // Redis 연결 실패

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/StompHandler.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/StompHandler.java
@@ -1,4 +1,5 @@
 package com.storix.infrastructure.external.chat;
+import com.storix.common.utils.RedisKeyStatic;
 
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.domain.domains.user.domain.Role;
@@ -170,7 +171,7 @@ public class StompHandler implements ChannelInterceptor {
 
         if (count == 1) {
             chatTopics.computeIfAbsent(roomId, id -> {
-                ChannelTopic topic = new ChannelTopic("room:" + id);
+                ChannelTopic topic = new ChannelTopic(RedisKeyStatic.Channel.CHAT_ROOM_PREFIX + id);
                 container.addMessageListener(subscriber, topic);
                 log.info(">>>> [Redis] 첫 번째 구독자 발생 - 리스너 등록됨: room:{}", id);
                 return topic;

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/RedisTopicRoomActiveUserNumberAdapter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/RedisTopicRoomActiveUserNumberAdapter.java
@@ -1,4 +1,5 @@
 package com.storix.infrastructure.external.topicroom;
+import com.storix.common.utils.RedisKeyStatic;
 
 import com.storix.domain.domains.topicroom.dto.TopicRoomActiveUserNumberResponseDto;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class RedisTopicRoomActiveUserNumberAdapter {
 
-    private static final String CHANNEL_PREFIX = "topic-room:active-users:";
+    private static final String CHANNEL_PREFIX = RedisKeyStatic.Channel.TOPIC_ROOM_ACTIVE_USERS_PREFIX;
 
     private final RedisTemplate<String, Object> jsonRedisTemplate;
 


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] `RedisKeyStatic` 신규 추가 (STORIX-Common)
> - [x] `@RedisHash` 키스페이스 5종 상수화
> - [x] 캐시 키 접두사 상수화 (Hashtag, Image, Onboarding, Exploration, Search, Library)
> - [x] pub/sub 채널 상수화 (채팅방, 토픽룸 활성 유저)
> - [x] `STORIXStatic`에 있던 Redis 키 7개를 `RedisKeyStatic`으로 이관
> - [x] 서재 최근 검색어 키에 구분자(`:`) 추가

Redis 키 문자열이 각 도메인 클래스와 헬퍼, `STORIXStatic`에 흩어져 있어 전체 키 목록을 파악하려면 파일을 일일이 찾아야 했습니다. 오타로 인한 키 불일치도 컴파일 시점에 잡히지 않았습니다.

```
Hash         refreshToken, onboardingToken, adminSignupPending,
             testerSignupPending, userBlacklist
Search       search:trending:, search:trending:aggregated,
             search:trending:aggregated:prev, search:recent:
Library      library:recent:
Hashtag      hashtag:meta:total_works, hashtag:df
Image        image:public:board:, image:public:profile:
Onboarding   onboarding::onboardingWorksList::v1
Exploration  exploration::chart::total:: 외 4개
Event        event::activePopup::v1, event::activeBanner::v1,
             event::pendingAppEvents::v1::
Notification featured:feed:, featured:topicroom:
Channel      room:, topic-room:active-users:
```

`@RedisHash(value = ...)`에 사용하므로 모두 컴파일 타임 상수(`public static final String`)로 정의했습니다.

## 📸 작업 화면 (스크린샷)
키 값이 기존과 동일한지 전량 대조했습니다. 서재 최근 검색어 키를 제외한 나머지는 변경 전 코드에서 제거된 문자열 리터럴과 `RedisKeyStatic`에 정의된 값이 모두 일치합니다.

`STORIX-Api`, `STORIX-Infrastructure`, `STORIX-Batch` 컴파일을 확인했습니다.

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #168

## 🖇️ 기타
상수 위치를 옮기는 작업이며, 서재 최근 검색어 키 하나만 값이 바뀝니다. 키 값이 달라지면 기존 데이터를 찾지 못하므로 나머지는 값 일치를 우선 확인했습니다.

**서재 최근 검색어 키 변경** — `library:recent` 뒤에 구분자가 없어 userId가 바로 붙었습니다.

```
변경 전  library:recent12
변경 후  library:recent:12
```

패턴 스캔 시 `library:recent1*`가 userId 1, 12, 13, 100을 함께 잡는 문제가 있어 다른 키와 형식을 맞췄습니다. 기존 키는 조회되지 않으므로 **서재 최근 검색어는 초기화**됩니다.

배포 후 남는 구 형식 키는 아래로 정리하면 됩니다. 패턴이 `[0-9]`로 시작해 새 형식(`library:recent:`)은 걸리지 않습니다.

```bash
# 개수 확인
docker exec storix-redis sh -c "redis-cli --scan --pattern 'library:recent[0-9]*' | wc -l"

# 삭제
docker exec storix-redis sh -c "redis-cli --scan --pattern 'library:recent[0-9]*' | xargs -r -n 500 redis-cli DEL"
```

`STORIXStatic.WITHDRAW_PREFIX`(`"DELETED:"`)는 탈퇴 시 닉네임과 oid를 마스킹하는 접두사라 Redis 키가 아니어서 그대로 두었습니다.

