### PR TITLE
Release v2.4.10

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AppEventController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AppEventController.java
@@ -43,6 +43,15 @@ public class AppEventController {
         return appEventUseCase.dismissPopupForToday(authUser.getUserId(), popupId);
     }
 
+    @PatchMapping("/popup/{popupId}/never-show")
+    @Operation(summary = "팝업 다시 보지 않기", description = "해당 팝업을 노출 기간 내내 이 유저에게 다시 노출하지 않습니다.")
+    public CustomResponse<Void> neverShowPopup(
+            @AuthenticationPrincipal AuthUserDetails authUser,
+            @PathVariable Long popupId
+    ) {
+        return appEventUseCase.dismissPopupForever(authUser.getUserId(), popupId);
+    }
+
     @GetMapping("/banner")
     @Operation(summary = "노출 중인 배너 조회", description = "현재 노출 가능한 배너를 최대 3개까지 반환합니다. 없으면 빈 배열.")
     public CustomResponse<List<BannerResponse>> getBanner() {

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AttendanceEventController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AttendanceEventController.java
@@ -1,0 +1,40 @@
+package com.storix.api.domain.event.controller;
+
+import com.storix.api.domain.event.usecase.AttendanceEventUseCase;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.event.dto.AttendanceCheckInResponse;
+import com.storix.domain.domains.event.dto.AttendanceStatusResponse;
+import com.storix.domain.domains.user.adaptor.AuthUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/attendance-event")
+@RequiredArgsConstructor
+@Tag(name = "출석 이벤트", description = "출석 체크 이벤트 API")
+public class AttendanceEventController {
+
+    private final AttendanceEventUseCase attendanceEventUseCase;
+
+    @GetMapping
+    @Operation(summary = "출석 현황 조회", description = "이벤트 기간, 출석한 날짜 목록, 오늘 출석 여부, 발급된 응모권 수를 한 번에 반환합니다. 진행 중인 출석 이벤트가 없으면 404.")
+    public CustomResponse<AttendanceStatusResponse> getStatus(
+            @AuthenticationPrincipal AuthUserDetails authUser
+    ) {
+        return attendanceEventUseCase.getStatus(authUser.getUserId());
+    }
+
+    @PostMapping("/check-in")
+    @Operation(summary = "출석 체크", description = "오늘(Asia/Seoul 00:00~23:59) 출석을 기록합니다. 기간 외 요청은 400, 이미 출석한 날 재요청은 409.")
+    public CustomResponse<AttendanceCheckInResponse> checkIn(
+            @AuthenticationPrincipal AuthUserDetails authUser
+    ) {
+        return attendanceEventUseCase.checkIn(authUser.getUserId());
+    }
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/AppEventRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/AppEventRequest.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Set;
 
 public record AppEventRequest(
@@ -36,7 +37,13 @@ public record AppEventRequest(
         boolean hasWinner,
 
         @Schema(description = "홍보 수단, 다중 선택 (PUSH / POPUP / BANNER)", example = "[\"PUSH\", \"POPUP\", \"BANNER\"]")
-        Set<PromotionType> promotionTypes
+        Set<PromotionType> promotionTypes,
+
+        @Schema(
+                description = "출석 이벤트 응모권 지급 기준. 키=누적 출석일, 값=누적 지급 응모권. 미지정 시 기본표(3일 1개, 7일 2개, 12일 5개) 적용",
+                example = "{\"3\": 1, \"7\": 2, \"12\": 5}"
+        )
+        Map<Integer, Integer> attendanceRewards
 ) {
     @AssertTrue(message = "이벤트 종료 일시는 시작 일시 이후여야 합니다.")
     private boolean isPeriodValid() {
@@ -45,6 +52,6 @@ public record AppEventRequest(
     }
 
     public AppEventCommand toCommand() {
-        return new AppEventCommand(name, description, startAt, endAt, hasWinner, promotionTypes);
+        return new AppEventCommand(name, description, startAt, endAt, hasWinner, promotionTypes, attendanceRewards);
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AppEventUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AppEventUseCase.java
@@ -56,6 +56,17 @@ public class AppEventUseCase {
         return CustomResponse.onSuccess(SuccessCode.APP_EVENT_POPUP_DISMISS_SUCCESS);
     }
 
+    // 팝업 다시 보지 않기 (노출 기간 내내)
+    public CustomResponse<Void> dismissPopupForever(Long userId, Long popupId) {
+
+        // 1. 팝업 존재 검증
+        eventPopupService.getById(popupId);
+
+        // 2. 다시 보지 않기 처리
+        popupDismissService.dismissForever(userId, popupId, LocalDate.now());
+        return CustomResponse.onSuccess(SuccessCode.APP_EVENT_POPUP_NEVER_SHOW_SUCCESS);
+    }
+
     // 노출 중인 배너 조회
     public CustomResponse<List<BannerResponse>> getActiveBanner() {
 

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AttendanceEventUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AttendanceEventUseCase.java
@@ -1,0 +1,43 @@
+package com.storix.api.domain.event.usecase;
+
+import com.storix.common.code.SuccessCode;
+import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.event.dto.AttendanceCheckInResponse;
+import com.storix.domain.domains.event.dto.AttendanceStatusResponse;
+import com.storix.domain.domains.event.service.AttendanceEventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Component
+@RequiredArgsConstructor
+public class AttendanceEventUseCase {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final AttendanceEventService attendanceEventService;
+
+    // 현재 진행 중인 출석 이벤트의 app_event_id (미설정 시 0 → 404)
+    @Value("${attendance-event.app-event-id:0}") private Long attendanceAppEventId;
+
+    // 출석 현황 조회
+    public CustomResponse<AttendanceStatusResponse> getStatus(Long userId) {
+
+        return CustomResponse.onSuccess(
+                SuccessCode.ATTENDANCE_EVENT_LOAD_SUCCESS,
+                attendanceEventService.getStatus(attendanceAppEventId, userId, LocalDateTime.now(KST))
+        );
+    }
+
+    // 출석 체크
+    public CustomResponse<AttendanceCheckInResponse> checkIn(Long userId) {
+
+        return CustomResponse.onSuccess(
+                SuccessCode.ATTENDANCE_EVENT_CHECK_IN_SUCCESS,
+                attendanceEventService.checkIn(attendanceAppEventId, userId, LocalDateTime.now(KST))
+        );
+    }
+}

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     ONBOARDING_DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "NICKNAME_ERROR_001", "이미 사용 중인 닉네임입니다."),
     PROFILE_DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "NICKNAME_ERROR_002", "이미 사용 중인 닉네임입니다."),
     PROFILE_FORBIDDEN_NICKNAME(HttpStatus.BAD_REQUEST, "NICKNAME_ERROR_003", "사용할 수 없는 닉네임입니다."),
+    PROFILE_NICKNAME_BANNED_WORD(HttpStatus.BAD_REQUEST, "NICKNAME_ERROR_004", "닉네임에 금칙어가 포함되어 있습니다."),
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "USER_ERROR_001", "로그인이 필요합니다."),
     FORBIDDEN_APPROACH(HttpStatus.FORBIDDEN, "USER_ERROR_002", "해당 요청을 수행할 권한이 없습니다."),
 
@@ -130,12 +131,18 @@ public enum ErrorCode {
     ADMIN_APP_EVENT_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "ADMIN_APP_EVENT_ERROR_002", "앱 이벤트명은 필수입니다."),
     ADMIN_APP_EVENT_PERIOD_REQUIRED(HttpStatus.BAD_REQUEST, "ADMIN_APP_EVENT_ERROR_003", "앱 이벤트 시작/종료 일시는 필수입니다."),
     ADMIN_APP_EVENT_INVALID_PERIOD(HttpStatus.BAD_REQUEST, "ADMIN_APP_EVENT_ERROR_004", "앱 이벤트 종료 일시는 시작 일시 이후여야 합니다."),
+    ADMIN_APP_EVENT_INVALID_ATTENDANCE_REWARDS(HttpStatus.BAD_REQUEST, "ADMIN_APP_EVENT_ERROR_005", "출석 응모권 지급 기준은 출석일 1 이상, 응모권 0 이상이며 출석일이 늘수록 누적 응모권이 줄어들 수 없습니다."),
 
     // App Event error
     APP_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "APP_EVENT_ERROR_001", "존재하지 않는 앱 이벤트입니다."),
     APP_EVENT_FORBIDDEN(HttpStatus.FORBIDDEN, "APP_EVENT_ERROR_002", "앱 이벤트를 확인할 권한이 없습니다."),
     APP_EVENT_PAYLOAD_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "APP_EVENT_ERROR_003", "앱 이벤트 payload 직렬화에 실패했습니다."),
     APP_EVENT_WINNER_FINALIZER_NOT_IMPLEMENTED(HttpStatus.INTERNAL_SERVER_ERROR, "APP_EVENT_ERROR_004", "당첨자 이벤트(hasWinner=true)는 종료 시 당첨자 확정(EventWinnerFinalizer) 구현이 필수입니다."),
+
+    // Attendance Event error
+    ATTENDANCE_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ATTENDANCE_EVENT_ERROR_001", "진행 중인 출석 이벤트가 없습니다."),
+    ATTENDANCE_EVENT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "ATTENDANCE_EVENT_ERROR_002", "출석 이벤트 기간이 아닙니다."),
+    ATTENDANCE_ALREADY_CHECKED_IN(HttpStatus.CONFLICT, "ATTENDANCE_EVENT_ERROR_003", "오늘은 이미 출석 체크를 완료했습니다."),
 
     // OIDC error
     OIDC_OLD_PUBLIC_KEY_ERROR(HttpStatus.BAD_REQUEST, "OIDC_ERORR_1", "OIDC 공개키 갱신이 필요합니다."),
@@ -154,13 +161,14 @@ public enum ErrorCode {
     ADULT_VERIFICATION_REQUIRED(HttpStatus.BAD_REQUEST, "TOPIC_ROOM_ERROR_001", "성인인증이 되지 않은 사용자입니다."),
     TOPIC_ROOM_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "TOPIC_ROOM_ERROR_002", "토픽룸 최대 개수는 9개입니다."),
     TOPIC_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "TOPIC_ROOM_ERROR_003", "해당 토픽룸을 찾을 수 없습니다."),
-    INVALID_TOPIC_ROOM_TITLE(HttpStatus.BAD_REQUEST, "TOPIC_ROOM_ERROR_004", "토픽룸에 금칙어가 포함되어 있습니다."),
+    INVALID_TOPIC_ROOM_TITLE(HttpStatus.BAD_REQUEST, "TOPIC_ROOM_ERROR_004", "토픽룸에 금칙어가 포함되어 있습니다."), // 제목에 금칙어 포함
     ALREADY_JOINED_ROOM(HttpStatus.CONFLICT, "TOPIC_ROOM_ERROR_005", "이미 참여 중인 토픽룸입니다."),
     SELF_REPORT_ERROR(HttpStatus.BAD_REQUEST, "TOPIC_ROOM_ERROR_006", "자기 자신은 신고할 수 없습니다."),
     TOPIC_ROOM_ALREADY_EXISTS(HttpStatus.CONFLICT, "TOPIC_ROOM_ERROR_007", "이미 해당 작품에 대한 토픽룸이 존재합니다."),
     TOPIC_ROOM_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "TOPIC_ROOM_ERROR_008", "해당 토픽룸에 참여하지 않은 유저입니다."),
     TODAY_TOPIC_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "TOPIC_ROOM_ERROR_009", "오늘의 토픽룸이 없습니다."),
     DUPLICATE_TOPIC_ROOM_REPORT(HttpStatus.BAD_REQUEST, "TOPIC_ROOM_ERROR_010", "이미 신고한 사용자입니다."),
+    TOPIC_ROOM_ADMIN_KEYWORD_TITLE(HttpStatus.BAD_REQUEST, "TOPIC_ROOM_ERROR_011", "사용할 수 없는 토픽룸 제목입니다."), // 제목에 관리자/운영 예약 키워드 포함
 
     // Search error
     SEARCH_NO_TOPIC_ROOM_FOUND(HttpStatus.NOT_FOUND, "SEARCH_ERROR_001", "검색한 키워드로 조회되는 토픽룸이 없습니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -42,6 +42,9 @@ public enum SuccessCode {
     APP_EVENTS_LOAD_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_001", "앱 이벤트 조회에 성공했습니다."),
     APP_EVENT_ACK_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_002", "앱 이벤트 확인 처리에 성공했습니다."),
     APP_EVENT_POPUP_DISMISS_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_003", "팝업 오늘 다시 안 보기 처리에 성공했습니다."),
+    APP_EVENT_POPUP_NEVER_SHOW_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_004", "팝업 다시 보지 않기 처리에 성공했습니다."),
+    ATTENDANCE_EVENT_LOAD_SUCCESS(HttpStatus.OK, "ATTENDANCE_EVENT_SUCCESS_001", "출석 이벤트 현황 조회에 성공했습니다."),
+    ATTENDANCE_EVENT_CHECK_IN_SUCCESS(HttpStatus.OK, "ATTENDANCE_EVENT_SUCCESS_002", "출석 체크에 성공했습니다."),
 
     // PushDevice success
     DEVICE_SYNC_SUCCESS(HttpStatus.OK, "DEVICE2001", "디바이스 동기화에 성공했습니다."),

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/bannedword/adaptor/BannedWordAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/bannedword/adaptor/BannedWordAdaptor.java
@@ -1,17 +1,24 @@
 package com.storix.domain.domains.bannedword.adaptor;
 
+import com.storix.domain.domains.bannedword.service.AdminKeywordMatcher;
 import com.storix.domain.domains.bannedword.service.BannedWordMatcher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-// 다른 도메인이 금칙어 검사가 필요할 때 거치는 어댑터. BannedWordMatcher(캐시/아호코라식 매칭)를 직접 주입받지 않도록 한다.
 @Component
 @RequiredArgsConstructor
 public class BannedWordAdaptor {
 
     private final BannedWordMatcher bannedWordMatcher;
+    private final AdminKeywordMatcher adminKeywordMatcher;
 
+    // DB로 관리되는 금칙어 포함 여부
     public boolean containsBannedWord(String text) {
         return bannedWordMatcher.containsBannedWord(text);
+    }
+
+    // 관리자/운영 예약 키워드 포함 여부
+    public boolean containsAdminKeyword(String text) {
+        return adminKeywordMatcher.containsAdminKeyword(text);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/bannedword/service/AdminKeywordMatcher.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/bannedword/service/AdminKeywordMatcher.java
@@ -1,0 +1,29 @@
+package com.storix.domain.domains.bannedword.service;
+
+import org.ahocorasick.trie.Trie;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+// 관리자/운영 주체를 사칭할 수 있는 예약 키워드를 검사
+@Component
+public class AdminKeywordMatcher {
+
+    // 사칭 방지용 예약 키워드
+    private static final List<String> ADMIN_KEYWORDS = List.of(
+            "관리자", "운영자", "운영팀", "매니저", "고객센터", "고객지원", "공식",
+            "스토릭스", "storix", "admin", "administrator", "manager", "system", "시스템"
+    );
+
+    private final Trie trie;
+
+    public AdminKeywordMatcher() {
+        Trie.TrieBuilder builder = Trie.builder().ignoreCase();
+        ADMIN_KEYWORDS.forEach(builder::addKeyword);
+        this.trie = builder.build();
+    }
+
+    public boolean containsAdminKeyword(String text) {
+        return text != null && !text.isBlank() && trie.containsMatch(text);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/AppEventAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/AppEventAdaptor.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class AppEventAdaptor {
@@ -21,6 +23,10 @@ public class AppEventAdaptor {
     public AppEvent findById(Long appEventId) {
         return appEventRepository.findById(appEventId)
                 .orElseThrow(() -> AppEventNotFoundException.EXCEPTION);
+    }
+
+    public Optional<AppEvent> findOptionalById(Long appEventId) {
+        return appEventRepository.findById(appEventId);
     }
 
     public Page<AppEvent> findAll(Pageable pageable) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/AttendanceCheckAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/AttendanceCheckAdaptor.java
@@ -1,0 +1,37 @@
+package com.storix.domain.domains.event.adaptor;
+
+import com.storix.domain.domains.event.domain.AttendanceCheck;
+import com.storix.domain.domains.event.repository.AttendanceCheckRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AttendanceCheckAdaptor {
+
+    private final AttendanceCheckRepository attendanceCheckRepository;
+
+    public boolean insertIfAbsent(Long appEventId, Long userId, LocalDate attendedOn) {
+        try {
+            attendanceCheckRepository.insert(appEventId, userId, attendedOn);
+            return true;
+        } catch (DataIntegrityViolationException e) {
+            return false;
+        }
+    }
+
+    public List<LocalDate> findAttendedDates(Long appEventId, Long userId) {
+        return attendanceCheckRepository.findAllByAppEventIdAndUserIdOrderByAttendedOnAsc(appEventId, userId)
+                .stream()
+                .map(AttendanceCheck::getAttendedOn)
+                .toList();
+    }
+
+    public long countAttendedDays(Long appEventId, Long userId) {
+        return attendanceCheckRepository.countByAppEventIdAndUserId(appEventId, userId);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/PopupDismissAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/PopupDismissAdaptor.java
@@ -13,10 +13,18 @@ public class PopupDismissAdaptor {
     private final PopupDismissRepository popupDismissRepository;
 
     public void upsertForToday(Long userId, Long popupId, LocalDate today) {
-        popupDismissRepository.upsertDismiss(userId, popupId, today);
+        popupDismissRepository.upsertDismiss(userId, popupId, today, false);
     }
 
-    public boolean isDismissedOn(Long userId, Long popupId, LocalDate date) {
-        return popupDismissRepository.existsByUserIdAndPopup_IdAndDismissedOn(userId, popupId, date);
+    public void upsertNeverShow(Long userId, Long popupId, LocalDate today) {
+        popupDismissRepository.upsertDismiss(userId, popupId, today, true);
+    }
+
+    public boolean isPermanentlyDismissed(Long userId, Long popupId) {
+        return popupDismissRepository.existsByUserIdAndPopup_IdAndPermanentTrue(userId, popupId);
+    }
+
+    public boolean isSuppressedOn(Long userId, Long popupId, LocalDate date) {
+        return popupDismissRepository.existsSuppressedOn(userId, popupId, date);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AppEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AppEvent.java
@@ -9,7 +9,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 @Entity
@@ -51,6 +53,17 @@ public class AppEvent extends BaseTimeEntity {
     @Column(name = "assignee_admin_id")
     private Long assigneeAdminId;
 
+    // 출석 이벤트 응모권 지급 기준: 누적 출석일 → 누적 지급 응모권. 비어 있으면 서비스의 기본 지급표를 사용한다.
+    @ElementCollection
+    @CollectionTable(
+            name = "app_event_attendance_rewards",
+            joinColumns = @JoinColumn(name = "app_event_id")
+    )
+    @MapKeyColumn(name = "attended_days")
+    @Column(name = "cumulative_tickets", nullable = false)
+    @BatchSize(size = 100)
+    private Map<Integer, Integer> attendanceRewards = new HashMap<>();
+
     @Builder
     public AppEvent(String name,
                     String description,
@@ -58,6 +71,7 @@ public class AppEvent extends BaseTimeEntity {
                     LocalDateTime endAt,
                     boolean hasWinner,
                     Set<PromotionType> promotionTypes,
+                    Map<Integer, Integer> attendanceRewards,
                     Long assigneeAdminId) {
         this.name = name;
         this.description = description;
@@ -67,6 +81,9 @@ public class AppEvent extends BaseTimeEntity {
         if (promotionTypes != null) {
             this.promotionTypes.addAll(promotionTypes);
         }
+        if (attendanceRewards != null) {
+            this.attendanceRewards.putAll(attendanceRewards);
+        }
         this.assigneeAdminId = assigneeAdminId;
     }
 
@@ -75,7 +92,8 @@ public class AppEvent extends BaseTimeEntity {
                        LocalDateTime startAt,
                        LocalDateTime endAt,
                        boolean hasWinner,
-                       Set<PromotionType> promotionTypes) {
+                       Set<PromotionType> promotionTypes,
+                       Map<Integer, Integer> attendanceRewards) {
         this.name = name;
         this.description = description;
         this.startAt = startAt;
@@ -85,6 +103,11 @@ public class AppEvent extends BaseTimeEntity {
         this.promotionTypes.clear();
         if (promotionTypes != null) {
             this.promotionTypes.addAll(promotionTypes);
+        }
+
+        this.attendanceRewards.clear();
+        if (attendanceRewards != null) {
+            this.attendanceRewards.putAll(attendanceRewards);
         }
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AttendanceCheck.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AttendanceCheck.java
@@ -1,0 +1,45 @@
+package com.storix.domain.domains.event.domain;
+
+import com.storix.common.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(
+        name = "event_attendance_checks",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_attendance_check_event_user_date",
+                columnNames = {"app_event_id", "user_id", "attended_on"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttendanceCheck extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attendance_check_id")
+    private Long id;
+
+    @Column(name = "app_event_id", nullable = false)
+    private Long appEventId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    // 출석 일자 (Asia/Seoul, 00:00~23:59 기준)
+    @Column(name = "attended_on", nullable = false)
+    private LocalDate attendedOn;
+
+    @Builder
+    public AttendanceCheck(Long appEventId, Long userId, LocalDate attendedOn) {
+        this.appEventId = appEventId;
+        this.userId = userId;
+        this.attendedOn = attendedOn;
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/PopupDismiss.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/PopupDismiss.java
@@ -36,10 +36,15 @@ public class PopupDismiss extends BaseTimeEntity {
     @Column(name = "dismissed_on", nullable = false)
     private LocalDate dismissedOn;
 
+    // "다시 보지 않기" - true면 노출 기간 내내 숨김
+    @Column(name = "is_permanent", nullable = false)
+    private boolean permanent;
+
     @Builder
-    public PopupDismiss(Long userId, Popup popup, LocalDate dismissedOn) {
+    public PopupDismiss(Long userId, Popup popup, LocalDate dismissedOn, boolean permanent) {
         this.userId = userId;
         this.popup = popup;
         this.dismissedOn = dismissedOn;
+        this.permanent = permanent;
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventCommand.java
@@ -3,6 +3,7 @@ package com.storix.domain.domains.event.dto;
 import com.storix.domain.domains.event.domain.PromotionType;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Set;
 
 public record AppEventCommand(
@@ -11,6 +12,7 @@ public record AppEventCommand(
         LocalDateTime startAt,
         LocalDateTime endAt,
         boolean hasWinner,
-        Set<PromotionType> promotionTypes
+        Set<PromotionType> promotionTypes,
+        Map<Integer, Integer> attendanceRewards
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Set;
 
 @Builder
@@ -33,6 +34,9 @@ public record AppEventResponse(
         @Schema(description = "홍보 수단, 다중 선택 (PUSH / POPUP / BANNER)")
         Set<PromotionType> promotionTypes,
 
+        @Schema(description = "출석 이벤트 응모권 지급 기준 (키=누적 출석일, 값=누적 지급 응모권). 미지정 시 빈 값")
+        Map<Integer, Integer> attendanceRewards,
+
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime createdAt,
 
@@ -49,6 +53,7 @@ public record AppEventResponse(
                 .status(AppEventStatus.resolve(appEvent.getStartAt(), appEvent.getEndAt(), LocalDateTime.now()))
                 .hasWinner(appEvent.isHasWinner())
                 .promotionTypes(Set.copyOf(appEvent.getPromotionTypes()))
+                .attendanceRewards(Map.copyOf(appEvent.getAttendanceRewards()))
                 .createdAt(appEvent.getCreatedAt())
                 .updatedAt(appEvent.getUpdatedAt())
                 .build();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AttendanceCheckInResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AttendanceCheckInResponse.java
@@ -1,0 +1,22 @@
+package com.storix.domain.domains.event.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record AttendanceCheckInResponse(
+        @Schema(description = "출석 처리된 날짜 (yyyy-MM-dd)")
+        LocalDate attendedDate,
+
+        @Schema(description = "누적 출석일 수")
+        int totalAttendedDays,
+
+        @Schema(description = "이번 출석으로 새로 발급된 응모권 수 (이벤트 지급표 기준, 기본표는 3일 +1/7일 +1/14일 +3)")
+        int newlyIssuedTickets,
+
+        @Schema(description = "지금까지 발급된 응모권 수")
+        int issuedTickets
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AttendanceStatusResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AttendanceStatusResponse.java
@@ -1,0 +1,34 @@
+package com.storix.domain.domains.event.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record AttendanceStatusResponse(
+        Long appEventId,
+
+        @Schema(description = "이벤트 시작일 (yyyy-MM-dd)")
+        LocalDate eventStartDate,
+
+        @Schema(description = "이벤트 종료일 (yyyy-MM-dd)")
+        LocalDate eventEndDate,
+
+        @Schema(description = "출석한 날짜 목록 (오름차순)")
+        List<LocalDate> attendedDates,
+
+        @Schema(description = "누적 출석일 수")
+        int totalAttendedDays,
+
+        @Schema(description = "오늘 출석 완료 여부")
+        boolean attendedToday,
+
+        @Schema(description = "지금까지 발급된 응모권 수 (이벤트 지급표 기준, 미지정 시 기본표 3일 1개/7일 2개/14일 5개)")
+        int issuedTickets,
+
+        @Schema(description = "이벤트 진행 중 여부 (기간 외면 false)")
+        boolean eventActive
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AppEventInvalidAttendanceRewardsException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AppEventInvalidAttendanceRewardsException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.event.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class AppEventInvalidAttendanceRewardsException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new AppEventInvalidAttendanceRewardsException();
+
+    private AppEventInvalidAttendanceRewardsException() { super(ErrorCode.ADMIN_APP_EVENT_INVALID_ATTENDANCE_REWARDS); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AttendanceAlreadyCheckedInException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AttendanceAlreadyCheckedInException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.event.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class AttendanceAlreadyCheckedInException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new AttendanceAlreadyCheckedInException();
+
+    private AttendanceAlreadyCheckedInException() { super(ErrorCode.ATTENDANCE_ALREADY_CHECKED_IN); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AttendanceEventNotActiveException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AttendanceEventNotActiveException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.event.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class AttendanceEventNotActiveException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new AttendanceEventNotActiveException();
+
+    private AttendanceEventNotActiveException() { super(ErrorCode.ATTENDANCE_EVENT_NOT_ACTIVE); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AttendanceEventNotFoundException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AttendanceEventNotFoundException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.event.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class AttendanceEventNotFoundException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new AttendanceEventNotFoundException();
+
+    private AttendanceEventNotFoundException() { super(ErrorCode.ATTENDANCE_EVENT_NOT_FOUND); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/AttendanceCheckRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/AttendanceCheckRepository.java
@@ -1,0 +1,28 @@
+package com.storix.domain.domains.event.repository;
+
+import com.storix.domain.domains.event.domain.AttendanceCheck;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AttendanceCheckRepository extends JpaRepository<AttendanceCheck, Long> {
+
+    List<AttendanceCheck> findAllByAppEventIdAndUserIdOrderByAttendedOnAsc(Long appEventId, Long userId);
+
+    long countByAppEventIdAndUserId(Long appEventId, Long userId);
+
+    // (app_event_id, user_id, attended_on) 유니크 기반 원자적 insert
+    // 중복이면 DataIntegrityViolationException, 그 외 무결성 위반도 그대로 전파된다
+    @Modifying
+    @Query(value = """
+            INSERT INTO event_attendance_checks (app_event_id, user_id, attended_on, created_at, updated_at)
+            VALUES (:appEventId, :userId, :attendedOn, NOW(), NOW())
+            """, nativeQuery = true)
+    int insert(@Param("appEventId") Long appEventId,
+               @Param("userId") Long userId,
+               @Param("attendedOn") LocalDate attendedOn);
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/PopupDismissRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/PopupDismissRepository.java
@@ -10,18 +10,30 @@ import java.time.LocalDate;
 
 public interface PopupDismissRepository extends JpaRepository<PopupDismiss, Long> {
 
-    boolean existsByUserIdAndPopup_IdAndDismissedOn(Long userId, Long popupId, LocalDate dismissedOn);
+    boolean existsByUserIdAndPopup_IdAndPermanentTrue(Long userId, Long popupId);
 
-    // (userId, popupId) 유니크 기반 원자적 upsert, 동시 요청도 안전
+    // 오늘 '다시 안 보기' 또는 '다시 보지 않기'(영구) 여부
+    @Query("""
+            select count(d) > 0 from PopupDismiss d
+            where d.userId = :userId and d.popup.id = :popupId
+              and (d.permanent = true or d.dismissedOn = :today)
+            """)
+    boolean existsSuppressedOn(@Param("userId") Long userId,
+                               @Param("popupId") Long popupId,
+                               @Param("today") LocalDate today);
+
+    // (userId, popupId) 유니크 기반 원자적 upsert, 동시 요청도 안전. 영구 dismiss는 daily 요청으로 되돌리지 않는다
     @Modifying
     @Query(value = """
-            INSERT INTO event_popup_dismisses (user_id, popup_id, dismissed_on, created_at, updated_at)
-            VALUES (:userId, :popupId, :today, NOW(), NOW())
+            INSERT INTO event_popup_dismisses (user_id, popup_id, dismissed_on, is_permanent, created_at, updated_at)
+            VALUES (:userId, :popupId, :today, :permanent, NOW(), NOW())
             ON DUPLICATE KEY UPDATE
                 dismissed_on = :today,
+                is_permanent = (is_permanent OR :permanent),
                 updated_at = NOW()
             """, nativeQuery = true)
     void upsertDismiss(@Param("userId") Long userId,
                        @Param("popupId") Long popupId,
-                       @Param("today") LocalDate today);
+                       @Param("today") LocalDate today,
+                       @Param("permanent") boolean permanent);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
@@ -4,6 +4,7 @@ import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
 import com.storix.domain.domains.event.domain.AppEvent;
 import com.storix.domain.domains.event.dto.AppEventCommand;
 import com.storix.domain.domains.event.dto.AppEventResponse;
+import com.storix.domain.domains.event.exception.AppEventInvalidAttendanceRewardsException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodException;
 import com.storix.domain.domains.event.exception.AppEventNameRequiredException;
 import com.storix.domain.domains.event.exception.AppEventPeriodRequiredException;
@@ -15,6 +16,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.TreeMap;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +40,7 @@ public class AppEventService {
                 .endAt(cmd.endAt())
                 .hasWinner(cmd.hasWinner())
                 .promotionTypes(cmd.promotionTypes())
+                .attendanceRewards(cmd.attendanceRewards())
                 .assigneeAdminId(adminUserId)
                 .build());
         return AppEventResponse.from(saved);
@@ -54,7 +58,8 @@ public class AppEventService {
                 cmd.startAt(),
                 cmd.endAt(),
                 cmd.hasWinner(),
-                cmd.promotionTypes()
+                cmd.promotionTypes(),
+                cmd.attendanceRewards()
         );
         // 이벤트 기간이 바뀌면 소속 팝업/배너 노출기간을 이벤트 기간 안으로 clamp (앱 이벤트 ⊇ 팝업/배너)
         if (periodChanged) {
@@ -95,6 +100,26 @@ public class AppEventService {
         }
         if (!cmd.startAt().isBefore(cmd.endAt())) {
             throw AppEventInvalidPeriodException.EXCEPTION;
+        }
+        validateAttendanceRewards(cmd.attendanceRewards());
+    }
+
+    // 지정하지 않으면(null/빈 값) 출석 이벤트 지급표는 서비스 기본값을 사용한다.
+    // 지정 시 출석일 ≥ 1, 응모권 ≥ 0, 출석일이 늘수록 누적 응모권이 감소하지 않아야 한다.
+    private void validateAttendanceRewards(Map<Integer, Integer> attendanceRewards) {
+        if (attendanceRewards == null || attendanceRewards.isEmpty()) {
+            return;
+        }
+        int prevCumulativeTickets = 0;
+        for (Map.Entry<Integer, Integer> reward : new TreeMap<>(attendanceRewards).entrySet()) {
+            Integer attendedDays = reward.getKey();
+            Integer cumulativeTickets = reward.getValue();
+            if (attendedDays == null || attendedDays < 1
+                    || cumulativeTickets == null || cumulativeTickets < 0
+                    || cumulativeTickets < prevCumulativeTickets) {
+                throw AppEventInvalidAttendanceRewardsException.EXCEPTION;
+            }
+            prevCumulativeTickets = cumulativeTickets;
         }
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AttendanceEventService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AttendanceEventService.java
@@ -1,0 +1,110 @@
+package com.storix.domain.domains.event.service;
+
+import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
+import com.storix.domain.domains.event.adaptor.AttendanceCheckAdaptor;
+import com.storix.domain.domains.event.domain.AppEvent;
+import com.storix.domain.domains.event.dto.AttendanceCheckInResponse;
+import com.storix.domain.domains.event.dto.AttendanceStatusResponse;
+import com.storix.domain.domains.event.exception.AttendanceAlreadyCheckedInException;
+import com.storix.domain.domains.event.exception.AttendanceEventNotActiveException;
+import com.storix.domain.domains.event.exception.AttendanceEventNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceEventService {
+
+    // 이벤트에 지급표를 지정하지 않았을 때 사용하는 기본값
+    // 누적 출석일 → 누적 지급 응모권 (3~6일 1개, 7~11일 2개, 12일 5개)
+    private static final NavigableMap<Integer, Integer> DEFAULT_TICKET_TOTALS_BY_ATTENDED_DAYS =
+            new TreeMap<>(Map.of(3, 1, 7, 2, 12, 5));
+
+    private final AppEventAdaptor appEventAdaptor;
+    private final AttendanceCheckAdaptor attendanceCheckAdaptor;
+
+    @Transactional(readOnly = true)
+    public AttendanceStatusResponse getStatus(Long appEventId, Long userId, LocalDateTime now) {
+        AppEvent event = resolveEvent(appEventId);
+        LocalDate today = now.toLocalDate();
+        NavigableMap<Integer, Integer> schedule = rewardScheduleOf(event);
+        List<LocalDate> attendedDates = attendanceCheckAdaptor.findAttendedDates(event.getId(), userId);
+        return AttendanceStatusResponse.builder()
+                .appEventId(event.getId())
+                .eventStartDate(startDateOf(event))
+                .eventEndDate(endDateOf(event))
+                .attendedDates(attendedDates)
+                .totalAttendedDays(attendedDates.size())
+                .attendedToday(attendedDates.contains(today))
+                .issuedTickets(issuedTicketsFor(schedule, attendedDates.size()))
+                .eventActive(isActiveOn(event, now))
+                .build();
+    }
+
+    @Transactional
+    public AttendanceCheckInResponse checkIn(Long appEventId, Long userId, LocalDateTime now) {
+        AppEvent event = resolveEvent(appEventId);
+        if (!isActiveOn(event, now)) {
+            throw AttendanceEventNotActiveException.EXCEPTION;
+        }
+        LocalDate today = now.toLocalDate();
+        if (!attendanceCheckAdaptor.insertIfAbsent(event.getId(), userId, today)) {
+            throw AttendanceAlreadyCheckedInException.EXCEPTION;
+        }
+        NavigableMap<Integer, Integer> schedule = rewardScheduleOf(event);
+        int totalAttendedDays = Math.toIntExact(attendanceCheckAdaptor.countAttendedDays(event.getId(), userId));
+        int issuedTickets = issuedTicketsFor(schedule, totalAttendedDays);
+        return AttendanceCheckInResponse.builder()
+                .attendedDate(today)
+                .totalAttendedDays(totalAttendedDays)
+                .newlyIssuedTickets(issuedTickets - issuedTicketsFor(schedule, totalAttendedDays - 1))
+                .issuedTickets(issuedTickets)
+                .build();
+    }
+
+    private AppEvent resolveEvent(Long appEventId) {
+        if (appEventId == null || appEventId <= 0) {
+            throw AttendanceEventNotFoundException.EXCEPTION;
+        }
+        return appEventAdaptor.findOptionalById(appEventId)
+                .orElseThrow(() -> AttendanceEventNotFoundException.EXCEPTION);
+    }
+
+    private boolean isActiveOn(AppEvent event, LocalDateTime now) {
+        return !now.isBefore(event.getStartAt()) && now.isBefore(event.getEndAt());
+    }
+
+    private static LocalDate startDateOf(AppEvent event) {
+        return event.getStartAt().toLocalDate();
+    }
+
+    // end_at이 자정(다음 날 00:00, exclusive)으로 저장된 경우 마지막 출석 가능일은 그 전날
+    private static LocalDate endDateOf(AppEvent event) {
+        LocalDateTime endAt = event.getEndAt();
+        return endAt.toLocalTime().equals(LocalTime.MIDNIGHT)
+                ? endAt.toLocalDate().minusDays(1)
+                : endAt.toLocalDate();
+    }
+
+    // 이벤트에 지급표가 지정돼 있으면 그것을, 없으면 기본 지급표를 사용한다
+    private static NavigableMap<Integer, Integer> rewardScheduleOf(AppEvent event) {
+        Map<Integer, Integer> configured = event.getAttendanceRewards();
+        return (configured == null || configured.isEmpty())
+                ? DEFAULT_TICKET_TOTALS_BY_ATTENDED_DAYS
+                : new TreeMap<>(configured);
+    }
+
+    private static int issuedTicketsFor(NavigableMap<Integer, Integer> schedule, int totalAttendedDays) {
+        Map.Entry<Integer, Integer> reached = schedule.floorEntry(totalAttendedDays);
+        return reached == null ? 0 : reached.getValue();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/PopupDismissService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/PopupDismissService.java
@@ -20,11 +20,17 @@ public class PopupDismissService {
         popupDismissAdaptor.upsertForToday(userId, popupId, today);
     }
 
+    // '다시 보지 않기' - 노출 기간 내내 미노출
+    @Transactional
+    public void dismissForever(Long userId, Long popupId, LocalDate today) {
+        popupDismissAdaptor.upsertNeverShow(userId, popupId, today);
+    }
+
     @Transactional(readOnly = true)
     public boolean isSuppressed(Long userId, Long popupId, PopupExposurePolicy policy, LocalDate today) {
         return switch (policy) {
-            case ALWAYS_DURING_PERIOD -> false;                                             // 닫기 버튼만 - 억제 없이 기간 내 항상 노출
-            case ONCE_PER_DAY -> popupDismissAdaptor.isDismissedOn(userId, popupId, today); // 오늘 dismiss 했으면 숨김
+            case ALWAYS_DURING_PERIOD -> popupDismissAdaptor.isPermanentlyDismissed(userId, popupId); // 닫기 버튼만 - '다시 보지 않기'한 유저만 숨김
+            case ONCE_PER_DAY -> popupDismissAdaptor.isSuppressedOn(userId, popupId, today);          // 오늘 dismiss 또는 영구 dismiss 시 숨김
         };
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/service/ProfileService.java
@@ -10,6 +10,7 @@ import com.storix.domain.domains.user.domain.Title;
 import com.storix.domain.domains.user.domain.TitleStage;
 import com.storix.domain.domains.user.domain.User;
 import com.storix.domain.domains.user.exception.me.ProfileForbiddenNicknameException;
+import com.storix.domain.domains.user.exception.me.ProfileNicknameBannedWordException;
 import com.storix.domain.domains.works.domain.Genre;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -96,10 +97,13 @@ public class ProfileService {
         return nickName;
     }
 
-    // 금칙어 검증
+    // 닉네임 금칙어/예약어 검증
     private void validateNicknameNotBanned(String nickName) {
-        if (bannedWordAdaptor.containsBannedWord(nickName)) {
+        if (bannedWordAdaptor.containsAdminKeyword(nickName)) {
             throw ProfileForbiddenNicknameException.EXCEPTION;
+        }
+        if (bannedWordAdaptor.containsBannedWord(nickName)) {
+            throw ProfileNicknameBannedWordException.EXCEPTION;
         }
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/exception/InvalidTitleAdminKeywordException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/exception/InvalidTitleAdminKeywordException.java
@@ -1,0 +1,13 @@
+package com.storix.domain.domains.topicroom.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class InvalidTitleAdminKeywordException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new InvalidTitleAdminKeywordException();
+
+    private InvalidTitleAdminKeywordException() {
+        super(ErrorCode.TOPIC_ROOM_ADMIN_KEYWORD_TITLE);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -212,6 +212,10 @@ public class TopicRoomService implements TopicRoomUseCase {
     @Transactional
     public Long createRoom(Long userId, TopicRoomCreateRequestDto request) {
 
+        // 제목 예약어/금칙어 검증
+        if (bannedWordAdaptor.containsAdminKeyword(request.getTopicRoomName())) {
+            throw InvalidTitleAdminKeywordException.EXCEPTION;
+        }
         if (bannedWordAdaptor.containsBannedWord(request.getTopicRoomName())) {
             throw InvalidTitleException.EXCEPTION;
         }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/exception/me/ProfileNicknameBannedWordException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/exception/me/ProfileNicknameBannedWordException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.user.exception.me;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class ProfileNicknameBannedWordException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new ProfileNicknameBannedWordException();
+
+    private ProfileNicknameBannedWordException() { super(ErrorCode.PROFILE_NICKNAME_BANNED_WORD); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/user/service/AuthService.java
@@ -20,6 +20,7 @@ import com.storix.domain.domains.user.dto.ReaderSignUpData;
 import com.storix.domain.domains.user.dto.ValidAuthDTO;
 import com.storix.domain.domains.user.exception.me.DuplicateUserException;
 import com.storix.domain.domains.user.exception.me.ProfileForbiddenNicknameException;
+import com.storix.domain.domains.user.exception.me.ProfileNicknameBannedWordException;
 import com.storix.common.utils.STORIXStatic;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.domain.domains.user.adaptor.TokenAdaptor;
@@ -151,10 +152,13 @@ public class AuthService {
         return authUserDetails;
     }
 
-    // 독자 닉네임 중복 체크
+    // 독자 닉네임 중복/금칙어/예약어 체크
     public void validNickname(String nickName) {
-        if (bannedWordAdaptor.containsBannedWord(nickName)) {
+        if (bannedWordAdaptor.containsAdminKeyword(nickName)) {
             throw ProfileForbiddenNicknameException.EXCEPTION;
+        }
+        if (bannedWordAdaptor.containsBannedWord(nickName)) {
+            throw ProfileNicknameBannedWordException.EXCEPTION;
         }
         userAdaptor.checkNicknameDuplicate(nickName);
     }

--- a/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AppEventServiceTest.java
+++ b/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AppEventServiceTest.java
@@ -5,6 +5,7 @@ import com.storix.domain.domains.event.domain.AppEvent;
 import com.storix.domain.domains.event.domain.AppEventStatus;
 import com.storix.domain.domains.event.dto.AppEventCommand;
 import com.storix.domain.domains.event.dto.AppEventResponse;
+import com.storix.domain.domains.event.exception.AppEventInvalidAttendanceRewardsException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodException;
 import com.storix.domain.domains.event.exception.AppEventNameRequiredException;
 import com.storix.domain.domains.event.exception.AppEventPeriodRequiredException;
@@ -19,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,7 +51,7 @@ class AppEventServiceTest {
     private AppEventService appEventService;
 
     private AppEventCommand command(LocalDateTime startAt, LocalDateTime endAt) {
-        return new AppEventCommand("앱 출시 이벤트", "설명", startAt, endAt, false, Set.of());
+        return new AppEventCommand("앱 출시 이벤트", "설명", startAt, endAt, false, Set.of(), Map.of());
     }
 
     private AppEvent appEvent(LocalDateTime startAt, LocalDateTime endAt) {
@@ -86,7 +88,7 @@ class AppEventServiceTest {
         @DisplayName("이름이 비면 예외 - 저장하지 않는다")
         void reject_blank_name() {
             LocalDateTime start = LocalDateTime.now().plusDays(1);
-            AppEventCommand cmd = new AppEventCommand("  ", "설명", start, start.plusDays(1), false, Set.of());
+            AppEventCommand cmd = new AppEventCommand("  ", "설명", start, start.plusDays(1), false, Set.of(), Map.of());
 
             assertThatThrownBy(() -> appEventService.create(cmd, ADMIN_ID))
                     .isInstanceOf(AppEventNameRequiredException.class);
@@ -107,6 +109,46 @@ class AppEventServiceTest {
             LocalDateTime start = LocalDateTime.now().plusDays(5);
             assertThatThrownBy(() -> appEventService.create(command(start, start), ADMIN_ID))
                     .isInstanceOf(AppEventInvalidPeriodException.class);
+            verify(appEventAdaptor, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("출석 지급표를 지정하면 그대로 저장한다")
+        void create_with_attendance_rewards() {
+            LocalDateTime start = LocalDateTime.now().plusDays(1);
+            LocalDateTime end = start.plusDays(20);
+            Map<Integer, Integer> rewards = Map.of(5, 1, 10, 3, 20, 10);
+            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", start, end, false, Set.of(), rewards);
+            given(appEventAdaptor.save(any(AppEvent.class))).willAnswer(inv -> inv.getArgument(0));
+
+            AppEventResponse saved = appEventService.create(cmd, ADMIN_ID);
+
+            assertThat(saved.attendanceRewards()).containsExactlyInAnyOrderEntriesOf(rewards);
+        }
+
+        @Test
+        @DisplayName("누적 응모권이 출석일 증가에 따라 감소하면 예외 - 저장하지 않는다")
+        void reject_non_monotonic_rewards() {
+            LocalDateTime start = LocalDateTime.now().plusDays(1);
+            LocalDateTime end = start.plusDays(20);
+            Map<Integer, Integer> rewards = Map.of(5, 3, 10, 1); // 10일차 누적이 5일차보다 작음
+            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", start, end, false, Set.of(), rewards);
+
+            assertThatThrownBy(() -> appEventService.create(cmd, ADMIN_ID))
+                    .isInstanceOf(AppEventInvalidAttendanceRewardsException.class);
+            verify(appEventAdaptor, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("출석일이 1 미만이면 예외 - 저장하지 않는다")
+        void reject_non_positive_day() {
+            LocalDateTime start = LocalDateTime.now().plusDays(1);
+            LocalDateTime end = start.plusDays(20);
+            Map<Integer, Integer> rewards = Map.of(0, 1); // 출석일 0
+            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", start, end, false, Set.of(), rewards);
+
+            assertThatThrownBy(() -> appEventService.create(cmd, ADMIN_ID))
+                    .isInstanceOf(AppEventInvalidAttendanceRewardsException.class);
             verify(appEventAdaptor, never()).save(any());
         }
     }

--- a/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AttendanceEventServiceTest.java
+++ b/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AttendanceEventServiceTest.java
@@ -1,0 +1,236 @@
+package com.storix.domain.domains.event.service;
+
+import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
+import com.storix.domain.domains.event.adaptor.AttendanceCheckAdaptor;
+import com.storix.domain.domains.event.domain.AppEvent;
+import com.storix.domain.domains.event.dto.AttendanceCheckInResponse;
+import com.storix.domain.domains.event.dto.AttendanceStatusResponse;
+import com.storix.domain.domains.event.exception.AttendanceAlreadyCheckedInException;
+import com.storix.domain.domains.event.exception.AttendanceEventNotActiveException;
+import com.storix.domain.domains.event.exception.AttendanceEventNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[출석 이벤트] 도메인 서비스 - 현황 조회/출석 체크/응모권 지급")
+class AttendanceEventServiceTest {
+
+    private static final Long EVENT_ID = 100L;
+    private static final Long USER_ID = 7L;
+    private static final LocalDate START = LocalDate.of(2026, 7, 20);
+    private static final LocalDate END = LocalDate.of(2026, 8, 2);
+
+    @Mock
+    private AppEventAdaptor appEventAdaptor;
+
+    @Mock
+    private AttendanceCheckAdaptor attendanceCheckAdaptor;
+
+    @InjectMocks
+    private AttendanceEventService attendanceEventService;
+
+    private AppEvent event(LocalDateTime startAt, LocalDateTime endAt) {
+        AppEvent e = AppEvent.builder()
+                .name("14일 출석 이벤트").description("설명")
+                .startAt(startAt).endAt(endAt)
+                .hasWinner(true)
+                .build();
+        ReflectionTestUtils.setField(e, "id", EVENT_ID);
+        return e;
+    }
+
+    private AppEvent defaultEvent() {
+        return event(START.atStartOfDay(), END.atTime(23, 59));
+    }
+
+    private AppEvent eventWithRewards(Map<Integer, Integer> rewards) {
+        AppEvent e = AppEvent.builder()
+                .name("커스텀 출석 이벤트").description("설명")
+                .startAt(START.atStartOfDay()).endAt(END.atTime(23, 59))
+                .hasWinner(true)
+                .attendanceRewards(rewards)
+                .build();
+        ReflectionTestUtils.setField(e, "id", EVENT_ID);
+        return e;
+    }
+
+    @Nested
+    @DisplayName("getStatus - 출석 현황 조회")
+    class GetStatus {
+
+        @Test
+        @DisplayName("출석 날짜/오늘 출석 여부/응모권 수/진행 여부를 한 번에 반환한다")
+        void status_ok() {
+            LocalDate today = START.plusDays(3);
+            List<LocalDate> attended = List.of(START, START.plusDays(1), START.plusDays(3));
+            given(appEventAdaptor.findOptionalById(EVENT_ID)).willReturn(Optional.of(defaultEvent()));
+            given(attendanceCheckAdaptor.findAttendedDates(EVENT_ID, USER_ID)).willReturn(attended);
+
+            AttendanceStatusResponse status = attendanceEventService.getStatus(EVENT_ID, USER_ID, today.atStartOfDay());
+
+            assertThat(status.appEventId()).isEqualTo(EVENT_ID);
+            assertThat(status.eventStartDate()).isEqualTo(START);
+            assertThat(status.eventEndDate()).isEqualTo(END);
+            assertThat(status.attendedDates()).containsExactlyElementsOf(attended);
+            assertThat(status.totalAttendedDays()).isEqualTo(3);
+            assertThat(status.attendedToday()).isTrue();
+            assertThat(status.issuedTickets()).isEqualTo(1); // 3일 달성
+            assertThat(status.eventActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이벤트 기간 외에는 eventActive=false 로 반환한다")
+        void status_inactive_after_end() {
+            LocalDate today = END.plusDays(1);
+            given(appEventAdaptor.findOptionalById(EVENT_ID)).willReturn(Optional.of(defaultEvent()));
+            given(attendanceCheckAdaptor.findAttendedDates(EVENT_ID, USER_ID)).willReturn(List.of());
+
+            AttendanceStatusResponse status = attendanceEventService.getStatus(EVENT_ID, USER_ID, today.atStartOfDay());
+
+            assertThat(status.eventActive()).isFalse();
+            assertThat(status.attendedToday()).isFalse();
+            assertThat(status.issuedTickets()).isZero();
+        }
+
+        @Test
+        @DisplayName("end_at이 자정(exclusive)이면 종료일은 그 전날이다")
+        void status_end_at_midnight() {
+            given(appEventAdaptor.findOptionalById(EVENT_ID))
+                    .willReturn(Optional.of(event(START.atStartOfDay(), END.plusDays(1).atStartOfDay())));
+            given(attendanceCheckAdaptor.findAttendedDates(EVENT_ID, USER_ID)).willReturn(List.of());
+
+            AttendanceStatusResponse status = attendanceEventService.getStatus(EVENT_ID, USER_ID, END.atStartOfDay());
+
+            assertThat(status.eventEndDate()).isEqualTo(END);
+            assertThat(status.eventActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이벤트가 설정되지 않았거나(0) 존재하지 않으면 404를 던진다")
+        void status_event_not_found() {
+            assertThatThrownBy(() -> attendanceEventService.getStatus(0L, USER_ID, START.atStartOfDay()))
+                    .isInstanceOf(AttendanceEventNotFoundException.class);
+
+            given(appEventAdaptor.findOptionalById(EVENT_ID)).willReturn(Optional.empty());
+            assertThatThrownBy(() -> attendanceEventService.getStatus(EVENT_ID, USER_ID, START.atStartOfDay()))
+                    .isInstanceOf(AttendanceEventNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("checkIn - 출석 체크")
+    class CheckIn {
+
+        @Test
+        @DisplayName("정상 출석 시 누적 출석일과 응모권 정보를 반환한다 (마일스톤 미달성)")
+        void checkIn_ok_no_milestone() {
+            LocalDate today = START.plusDays(1);
+            given(appEventAdaptor.findOptionalById(EVENT_ID)).willReturn(Optional.of(defaultEvent()));
+            given(attendanceCheckAdaptor.insertIfAbsent(EVENT_ID, USER_ID, today)).willReturn(true);
+            given(attendanceCheckAdaptor.countAttendedDays(EVENT_ID, USER_ID)).willReturn(2L);
+
+            AttendanceCheckInResponse response = attendanceEventService.checkIn(EVENT_ID, USER_ID, today.atStartOfDay());
+
+            assertThat(response.attendedDate()).isEqualTo(today);
+            assertThat(response.totalAttendedDays()).isEqualTo(2);
+            assertThat(response.newlyIssuedTickets()).isZero();
+            assertThat(response.issuedTickets()).isZero();
+        }
+
+        @Test
+        @DisplayName("7일 달성 시 누적 응모권이 2개가 된다 (+1)")
+        void checkIn_seven_days_issues_ticket() {
+            LocalDate today = START.plusDays(6);
+            given(appEventAdaptor.findOptionalById(EVENT_ID)).willReturn(Optional.of(defaultEvent()));
+            given(attendanceCheckAdaptor.insertIfAbsent(EVENT_ID, USER_ID, today)).willReturn(true);
+            given(attendanceCheckAdaptor.countAttendedDays(EVENT_ID, USER_ID)).willReturn(7L);
+
+            AttendanceCheckInResponse response = attendanceEventService.checkIn(EVENT_ID, USER_ID, today.atStartOfDay());
+
+            assertThat(response.newlyIssuedTickets()).isEqualTo(1);
+            assertThat(response.issuedTickets()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("12일 달성 시 누적 응모권이 5개가 된다 (+3)")
+        void checkIn_twelve_days_issues_tickets() {
+            LocalDate today = START.plusDays(11);
+            given(appEventAdaptor.findOptionalById(EVENT_ID)).willReturn(Optional.of(defaultEvent()));
+            given(attendanceCheckAdaptor.insertIfAbsent(EVENT_ID, USER_ID, today)).willReturn(true);
+            given(attendanceCheckAdaptor.countAttendedDays(EVENT_ID, USER_ID)).willReturn(12L);
+
+            AttendanceCheckInResponse response = attendanceEventService.checkIn(EVENT_ID, USER_ID, today.atStartOfDay());
+
+            assertThat(response.newlyIssuedTickets()).isEqualTo(3);
+            assertThat(response.issuedTickets()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("이벤트에 지정된 지급표를 사용해 응모권을 계산한다 (기본표 대신)")
+        void checkIn_uses_event_reward_schedule() {
+            // 이벤트가 5일차부터 3개 지급하도록 지정 → 기본표(3일 1개)와 다른 결과
+            LocalDate today = START.plusDays(4);
+            given(appEventAdaptor.findOptionalById(EVENT_ID))
+                    .willReturn(Optional.of(eventWithRewards(Map.of(5, 3, 10, 8))));
+            given(attendanceCheckAdaptor.insertIfAbsent(EVENT_ID, USER_ID, today)).willReturn(true);
+            given(attendanceCheckAdaptor.countAttendedDays(EVENT_ID, USER_ID)).willReturn(5L);
+
+            AttendanceCheckInResponse response = attendanceEventService.checkIn(EVENT_ID, USER_ID, today.atStartOfDay());
+
+            assertThat(response.newlyIssuedTickets()).isEqualTo(3); // 4일차 0개 → 5일차 3개
+            assertThat(response.issuedTickets()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("이미 출석한 날 재요청 시 409를 던진다")
+        void checkIn_duplicate() {
+            LocalDate today = START.plusDays(1);
+            given(appEventAdaptor.findOptionalById(EVENT_ID)).willReturn(Optional.of(defaultEvent()));
+            given(attendanceCheckAdaptor.insertIfAbsent(EVENT_ID, USER_ID, today)).willReturn(false);
+
+            assertThatThrownBy(() -> attendanceEventService.checkIn(EVENT_ID, USER_ID, today.atStartOfDay()))
+                    .isInstanceOf(AttendanceAlreadyCheckedInException.class);
+        }
+
+        @Test
+        @DisplayName("이벤트 기간 외 출석 요청 시 400을 던지고 출석을 기록하지 않는다")
+        void checkIn_not_active() {
+            LocalDate today = START.minusDays(1);
+            given(appEventAdaptor.findOptionalById(EVENT_ID)).willReturn(Optional.of(defaultEvent()));
+
+            assertThatThrownBy(() -> attendanceEventService.checkIn(EVENT_ID, USER_ID, today.atStartOfDay()))
+                    .isInstanceOf(AttendanceEventNotActiveException.class);
+            verify(attendanceCheckAdaptor, never()).insertIfAbsent(EVENT_ID, USER_ID, today);
+        }
+
+        @Test
+        @DisplayName("시작 시각 이전에는 같은 날이어도 400을 던진다 (시:분 경계)")
+        void checkIn_before_start_time() {
+            AppEvent startsAtThreePm = event(START.atTime(15, 0), END.atTime(23, 59));
+            given(appEventAdaptor.findOptionalById(EVENT_ID)).willReturn(Optional.of(startsAtThreePm));
+
+            LocalDateTime beforeStart = START.atTime(9, 0);
+            assertThatThrownBy(() -> attendanceEventService.checkIn(EVENT_ID, USER_ID, beforeStart))
+                    .isInstanceOf(AttendanceEventNotActiveException.class);
+            verify(attendanceCheckAdaptor, never()).insertIfAbsent(EVENT_ID, USER_ID, START);
+        }
+    }
+}

--- a/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/PopupDismissServiceTest.java
+++ b/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/PopupDismissServiceTest.java
@@ -14,10 +14,9 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("[이벤트 팝업] 오늘 다시 안 보기 - 원자적 upsert / 조회")
+@DisplayName("[이벤트 팝업] 오늘 다시 안 보기 / 다시 보지 않기 - 원자적 upsert / 조회")
 class PopupDismissServiceTest {
 
     private static final Long USER_ID = 7L;
@@ -39,17 +38,28 @@ class PopupDismissServiceTest {
     }
 
     @Test
-    @DisplayName("ONCE_PER_DAY - 오늘 dismiss 했으면 숨김")
+    @DisplayName("다시 보지 않기는 영구 upsert 에 위임한다")
+    void dismiss_forever_delegates_to_never_show_upsert() {
+        popupDismissService.dismissForever(USER_ID, POPUP_ID, TODAY);
+
+        verify(popupDismissAdaptor).upsertNeverShow(USER_ID, POPUP_ID, TODAY);
+    }
+
+    @Test
+    @DisplayName("ONCE_PER_DAY - 오늘 dismiss 또는 영구 dismiss 했으면 숨김")
     void suppressed_once_per_day() {
-        given(popupDismissAdaptor.isDismissedOn(USER_ID, POPUP_ID, TODAY)).willReturn(true);
+        given(popupDismissAdaptor.isSuppressedOn(USER_ID, POPUP_ID, TODAY)).willReturn(true);
 
         assertThat(popupDismissService.isSuppressed(USER_ID, POPUP_ID, PopupExposurePolicy.ONCE_PER_DAY, TODAY)).isTrue();
     }
 
     @Test
-    @DisplayName("ALWAYS_DURING_PERIOD - 닫기만, dismiss 조회 없이 항상 노출")
-    void never_suppressed_when_always() {
+    @DisplayName("ALWAYS_DURING_PERIOD - 영구 dismiss 한 유저만 숨김, 그 외 항상 노출")
+    void suppressed_when_always_only_if_permanent() {
+        given(popupDismissAdaptor.isPermanentlyDismissed(USER_ID, POPUP_ID)).willReturn(false);
         assertThat(popupDismissService.isSuppressed(USER_ID, POPUP_ID, PopupExposurePolicy.ALWAYS_DURING_PERIOD, TODAY)).isFalse();
-        verifyNoInteractions(popupDismissAdaptor);
+
+        given(popupDismissAdaptor.isPermanentlyDismissed(USER_ID, POPUP_ID)).willReturn(true);
+        assertThat(popupDismissService.isSuppressed(USER_ID, POPUP_ID, PopupExposurePolicy.ALWAYS_DURING_PERIOD, TODAY)).isTrue();
     }
 }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] PR #145의 커밋 cherry-pick (출석 이벤트 기능 추가)
> - [x] release/v2.4.10 구성

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #145

## 🖇️ 기타
**DDL 은 자동 반영됩니다.** `ddl-auto: update` 로 `event_attendance_checks`, `app_event_attendance_rewards` 테이블이 배포 시 생성됩니다. 수동 작업은 없습니다.

**출석 이벤트 API 는 환경변수 설정 전까지 동작하지 않습니다.**

```
attendance-event.app-event-id
```

미설정 시 기본값 `0` 으로 404 를 반환합니다. 이벤트를 오픈하려면 관리자 페이지에서 앱 이벤트를 생성한 뒤 해당 id 를 `.env` 에 넣고 컨테이너를 재생성해야 합니다.

**cherry-pick 방식**

PR #145 의 개별 커밋 중 `1e33b21` 이 develop 을 가져온 머지 커밋이며, `AppEventResponse` 의 `Set.copyOf` 충돌 해결이 그 안에 있습니다. 개별 cherry-pick 시 같은 충돌이 재발하므로 머지 커밋 `3dc0bfe` 을 `-m 1` 로 적용했습니다. 적용 후 `git diff origin/develop` 이 비어 있음을 확인했습니다.