### PR TITLE
Release v2.4.9

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthUseCase.java
@@ -4,7 +4,6 @@ import com.storix.common.annotation.UseCase;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.api.domain.user.controller.dto.AuthorizationResponse;
 import com.storix.api.domain.user.controller.dto.LoginWithTokenResponse;
-import com.storix.api.domain.user.helper.CookieHelper;
 import com.storix.api.domain.user.helper.TokenGenerateHelper;
 import com.storix.domain.domains.user.service.AuthService;
 import com.storix.api.domain.user.helper.OAuthHelper;
@@ -27,7 +26,6 @@ public class AuthUseCase {
 
     private final OAuthHelper oauthHelper;
     private final TokenGenerateHelper tokenGenerateHelper;
-    private final CookieHelper cookieHelper;
 
     // 독자 회원 가입 가능 여부 (Web)
     // - authCode로 토큰을 얻은 뒤 공통 검증
@@ -78,7 +76,6 @@ public class AuthUseCase {
                 tokenResponse.accessToken(), tokenResponse.refreshToken());
 
         return ResponseEntity.ok()
-                .headers(cookieHelper.getTokenCookie(tokenResponse.refreshToken()))
                 .body(CustomResponse.onSuccess(SuccessCode.AUTH_SIGNUP_SUCCESS, result));
     }
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthorizationUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/AuthorizationUseCase.java
@@ -25,7 +25,7 @@ public class AuthorizationUseCase {
     public ResponseEntity<CustomResponse<AuthorizationResponse>> getTokenRefresh(
             String cookieRefreshToken, String bodyRefreshToken
     ) {
-        boolean useBodyToken = cookieRefreshToken == null || cookieRefreshToken.isBlank();
+        boolean useBodyToken = bodyRefreshToken != null && !bodyRefreshToken.isBlank();
         String refreshToken = useBodyToken ? bodyRefreshToken : cookieRefreshToken;
 
         if (refreshToken == null || refreshToken.isBlank()) throw RefreshTokenNotExistException.EXCEPTION;

--- a/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LogoutUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/user/usecase/LogoutUseCase.java
@@ -24,6 +24,7 @@ public class LogoutUseCase {
         authService.logout(userId, installationId, refreshToken);
 
         return ResponseEntity.ok()
+                    .headers(cookieHelper.deleteCookie())
                     .body(CustomResponse.onSuccess(SuccessCode.AUTH_LOGOUT_SUCCESS));
     }
 


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] PR #186의 커밋 cherry-pick (가입 응답 쿠키 제거 및 토큰 재발급 body 우선 처리)
> - [x] release/v2.4.9 구성

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #185

## 🖇️ 기타
**DB · Redis 작업은 없습니다.**

**배포 후 확인**

재발급이 body 경로를 타는지 로그로 확인합니다.

```
{job="storix", env="prod"} |~ "토큰 재발급"
```

`native=true` 로 찍히면 정상입니다. 이미 쿠키가 저장된 기기도 재설치 없이 동작하며, 다른 계정의 userId 로 `Refresh Token 불일치` 가 발생하지 않아야 합니다.