### PR TITLE
Feat: [로깅] 전체 API 요청·완료 로그 및 커스텀 예외 WARN 기록

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AdminAppEventUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AdminAppEventUseCase.java
@@ -10,8 +10,10 @@ import com.storix.domain.domains.event.service.AppEventService;
 import com.storix.domain.domains.event.service.EventContentCacheHelper;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AdminAppEventUseCase {
@@ -23,6 +25,7 @@ public class AdminAppEventUseCase {
     public CustomResponse<AppEventResponse> createAppEvent(AuthUserDetails authUser, AppEventRequest req) {
 
         AppEventResponse result = appEventService.create(req.toCommand(), authUser.getUserId());
+        log.info(">>> [AppEvent] 생성 완료 appEventId={}", result.id());
         return CustomResponse.onSuccess(SuccessCode.ADMIN_APP_EVENT_CREATE_SUCCESS, result);
     }
 
@@ -49,6 +52,7 @@ public class AdminAppEventUseCase {
         // 2. 소속 팝업·배너 노출기간도 함께 바뀌므로 캐시 무효화
         eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
         eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
+        log.info(">>> [AppEvent] 수정 완료 appEventId={}", appEventId);
         return CustomResponse.onSuccess(SuccessCode.ADMIN_APP_EVENT_UPDATE_SUCCESS, result);
     }
 
@@ -61,6 +65,7 @@ public class AdminAppEventUseCase {
         // 2. 소속 팝업·배너도 함께 종료되므로 캐시 무효화
         eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
         eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
+        log.info(">>> [AppEvent] 강제 종료 appEventId={}", appEventId);
         return CustomResponse.onSuccess(SuccessCode.ADMIN_APP_EVENT_CANCEL_SUCCESS, result);
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/BannerUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/BannerUseCase.java
@@ -13,10 +13,12 @@ import com.storix.domain.domains.event.service.EventContentCacheHelper;
 import com.storix.domain.domains.image.domain.EventImageSurface;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class BannerUseCase {
@@ -32,6 +34,7 @@ public class BannerUseCase {
 
         // 1. 이벤트 이미지 S3 업로드
         String imageObjectKey = s3UploadHelper.uploadEventImage(file, req.appEventId(), EventImageSurface.BANNER);
+        log.info(">>> [Banner] 이미지 업로드 objectKey={}", imageObjectKey);
 
         // 2. 배너 생성. 검증 실패 시 올린 이미지 롤백
         Banner banner;
@@ -39,11 +42,13 @@ public class BannerUseCase {
             banner = eventBannerService.create(req.toCommand(imageObjectKey), authUser.getUserId());
         } catch (Exception e) {
             s3UploadHelper.delete(imageObjectKey);
+            log.warn(">>> [Banner] 생성 실패로 이미지 롤백 objectKey={}", imageObjectKey);
             throw e;
         }
 
         // 3. 이벤트 배너 캐시 무효화
         eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
+        log.info(">>> [Banner] 생성 완료 bannerId={}", banner.getId());
         return CustomResponse.onSuccess(SuccessCode.EVENT_BANNER_CREATE_SUCCESS, BannerResponse.from(banner).withBaseUrl(baseUrl));
     }
 
@@ -72,19 +77,24 @@ public class BannerUseCase {
         String imageObjectKey = replaceImage
                 ? s3UploadHelper.uploadEventImage(file, req.appEventId(), EventImageSurface.BANNER)
                 : oldImageObjectKey;
+        if (replaceImage) log.info(">>> [Banner] 이미지 교체 업로드 objectKey={}", imageObjectKey);
 
         // 2. 배너 수정. 실패 시 새로 올린 이미지 롤백
         Banner banner;
         try {
             banner = eventBannerService.update(bannerId, req.toCommand(imageObjectKey));
         } catch (Exception e) {
-            if (replaceImage) s3UploadHelper.delete(imageObjectKey);
+            if (replaceImage) {
+                s3UploadHelper.delete(imageObjectKey);
+                log.warn(">>> [Banner] 수정 실패로 이미지 롤백 objectKey={}", imageObjectKey);
+            }
             throw e;
         }
 
         // 3. 교체 성공 시 옛 이미지 정리 + 캐시 무효화
         if (replaceImage) s3UploadHelper.delete(oldImageObjectKey);
         eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
+        log.info(">>> [Banner] 수정 완료 bannerId={} imageReplaced={}", bannerId, replaceImage);
         return CustomResponse.onSuccess(SuccessCode.EVENT_BANNER_UPDATE_SUCCESS, BannerResponse.from(banner).withBaseUrl(baseUrl));
     }
 
@@ -96,6 +106,7 @@ public class BannerUseCase {
 
         // 2. 이벤트 배너 캐시 무효화
         eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_BANNER);
+        log.info(">>> [Banner] 강제 종료 bannerId={}", bannerId);
         return CustomResponse.onSuccess(SuccessCode.EVENT_BANNER_CANCEL_SUCCESS, BannerResponse.from(banner).withBaseUrl(baseUrl));
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/PopupUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/PopupUseCase.java
@@ -13,10 +13,12 @@ import com.storix.domain.domains.event.service.PopupService;
 import com.storix.domain.domains.image.domain.EventImageSurface;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PopupUseCase {
@@ -32,6 +34,7 @@ public class PopupUseCase {
 
         // 1. 이벤트 이미지 S3 업로드
         String imageObjectKey = s3UploadHelper.uploadEventImage(file, req.appEventId(), EventImageSurface.POPUP);
+        log.info(">>> [Popup] 이미지 업로드 objectKey={}", imageObjectKey);
 
         // 2. 팝업 생성. 검증 실패 시 올린 이미지 롤백
         Popup popup;
@@ -39,11 +42,13 @@ public class PopupUseCase {
             popup = eventPopupService.create(req.toCommand(imageObjectKey), authUser.getUserId());
         } catch (Exception e) {
             s3UploadHelper.delete(imageObjectKey);
+            log.warn(">>> [Popup] 생성 실패로 이미지 롤백 objectKey={}", imageObjectKey);
             throw e;
         }
 
         // 3. 이벤트 팝업 캐시 무효화
         eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
+        log.info(">>> [Popup] 생성 완료 popupId={}", popup.getId());
         return CustomResponse.onSuccess(SuccessCode.EVENT_POPUP_CREATE_SUCCESS, PopupResponse.from(popup).withBaseUrl(baseUrl));
     }
 
@@ -72,19 +77,24 @@ public class PopupUseCase {
         String imageObjectKey = replaceImage
                 ? s3UploadHelper.uploadEventImage(file, req.appEventId(), EventImageSurface.POPUP)
                 : oldImageObjectKey;
+        if (replaceImage) log.info(">>> [Popup] 이미지 교체 업로드 objectKey={}", imageObjectKey);
 
         // 2. 팝업 수정. 실패 시 새로 올린 이미지 롤백
         Popup popup;
         try {
             popup = eventPopupService.update(popupId, req.toCommand(imageObjectKey));
         } catch (Exception e) {
-            if (replaceImage) s3UploadHelper.delete(imageObjectKey);
+            if (replaceImage) {
+                s3UploadHelper.delete(imageObjectKey);
+                log.warn(">>> [Popup] 수정 실패로 이미지 롤백 objectKey={}", imageObjectKey);
+            }
             throw e;
         }
 
         // 3. 교체 성공 시 옛 이미지 정리 + 캐시 무효화
         if (replaceImage) s3UploadHelper.delete(oldImageObjectKey);
         eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
+        log.info(">>> [Popup] 수정 완료 popupId={} imageReplaced={}", popupId, replaceImage);
         return CustomResponse.onSuccess(SuccessCode.EVENT_POPUP_UPDATE_SUCCESS, PopupResponse.from(popup).withBaseUrl(baseUrl));
     }
 
@@ -96,6 +106,7 @@ public class PopupUseCase {
 
         // 2. 이벤트 팝업 캐시 무효화
         eventContentCacheHelper.evict(RedisKeyStatic.Event.ACTIVE_POPUP);
+        log.info(">>> [Popup] 강제 종료 popupId={}", popupId);
         return CustomResponse.onSuccess(SuccessCode.EVENT_POPUP_CANCEL_SUCCESS, PopupResponse.from(popup).withBaseUrl(baseUrl));
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/AdminNotificationUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/AdminNotificationUseCase.java
@@ -13,8 +13,10 @@ import com.storix.domain.domains.notification.service.AdminNotificationBroadcast
 import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AdminNotificationUseCase {
@@ -34,6 +36,8 @@ public class AdminNotificationUseCase {
 
         // 1. 운영자 알림 생성 (생성 관리자 id 저장)
         Long adminNotificationId = adminNotificationService.create(req.toCommand(), authUser.getUserId());
+        log.info(">>> [AdminNotification] 생성 완료 adminNotificationId={} sendType={}",
+                adminNotificationId, req.sendType());
 
         // 2. 즉시 발송인 경우, 브로드캐스트 발송
         if (req.sendType() == AdminNotificationSendType.IMMEDIATE) {
@@ -70,6 +74,8 @@ public class AdminNotificationUseCase {
         // 1. 운영자 알림 수정
         AdminNotificationResponse result =
                 AdminNotificationResponse.from(adminNotificationService.update(adminNotificationId, req.toCommand()));
+        log.info(">>> [AdminNotification] 수정 완료 adminNotificationId={} sendType={}",
+                adminNotificationId, req.sendType());
 
         // 2. 즉시 발송으로 변경된 경우, 브로드캐스트 발송
         if (req.sendType() == AdminNotificationSendType.IMMEDIATE) {
@@ -84,6 +90,7 @@ public class AdminNotificationUseCase {
 
         AdminNotificationResponse result =
                 AdminNotificationResponse.from(adminNotificationService.cancel(adminNotificationId));
+        log.info(">>> [AdminNotification] 예약 취소 adminNotificationId={}", adminNotificationId);
         return CustomResponse.onSuccess(SuccessCode.ADMIN_NOTIFICATION_CANCEL_SUCCESS, result);
     }
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/usecase/PushDeviceUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/pushdevice/usecase/PushDeviceUseCase.java
@@ -18,24 +18,22 @@ public class PushDeviceUseCase {
     public void sync(Long userId, DeviceSyncRequest request) {
         boolean isNew = pushDeviceService.sync(userId, request.toCommand());
 
-        if (isNew) {
-            log.info(">>>> [PushDevice] register installationId={}", request.installationId());
-        } else {
-            log.info(">>>> [PushDevice] refresh installationId={}", request.installationId());
-        }
+        log.info(">>> [PushDevice] 동기화 installationId={} isNew={}", request.installationId(), isNew);
     }
 
     // 2. 단일 디바이스 푸시 알림 해제
     public void unregister(Long userId, String installationId) {
         int affected = pushDeviceService.unregister(userId, installationId);
         if (affected == 0) {
-            log.warn(">>>> [PushDevice] unregister target not found (already inactive or never registered) installationId={}",
-                    installationId);
+            log.warn(">>> [PushDevice] 해제 대상 없음 installationId={}", installationId);
+            return;
         }
+        log.info(">>> [PushDevice] 해제 installationId={}", installationId);
     }
 
     // 3. FCM 토큰 갱신
     public void refreshFcmToken(Long userId, RefreshFcmTokenRequest request) {
         pushDeviceService.refreshFcmToken(userId, request.installationId(), request.fcmToken());
+        log.info(">>> [PushDevice] FCM 토큰 갱신 installationId={}", request.installationId());
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthorizationUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthorizationUseCase.java
@@ -9,8 +9,10 @@ import com.storix.common.payload.CustomResponse;
 import com.storix.common.code.SuccessCode;
 import com.storix.domain.domains.user.exception.token.RefreshTokenNotExistException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 
+@Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class AuthorizationUseCase {
@@ -30,6 +32,7 @@ public class AuthorizationUseCase {
 
         Long userId = tokenGenerateHelper.validateRefreshToken(refreshToken);
         LoginWithTokenResponse tokenResponse = tokenGenerateHelper.reissueTokens(userId);
+        log.info(">>> [Auth] 토큰 재발급 userId={} native={}", userId, useBodyToken);
 
         // Native: body로 access/refresh 둘 다 반환
         if (useBodyToken) {

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LoginUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LoginUseCase.java
@@ -16,8 +16,10 @@ import com.storix.domain.domains.user.domain.OAuthProvider;
 import com.storix.common.payload.CustomResponse;
 import com.storix.common.code.SuccessCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 
+@Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class LoginUseCase {
@@ -39,6 +41,7 @@ public class LoginUseCase {
 
         AuthUserDetails userDetails = readerLoginService.execute(oauthInfo, oauthRefreshToken);
         LoginWithTokenResponse loginToken = tokenGenerateHelper.generateLoginWithToken(userDetails);
+        log.info(">>> [Auth] 로그인 userId={} provider={} native={}", userDetails.getUserId(), provider, isNative);
 
         // Native: body로 access/refresh 둘 다 반환
         if (isNative) {

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/WithDrawUseCase.java
@@ -36,13 +36,15 @@ public class WithDrawUseCase {
                 case APPLE -> oauthHelper.unlinkAppleUser(oauthInfo.getOauthRefreshToken());
                 case SLACK -> {} // admin 만 해당 (연결 해제 불필요)
             }
+            log.info(">>> [Withdraw] OAuth 연결 해제 provider={}", oauthInfo.getProvider());
         } catch (Exception e) {
-            log.warn("OAuth unlink failed; continuing withdraw. provider={}", oauthInfo.getProvider(), e);
+            log.warn(">>> [Withdraw] OAuth 연결 해제 실패 provider={}", oauthInfo.getProvider(), e);
             // TODO: best-effort + 재시도 워커 처리 고려중
         }
 
         // 2. 유저 탈퇴 처리 (RefreshToken / 관심작품 / 서재 삭제 + 푸시 알림 발송 대상 제외 + 탈퇴 사유 로그)
         authService.withDrawUser(userId, reasons, detail);
+        log.info(">>> [Withdraw] 탈퇴 완료 reasons={}", reasons);
 
         return ResponseEntity.ok()
                 .headers(cookieHelper.deleteCookie())

--- a/STORIX-Api/src/main/java/com/storix/api/global/GlobalExceptionHandler.java
+++ b/STORIX-Api/src/main/java/com/storix/api/global/GlobalExceptionHandler.java
@@ -40,6 +40,8 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ex.getErrorCode();
         ErrorResponse response = new ErrorResponse(errorCode);
 
+        warnFailure(errorCode);
+
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(response);
@@ -50,6 +52,8 @@ public class GlobalExceptionHandler {
 
         ErrorCode errorCode = ex.getErrorCode();
         ErrorResponse body = new ErrorResponse(errorCode);
+
+        warnFailure(errorCode);
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
@@ -73,6 +77,8 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
         ErrorResponse response = new ErrorResponse(errorCode, fieldErrors);
 
+        warnFailure(errorCode, fieldErrors);
+
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(response);
@@ -92,6 +98,8 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
         ErrorResponse response = new ErrorResponse(errorCode, fieldErrors);
 
+        warnFailure(errorCode, fieldErrors);
+
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(response);
@@ -108,6 +116,8 @@ public class GlobalExceptionHandler {
 
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
         ErrorResponse response = new ErrorResponse(errorCode, List.of(fer));
+
+        warnFailure(errorCode, List.of(fer));
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
@@ -155,6 +165,8 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.DATA_INTEGRITY_VIOLATION_REQUEST;
         ErrorResponse response = new ErrorResponse(errorCode, java.util.List.of(fer));
 
+        warnFailure(errorCode, List.of(fer));
+
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(response);
@@ -167,8 +179,6 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleNotReadable(HttpMessageNotReadableException e) {
-
-        log.warn("Body parse exception", e);
 
         if (e.getCause() instanceof InvalidFormatException ife) {
             String field = ife.getPath().stream()
@@ -196,12 +206,16 @@ public class GlobalExceptionHandler {
                     .build();
 
             ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+            warnFailure(errorCode, List.of(fer));
+
             return ResponseEntity
                     .status(errorCode.getHttpStatus())
                     .body(new ErrorResponse(errorCode, List.of(fer)));
         }
 
         ErrorCode errorCode = ErrorCode.INVALID_JSON_REQUEST;
+        warnFailure(errorCode);
+
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(new ErrorResponse(errorCode));
@@ -211,10 +225,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageConversionException.class)
     public ResponseEntity<ErrorResponse> handleConversion(HttpMessageConversionException e) {
 
-        log.warn("Format exception", e);
-
         ErrorCode errorCode = ErrorCode.INVALID_JSON_REQUEST;
         ErrorResponse response = new ErrorResponse(errorCode);
+
+        // 응답 직렬화 실패면 서버 결함이라 스택이 필요하다
+        log.warn(">>> [Http] 처리 실패 code={} status={} message={}",
+                errorCode.getCode(), errorCode.getHttpStatus().value(), errorCode.getMessage(), e);
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
@@ -225,10 +241,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<ErrorResponse> handleMaxUploadSize(MaxUploadSizeExceededException e) {
 
-        log.warn("Upload size exceeded", e);
-
         ErrorCode errorCode = ErrorCode.IMAGE_FILE_TOO_LARGE;
         ErrorResponse response = new ErrorResponse(errorCode);
+
+        warnFailure(errorCode);
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
@@ -238,14 +254,29 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleAll(Exception e) {
 
-        log.error("Unhandled exception", e);
-
         ErrorCode errorCode = ErrorCode.UNHANDLED_ERROR;
         ErrorResponse response = new ErrorResponse(errorCode);
+
+        log.error(">>> [Http] 처리 실패 code={} status={} message={}",
+                errorCode.getCode(), errorCode.getHttpStatus().value(), errorCode.getMessage(), e);
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(response);
+    }
+
+    private void warnFailure(ErrorCode errorCode) {
+        log.warn(">>> [Http] 처리 실패 code={} status={} message={}",
+                errorCode.getCode(), errorCode.getHttpStatus().value(), errorCode.getMessage());
+    }
+
+    // 입력값은 개인정보일 수 있어 필드명만 남긴다
+    private void warnFailure(ErrorCode errorCode, List<FieldErrorResponse> fieldErrors) {
+        log.warn(">>> [Http] 처리 실패 code={} status={} message={} fields={}",
+                errorCode.getCode(),
+                errorCode.getHttpStatus().value(),
+                errorCode.getMessage(),
+                fieldErrors.stream().map(FieldErrorResponse::field).toList());
     }
 
 }

--- a/STORIX-Api/src/main/java/com/storix/api/global/GlobalExceptionHandler.java
+++ b/STORIX-Api/src/main/java/com/storix/api/global/GlobalExceptionHandler.java
@@ -225,11 +225,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageConversionException.class)
     public ResponseEntity<ErrorResponse> handleConversion(HttpMessageConversionException e) {
 
-        ErrorCode errorCode = ErrorCode.INVALID_JSON_REQUEST;
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         ErrorResponse response = new ErrorResponse(errorCode);
 
-        // 응답 직렬화 실패면 서버 결함이라 스택이 필요하다
-        log.warn(">>> [Http] 처리 실패 code={} status={} message={}",
+        // 응답 직렬화 실패라 서버 결함이다
+        log.error(">>> [Http] 처리 실패 code={} status={} message={}",
                 errorCode.getCode(), errorCode.getHttpStatus().value(), errorCode.getMessage(), e);
 
         return ResponseEntity

--- a/STORIX-Api/src/main/resources/logback-spring.xml
+++ b/STORIX-Api/src/main/resources/logback-spring.xml
@@ -15,7 +15,7 @@
         <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <timeZone>Asia/Seoul</timeZone>
-                <customFields>{"app":"storix-api","instance":"${HOSTNAME}"}</customFields>
+                <customFields>{"app":"storix-api"}</customFields>
             </encoder>
         </appender>
         <root level="INFO">

--- a/STORIX-Api/src/main/resources/logback-spring.xml
+++ b/STORIX-Api/src/main/resources/logback-spring.xml
@@ -15,7 +15,7 @@
         <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <timeZone>Asia/Seoul</timeZone>
-                <customFields>{"app":"storix-api"}</customFields>
+                <customFields>{"app":"storix-api","instance":"${HOSTNAME}"}</customFields>
             </encoder>
         </appender>
         <root level="INFO">

--- a/STORIX-Batch/src/main/resources/logback-spring.xml
+++ b/STORIX-Batch/src/main/resources/logback-spring.xml
@@ -15,7 +15,7 @@
         <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <timeZone>Asia/Seoul</timeZone>
-                <customFields>{"app":"storix-batch"}</customFields>
+                <customFields>{"app":"storix-batch","instance":"${HOSTNAME}"}</customFields>
             </encoder>
         </appender>
         <root level="INFO">

--- a/STORIX-Batch/src/main/resources/logback-spring.xml
+++ b/STORIX-Batch/src/main/resources/logback-spring.xml
@@ -15,7 +15,7 @@
         <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <timeZone>Asia/Seoul</timeZone>
-                <customFields>{"app":"storix-batch","instance":"${HOSTNAME}"}</customFields>
+                <customFields>{"app":"storix-batch"}</customFields>
             </encoder>
         </appender>
         <root level="INFO">

--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -72,6 +72,7 @@ public class STORIXStatic {
         public static final String ENDPOINT = "endpoint";
         public static final String HTTP_METHOD = "httpMethod";
         public static final String ROLE = "role";
+        public static final String ALB_TRACE_ID = "albTraceId";
         public static final String RECIPIENT_USER_ID = "recipientUserId";
         public static final String ADMIN_NOTIFICATION_ID = "adminNotificationId";
     }

--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -71,6 +71,8 @@ public class STORIXStatic {
         public static final String USER_ID = "userId";
         public static final String ENDPOINT = "endpoint";
         public static final String HTTP_METHOD = "httpMethod";
+        public static final String ROLE = "role";
+        public static final String RECIPIENT_USER_ID = "recipientUserId";
         public static final String ADMIN_NOTIFICATION_ID = "adminNotificationId";
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/TokenAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/adaptor/TokenAdaptor.java
@@ -8,6 +8,7 @@ import com.storix.domain.domains.user.exception.auth.InvalidLogoutException;
 import com.storix.domain.domains.user.exception.token.InvalidRefreshTokenException;
 import com.storix.domain.domains.user.exception.token.InvalidTokenException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -17,6 +18,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenAdaptor {
@@ -50,17 +52,20 @@ public class TokenAdaptor {
 
     // RefreshToken
     public void saveRefreshToken(Long userId, String refreshToken, long ttlSeconds) {
-        redisTemplate.execute(SAVE_SCRIPT,
+        Long deviceCount = redisTemplate.execute(SAVE_SCRIPT,
                 Collections.singletonList(refreshTokenKey(userId)),
                 refreshToken,
                 String.valueOf(now()),
                 String.valueOf(ttlSeconds),
                 String.valueOf(MAX_DEVICE_COUNT));
+        log.info(">>> [Auth] Refresh Token 저장 userId={} deviceCount={}", userId, deviceCount);
     }
 
     public void consumeRefreshToken(Long userId, String refreshToken) {
         Long consumed = redisTemplate.opsForHash().delete(refreshTokenKey(userId), refreshToken);
         if (consumed == null || consumed == 0L) {
+            Long remaining = redisTemplate.opsForHash().size(refreshTokenKey(userId));
+            log.warn(">>> [Auth] Refresh Token 불일치 userId={} remainingDeviceCount={}", userId, remaining);
             throw InvalidRefreshTokenException.EXCEPTION;
         }
     }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/AsyncConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/AsyncConfig.java
@@ -65,6 +65,7 @@ public class AsyncConfig {
         executor.setQueueCapacity(100);
 
         executor.setThreadNamePrefix("Log-Thread-");
+        executor.setTaskDecorator(mdcTaskDecorator());
 
         executor.initialize();
         return executor;
@@ -77,6 +78,7 @@ public class AsyncConfig {
         executor.setMaxPoolSize(10);
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("ChatAsync-");
+        executor.setTaskDecorator(mdcTaskDecorator());
         executor.initialize();
         return executor;
     }
@@ -88,6 +90,7 @@ public class AsyncConfig {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(10);
         executor.setThreadNamePrefix("SlackAsync-");
+        executor.setTaskDecorator(mdcTaskDecorator());
         executor.initialize();
         return executor;
     }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/WebSocketConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.storix.infrastructure.config;
 
 import com.storix.infrastructure.external.chat.StompHandler;
+import com.storix.infrastructure.external.chat.StompMdcInterceptor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -24,6 +25,7 @@ import java.util.Map;
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompHandler stompHandler;
+    private final StompMdcInterceptor stompMdcInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -93,6 +95,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(stompHandler);
+        registration.interceptors(stompMdcInterceptor, stompHandler);
     }
 }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/ChatMessageEnvelope.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/ChatMessageEnvelope.java
@@ -1,0 +1,12 @@
+package com.storix.infrastructure.external.chat;
+
+import com.storix.domain.domains.chat.dto.ChatMessageResponseDto;
+
+public record ChatMessageEnvelope(
+        String traceId,
+        ChatMessageResponseDto message
+) {
+    public static ChatMessageEnvelope of(String traceId, ChatMessageResponseDto message) {
+        return new ChatMessageEnvelope(traceId, message);
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/RedisChatAdapter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/RedisChatAdapter.java
@@ -5,7 +5,9 @@ import com.storix.domain.domains.chat.application.port.PublishChatPort;
 import com.storix.domain.domains.chat.dto.ChatMessageResponseDto;
 import com.storix.domain.domains.topicroom.exception.ChatConnectionFailureException;
 import com.storix.domain.domains.topicroom.exception.MessageDeliveryException;
+import com.storix.common.utils.STORIXStatic;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -26,18 +28,18 @@ public class RedisChatAdapter implements PublishChatPort {
 
         try {
             // "room:1" 형식으로 메시지 전송
-            jsonRedisTemplate.convertAndSend(RedisKeyStatic.Channel.CHAT_ROOM_PREFIX + response.roomId(), response);
+            ChatMessageEnvelope envelope = ChatMessageEnvelope.of(MDC.get(STORIXStatic.Mdc.TRACE_ID), response);
+            jsonRedisTemplate.convertAndSend(RedisKeyStatic.Channel.CHAT_ROOM_PREFIX + response.roomId(), envelope);
         } catch (RedisConnectionFailureException e) {
 
             // Redis 연결 실패
-            log.error(">>>> [Redis Error] Redis 연결 실패로 메시지 전송 불가 - RoomId: {}, Msg: {}",
-                    response.roomId(), e);
+            log.error(">>> [Chat] Redis 연결 실패로 메시지 발행 불가 roomId={}", response.roomId(), e);
 
             throw ChatConnectionFailureException.EXCEPTION;
         } catch (Exception e) {
 
             // 기타 오류
-            log.error(">>>> [Redis Error] 메시지 발행 중 기타 오류 발생", e);
+            log.error(">>> [Chat] 메시지 발행 실패 roomId={}", response.roomId(), e);
             throw MessageDeliveryException.EXCEPTION;
         }
     }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/RedisSubscriber.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/RedisSubscriber.java
@@ -1,9 +1,12 @@
 package com.storix.infrastructure.external.chat;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.storix.common.utils.STORIXStatic;
 import com.storix.domain.domains.chat.dto.ChatMessageResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -21,17 +24,26 @@ public class RedisSubscriber implements MessageListener {
     @Override
     public void onMessage(Message message, byte[] pattern) {
 
-        log.info(">>>> [Redis Subscriber] Redis로부터 메시지 감지");
-
         try {
-            ChatMessageResponseDto response = objectMapper.readValue(message.getBody(), ChatMessageResponseDto.class);
+            JsonNode root = objectMapper.readTree(message.getBody());
 
-            log.info(">>>> [Redis Subscriber] 전달 시작 - 방: {}, 메시지: {}", response.roomId(), response.message());
+            // 배포 과도기에는 봉투 없이 발행된 메시지도 들어온다
+            boolean enveloped = root.has("message");
+            JsonNode payload = enveloped ? root.get("message") : root;
 
+            if (enveloped && root.hasNonNull("traceId")) {
+                MDC.put(STORIXStatic.Mdc.TRACE_ID, root.get("traceId").asText());
+            }
+
+            ChatMessageResponseDto response = objectMapper.treeToValue(payload, ChatMessageResponseDto.class);
             messagingTemplate.convertAndSend("/sub/chat/room/" + response.roomId(), response);
 
+            log.info(">>> [Chat] 구독자 전달 roomId={}", response.roomId());
+
         } catch (Exception e) {
-            log.error(">>>> [Redis Subscriber Error] 메시지 파싱 중 오류: ", e);
+            log.error(">>> [Chat] 구독 메시지 처리 실패", e);
+        } finally {
+            MDC.remove(STORIXStatic.Mdc.TRACE_ID);
         }
     }
 }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/StompHandler.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/StompHandler.java
@@ -54,12 +54,12 @@ public class StompHandler implements ChannelInterceptor {
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
         if (accessor == null) {
-            log.warn(">>>> [STOMP_DIAG] inbound message without StompHeaderAccessor headers={}", message.getHeaders().keySet());
+            log.warn(">>> [Stomp] 헤더 없는 인바운드 메시지 headers={}", message.getHeaders().keySet());
             return message;
         }
 
         StompCommand command = accessor.getCommand();
-        log.info(">>>> [STOMP_DIAG] inbound command={}, sessionId={}, destination={}, subscriptionId={}, nativeHeaderKeys={}, user={}",
+        log.debug(">>> [Stomp] 인바운드 command={}, sessionId={}, destination={}, subscriptionId={}, nativeHeaderKeys={}, user={}",
                 command,
                 accessor.getSessionId(),
                 accessor.getDestination(),

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/StompMdcInterceptor.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/StompMdcInterceptor.java
@@ -1,0 +1,53 @@
+package com.storix.infrastructure.external.chat;
+
+import com.storix.common.utils.STORIXStatic;
+import com.storix.domain.domains.user.adaptor.AuthUserDetails;
+import org.slf4j.MDC;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ExecutorChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.UUID;
+
+@Component
+public class StompMdcInterceptor implements ExecutorChannelInterceptor {
+
+    @Override
+    public Message<?> beforeHandle(Message<?> message, MessageChannel channel, MessageHandler handler) {
+        if (!(handler instanceof SimpAnnotationMethodMessageHandler)) return message;
+
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null) return message;
+
+        MDC.put(STORIXStatic.Mdc.TRACE_ID, UUID.randomUUID().toString().replace("-", ""));
+
+        String destination = accessor.getDestination();
+        if (destination != null) MDC.put(STORIXStatic.Mdc.ENDPOINT, destination);
+
+        Principal user = accessor.getUser();
+        if (user instanceof Authentication auth && auth.getPrincipal() instanceof AuthUserDetails details) {
+            MDC.put(STORIXStatic.Mdc.USER_ID, String.valueOf(details.getUserId()));
+            MDC.put(STORIXStatic.Mdc.ROLE, details.getRole().getStringValue());
+        }
+        return message;
+    }
+
+    @Override
+    public void afterMessageHandled(
+            Message<?> message, MessageChannel channel, MessageHandler handler, Exception ex
+    ) {
+        if (!(handler instanceof SimpAnnotationMethodMessageHandler)) return;
+
+        MDC.remove(STORIXStatic.Mdc.TRACE_ID);
+        MDC.remove(STORIXStatic.Mdc.ENDPOINT);
+        MDC.remove(STORIXStatic.Mdc.USER_ID);
+        MDC.remove(STORIXStatic.Mdc.ROLE);
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dispatcher/AdminNotificationDispatcher.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dispatcher/AdminNotificationDispatcher.java
@@ -79,7 +79,7 @@ public class AdminNotificationDispatcher {
         // 3. 유저별 FCM 발송 -> 결과 분류
         Map<Long, AdminNotificationDeliveryOutcome> outcomes = new LinkedHashMap<>();
         for (Long userId : targets) {
-            MDC.put(STORIXStatic.Mdc.USER_ID, String.valueOf(userId)); // 유저 단위 로그 상관키 (FcmSender 로그까지 전파)
+            MDC.put(STORIXStatic.Mdc.RECIPIENT_USER_ID, String.valueOf(userId)); // FcmSender 로그까지 전파
             try {
                 List<String> tokens = tokensByUserId.getOrDefault(userId, List.of());
                 if (tokens.isEmpty()) {
@@ -102,15 +102,13 @@ public class AdminNotificationDispatcher {
                     }
                 } catch (FcmTransientException e) {
                     outcomes.put(userId, AdminNotificationDeliveryOutcome.TRANSIENT_FAILURE);
-                    log.warn(">>> [AdminNotification] 푸시 일시 실패 recipientUserId={}, code={}",
-                            userId, e.getMessagingErrorCode());
+                    log.warn(">>> [AdminNotification] 푸시 일시 실패 code={}", e.getMessagingErrorCode());
                 } catch (Exception e) {
                     outcomes.put(userId, AdminNotificationDeliveryOutcome.PERMANENT_FAILURE);
-                    log.warn(">>> [AdminNotification] 푸시 영구 실패 recipientUserId={}, cause={}",
-                            userId, e.getMessage());
+                    log.warn(">>> [AdminNotification] 푸시 영구 실패 cause={}", e.getMessage());
                 }
             } finally {
-                MDC.remove(STORIXStatic.Mdc.USER_ID);
+                MDC.remove(STORIXStatic.Mdc.RECIPIENT_USER_ID);
             }
         }
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/ErrorHandlingFilter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/ErrorHandlingFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -16,6 +17,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ErrorHandlingFilter extends OncePerRequestFilter {
@@ -38,6 +40,9 @@ public class ErrorHandlingFilter extends OncePerRequestFilter {
 
     private void responseToClient(HttpServletResponse response, ErrorCode errorCode, ErrorResponse body)
             throws IOException {
+        log.warn(">>> [Http] 인증 실패 code={} status={} message={}",
+                errorCode.getCode(), errorCode.getHttpStatus().value(), errorCode.getMessage());
+
         response.setStatus(errorCode.getHttpStatus().value());
         response.setContentType("application/json;charset=UTF-8");
         objectMapper.writeValue(response.getWriter(), body);

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/JwtAuthenticationFilter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/JwtAuthenticationFilter.java
@@ -55,6 +55,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             AuthUserDetails userDetails = (AuthUserDetails) authentication.getPrincipal();
             MDC.put(STORIXStatic.Mdc.USER_ID, String.valueOf(userDetails.getUserId()));
+            MDC.put(STORIXStatic.Mdc.ROLE, userDetails.getRole().getStringValue());
         }
 
         filterChain.doFilter(request, response);

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/MdcContextFilter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/MdcContextFilter.java
@@ -23,6 +23,9 @@ public class MdcContextFilter extends OncePerRequestFilter {
     private static final String TRACE_ID_HEADER = "X-Trace-Id";
     private static final Pattern TRACE_ID_PATTERN = Pattern.compile("[A-Za-z0-9_-]{1,64}");
 
+    private static final String ALB_TRACE_ID_HEADER = "X-Amzn-Trace-Id";
+    private static final Pattern ALB_TRACE_ID_PATTERN = Pattern.compile("[A-Za-z0-9=;:_-]{1,128}");
+
     // 주기적으로 호출돼 추적 가치가 없는 경로
     private static final List<String> UNLOGGED_URI_PREFIXES = List.of(
             "/actuator",
@@ -43,6 +46,11 @@ public class MdcContextFilter extends OncePerRequestFilter {
         MDC.put(STORIXStatic.Mdc.TRACE_ID, traceId);
         MDC.put(STORIXStatic.Mdc.ENDPOINT, uri);
         MDC.put(STORIXStatic.Mdc.HTTP_METHOD, request.getMethod());
+
+        String albTraceId = request.getHeader(ALB_TRACE_ID_HEADER);
+        if (albTraceId != null && ALB_TRACE_ID_PATTERN.matcher(albTraceId).matches()) {
+            MDC.put(STORIXStatic.Mdc.ALB_TRACE_ID, albTraceId);
+        }
 
         boolean logged = isLogged(uri);
         long startedAt = System.nanoTime();
@@ -66,6 +74,7 @@ public class MdcContextFilter extends OncePerRequestFilter {
             MDC.remove(STORIXStatic.Mdc.TRACE_ID);
             MDC.remove(STORIXStatic.Mdc.ENDPOINT);
             MDC.remove(STORIXStatic.Mdc.HTTP_METHOD);
+            MDC.remove(STORIXStatic.Mdc.ALB_TRACE_ID);
             MDC.remove(STORIXStatic.Mdc.USER_ID);
             MDC.remove(STORIXStatic.Mdc.ROLE);
         }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/MdcContextFilter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/MdcContextFilter.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 @Slf4j
@@ -20,8 +22,14 @@ public class MdcContextFilter extends OncePerRequestFilter {
 
     private static final String TRACE_ID_HEADER = "X-Trace-Id";
     private static final Pattern TRACE_ID_PATTERN = Pattern.compile("[A-Za-z0-9_-]{1,64}");
-    private static final String ADMIN_URI_PREFIX = "/api/v1/admin";
-    private static final String ADMIN_AUTH_URI_PREFIX = "/api/v1/auth/admin";
+
+    // 주기적으로 호출돼 추적 가치가 없는 경로
+    private static final List<String> UNLOGGED_URI_PREFIXES = List.of(
+            "/actuator",
+            "/swagger-ui",
+            "/v3/api-docs",
+            "/favicon.ico"
+    );
 
     @Override
     protected void doFilterInternal(
@@ -30,29 +38,41 @@ public class MdcContextFilter extends OncePerRequestFilter {
         String traceId = resolveTraceId(request.getHeader(TRACE_ID_HEADER));
         response.setHeader(TRACE_ID_HEADER, traceId);
 
+        String uri = request.getRequestURI();
+
         MDC.put(STORIXStatic.Mdc.TRACE_ID, traceId);
-        MDC.put(STORIXStatic.Mdc.ENDPOINT, request.getRequestURI());
+        MDC.put(STORIXStatic.Mdc.ENDPOINT, uri);
         MDC.put(STORIXStatic.Mdc.HTTP_METHOD, request.getMethod());
 
-        boolean admin = isAdminRequest(request.getRequestURI());
-        if (admin) {
-            log.info(">>> [Admin] 요청 진입 query={}", request.getQueryString());
+        boolean logged = isLogged(uri);
+        long startedAt = System.nanoTime();
+
+        if (logged) {
+            String query = request.getQueryString();
+            if (query == null) {
+                log.info(">>> [Http] 요청 진입");
+            } else {
+                log.info(">>> [Http] 요청 진입 query={}", query);
+            }
         }
         try {
             filterChain.doFilter(request, response);
         } finally {
-            if (admin) {
-                log.info(">>> [Admin] 요청 완료 status={}", response.getStatus());
+            if (logged) {
+                log.info(">>> [Http] 요청 완료 status={} tookMs={}",
+                        response.getStatus(),
+                        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt));
             }
             MDC.remove(STORIXStatic.Mdc.TRACE_ID);
             MDC.remove(STORIXStatic.Mdc.ENDPOINT);
             MDC.remove(STORIXStatic.Mdc.HTTP_METHOD);
             MDC.remove(STORIXStatic.Mdc.USER_ID);
+            MDC.remove(STORIXStatic.Mdc.ROLE);
         }
     }
 
-    private boolean isAdminRequest(String uri) {
-        return uri.startsWith(ADMIN_URI_PREFIX) || uri.startsWith(ADMIN_AUTH_URI_PREFIX);
+    private boolean isLogged(String uri) {
+        return UNLOGGED_URI_PREFIXES.stream().noneMatch(uri::startsWith);
     }
 
     private String resolveTraceId(String fromHeader) {

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/SecurityDeniedHandler.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/SecurityDeniedHandler.java
@@ -6,12 +6,14 @@ import com.storix.common.payload.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SecurityDeniedHandler implements AccessDeniedHandler {
@@ -21,6 +23,10 @@ public class SecurityDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
         ErrorCode code = ErrorCode.FORBIDDEN;
+
+        log.warn(">>> [Http] 접근 거부 code={} status={} message={}",
+                code.getCode(), code.getHttpStatus().value(), code.getMessage());
+
         response.setStatus(code.getHttpStatus().value());
         response.setContentType("application/json;charset=UTF-8");
         objectMapper.writeValue(response.getWriter(), new ErrorResponse(code));

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/SecurityEntryPoint.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/global/security/SecurityEntryPoint.java
@@ -6,12 +6,14 @@ import com.storix.common.payload.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SecurityEntryPoint implements AuthenticationEntryPoint {
@@ -21,6 +23,10 @@ public class SecurityEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
         ErrorCode code = ErrorCode.TOKEN_NOT_EXIST;
+
+        log.warn(">>> [Http] 인증 실패 code={} status={} message={}",
+                code.getCode(), code.getHttpStatus().value(), code.getMessage());
+
         response.setStatus(code.getHttpStatus().value());
         response.setContentType("application/json;charset=UTF-8");
         objectMapper.writeValue(response.getWriter(), new ErrorResponse(code));

--- a/STORIX-Infrastructure/src/test/java/com/storix/infrastructure/global/security/MdcContextFilterTest.java
+++ b/STORIX-Infrastructure/src/test/java/com/storix/infrastructure/global/security/MdcContextFilterTest.java
@@ -1,14 +1,21 @@
 package com.storix.infrastructure.global.security;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.storix.common.utils.STORIXStatic;
 import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,6 +26,25 @@ class MdcContextFilterTest {
     private final MdcContextFilter filter = new MdcContextFilter();
 
     private static final String HEADER = "X-Trace-Id";
+
+    private final Logger filterLogger = (Logger) LoggerFactory.getLogger(MdcContextFilter.class);
+    private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+
+    @BeforeEach
+    void attachAppender() {
+        appender.start();
+        filterLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        filterLogger.detachAppender(appender);
+        appender.stop();
+    }
+
+    private List<String> loggedMessages() {
+        return appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+    }
 
     // 필터가 finally 에서 지우므로 체인이 도는 순간에 떠둔다
     private Map<String, String> captured;
@@ -89,17 +115,53 @@ class MdcContextFilterTest {
     @Test
     @DisplayName("요청이 끝나면 MDC 를 비운다 — 스레드 재사용 시 남으면 안 된다")
     void clearsMdcAfterRequest() throws Exception {
-        FilterChain chainPuttingUserId = (req, res) -> MDC.put(STORIXStatic.Mdc.USER_ID, "1");
+        // userId·role 은 뒤에 오는 JwtAuthenticationFilter 가 채운다
+        FilterChain chainPuttingPrincipal = (req, res) -> {
+            MDC.put(STORIXStatic.Mdc.USER_ID, "1");
+            MDC.put(STORIXStatic.Mdc.ROLE, "READER");
+        };
 
         filter.doFilter(
                 new MockHttpServletRequest("GET", "/api/v1/works/1"),
                 new MockHttpServletResponse(),
-                chainPuttingUserId
+                chainPuttingPrincipal
         );
 
         assertThat(MDC.get(STORIXStatic.Mdc.TRACE_ID)).isNull();
         assertThat(MDC.get(STORIXStatic.Mdc.ENDPOINT)).isNull();
         assertThat(MDC.get(STORIXStatic.Mdc.HTTP_METHOD)).isNull();
         assertThat(MDC.get(STORIXStatic.Mdc.USER_ID)).isNull();
+        assertThat(MDC.get(STORIXStatic.Mdc.ROLE)).isNull();
+    }
+
+    @Test
+    @DisplayName("관리자 경로가 아니어도 진입·완료 로그를 남긴다")
+    void logsEveryRequest() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/works/1");
+        request.setQueryString("page=0");
+
+        run(request);
+
+        List<String> messages = loggedMessages();
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0)).isEqualTo(">>> [Http] 요청 진입 query=page=0");
+        assertThat(messages.get(1)).matches(">>> \\[Http] 요청 완료 status=200 tookMs=\\d+");
+    }
+
+    @Test
+    @DisplayName("쿼리스트링이 없으면 진입 로그에 붙이지 않는다")
+    void omitsQueryWhenAbsent() throws Exception {
+        run(new MockHttpServletRequest("GET", "/api/v1/works/1"));
+
+        assertThat(loggedMessages().get(0)).isEqualTo(">>> [Http] 요청 진입");
+    }
+
+    @Test
+    @DisplayName("actuator 등 추적 가치가 없는 경로는 로그를 남기지 않는다")
+    void skipsUnloggedPaths() throws Exception {
+        run(new MockHttpServletRequest("GET", "/actuator/prometheus"));
+
+        assertThat(loggedMessages()).isEmpty();
+        assertThat(captured.get(STORIXStatic.Mdc.TRACE_ID)).hasSize(32);
     }
 }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] 진입·완료 로그를 관리자 경로에서 전체 API로 확대 (상태코드·처리시간 포함)
> - [x] 인증된 요청의 role을 MDC에 추가
> - [x] `GlobalExceptionHandler` 전 핸들러에 code·status·message WARN 기록
> - [x] 필터 단계에서 끊기던 인증 실패·접근 거부 기록
> - [x] UseCase의 트랜잭션 밖 처리 단계 로그 추가
> - [x] 로그인·토큰 재발급 경로 로그 추가
> - [x] MDC 전파가 빠진 비동기 executor 보완
> - [x] STOMP·Redis Pub/Sub 구간 traceId 전파
> - [x] ALB 추적 ID 기록

**한 요청이 남기는 로그**

```
>>> [Http] 요청 진입 query=page=0
>>> [Http] 처리 실패 code=REPORT_ERROR_002 status=400 message=신고 처리 요청이 올바르지 않습니다.
>>> [Http] 요청 완료 status=400 tookMs=24
```

`traceId`·`endpoint`·`httpMethod`·`userId`·`role`은 MDC로 붙으므로 메시지에 중복해 넣지 않았습니다. 처리 시간은 `System.nanoTime()` 기준이며, `finally`에서 남기므로 예외로 끝난 요청도 완료 로그가 나옵니다.

**인증 실패 기록**

`ErrorHandlingFilter`·`SecurityEntryPoint`·`SecurityDeniedHandler`는 `@RestControllerAdvice`를 타지 않아 필터 단계에서 응답을 직접 쓰므로 별도 로그를 달았습니다.

**토큰 재발급 경로**

`/tokens/refresh`는 permitAll이라 MDC에 `userId`가 없습니다. 재발급이 거부돼도 어느 유저인지 알 수 없어 `TokenAdaptor`에서 직접 남깁니다. 남은 기기 수를 함께 기록해 원인을 가릅니다.

| `remainingDeviceCount` | 해석 |
| --- | --- |
| 0 | 유저 키 자체가 없음 (정지·탈퇴·전체 로그아웃) |
| 1 이상 | 키는 있으나 해당 토큰만 없음 (회전됨 또는 상한 축출) |

**UseCase 로그 기준**

트랜잭션이 되돌려주지 않는 단계만 남깁니다. S3 업로드·캐시 무효화·OAuth 연결 해제가 해당하고, 조회·매핑만 하는 단계는 제외했습니다. 보상 삭제 경로는 `objectKey`와 함께 WARN으로 남겨 S3 orphan을 나중에 찾을 수 있게 했습니다.

**비동기·STOMP 전파**

`logThreadPool`·`chatAsyncExecutor`·`slackTaskExecutor`에 `TaskDecorator`가 없어 해당 스레드 로그에 traceId가 없었습니다. STOMP는 서블릿 필터를 타지 않아 인바운드 채널 인터셉터에서 MDC를 채웁니다.

인스턴스 간 전달은 발행 페이로드를 traceId 봉투로 감쌌습니다. 클라이언트로 나가는 형식은 바뀌지 않습니다.

```json
{ "traceId": "9f2c4a...", "message": { "roomId": 12, "message": "...", "messageType": "TALK" } }
```

## 📸 작업 화면 (스크린샷)
dev/prod는 `LogstashEncoder`라 MDC가 JSON 필드로 나갑니다.

```json
{
  "level": "WARN",
  "message": ">>> [Http] 처리 실패 code=REPORT_ERROR_002 status=400 message=신고 처리 요청이 올바르지 않습니다.",
  "traceId": "9f2c4a71b8e54d1a",
  "endpoint": "/api/v1/admin/reports/46",
  "httpMethod": "PATCH",
  "userId": "3",
  "role": "ADMIN",
  "app": "storix-api"
}
```

## 💬 리뷰 요구사항(선택)
로그 형식과 남기는 지점의 기준을 봐주세요. 특히 UseCase에서 어디까지 남길지가 판단이 갈릴 수 있습니다.

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #179

## 🖇️ 기타
**배포 순서에 제약이 있습니다.**

채팅 발행 페이로드가 봉투 형식으로 바뀝니다. 수신 측은 구버전 메시지도 처리하지만 반대는 되지 않아, 구버전 인스턴스가 신버전 메시지를 받으면 해당 방의 채팅이 전달되지 않습니다. 단일 인스턴스에 stop→start 배포면 안전하며, **오토스케일링 전환 전에 배포되어야 합니다.**
