### PR TITLE
Release v2.4.8

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -74,7 +74,8 @@ public class AuthUseCase {
     public ResponseEntity<CustomResponse<AuthorizationResponse>> readerSignup(ReaderSignUpData data, String jti) {
         AuthUserDetails userDetails = authService.signUpReaderUser(data, jti);
         LoginWithTokenResponse tokenResponse = tokenGenerateHelper.generateLoginWithToken(userDetails);
-        AuthorizationResponse result = AuthorizationResponse.webRefresh(tokenResponse.accessToken());
+        AuthorizationResponse result = AuthorizationResponse.nativeRefresh(
+                tokenResponse.accessToken(), tokenResponse.refreshToken());
 
         return ResponseEntity.ok()
                 .headers(cookieHelper.getTokenCookie(tokenResponse.refreshToken()))


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] PR #183의 커밋 cherry-pick (회원가입 응답에 refreshToken 포함)
> - [x] release/v2.4.8 구성

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #182

## 🖇️ 기타
**DB · Redis 작업은 없습니다.**

**배포 후 확인**

가입 응답 body 에 `refreshToken` 이 포함되는지 확인합니다.

```bash
curl -i -X POST 'https://dev.storix.kr/api/v2/auth/users/reader/signup' \
  -H 'Authorization: Bearer <온보딩토큰>' -H 'Content-Type: application/json' -d '{...}'
```

가입 이전에 발급된 세션은 클라이언트에 refreshToken 이 없으므로, 기존 가입자는 재로그인해야 정상화됩니다.

앱 실행 시 재발급이 도는지는 로그로 확인할 수 있습니다.

```
{job="storix", env="prod"} |~ "\\[Auth\\]"
```