### PR TITLE
Fix: [작품] enum 컬럼 값 누락 시 조회 500 방어

### DIFF
--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/dto/BoardWorksInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/feed/dto/BoardWorksInfo.java
@@ -27,8 +27,8 @@ public record BoardWorksInfo(
                 works.thumbnailUrl(),
                 works.worksName(),
                 works.artistName(),
-                works.worksType().getDbValue(),
-                works.genre().getDbValue(),
+                works.worksType() != null ? works.worksType().getDbValue() : null,
+                works.genre() != null ? works.genre().getDbValue() : null,
                 hashtags
         );
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/library/dto/StandardLibraryWorksInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/library/dto/StandardLibraryWorksInfo.java
@@ -28,12 +28,12 @@ public record StandardLibraryWorksInfo(
                 worksInfo.worksName(),
                 artistName,
                 worksInfo.thumbnailUrl(),
-                worksInfo.worksType().getDbValue(),
-                worksInfo.genre().getDbValue(),
+                worksInfo.worksType() != null ? worksInfo.worksType().getDbValue() : null,
+                worksInfo.genre() != null ? worksInfo.genre().getDbValue() : null,
 
                 // 리뷰 정보
                 reviewId,
-                rating.getDbValue()
+                rating != null ? rating.getDbValue() : null
         );
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/dto/FavoriteWorksWithReviewInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/profile/dto/FavoriteWorksWithReviewInfo.java
@@ -22,7 +22,7 @@ public record FavoriteWorksWithReviewInfo(
                 base.worksName(),
                 base.artistName(),
                 base.thumbnailUrl(),
-                base.worksType().getDbValue(),
+                base.worksType() != null ? base.worksType().getDbValue() : null,
                 isReviewed,
                 rating
         );

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/adaptor/WorksPersistenceAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/adaptor/WorksPersistenceAdaptor.java
@@ -11,6 +11,7 @@ import com.storix.domain.domains.works.repository.WorksRepository;
 import com.storix.domain.domains.plus.exception.WorksNotExistException;
 import com.storix.domain.domains.works.exception.UnknownWorksException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -24,6 +25,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class WorksPersistenceAdaptor implements LoadWorksPort {
@@ -119,6 +121,7 @@ public class WorksPersistenceAdaptor implements LoadWorksPort {
         }
 
         List<WorksInfo> worksInfos = worksRepository.findWorksInfoByIds(worksIds);
+        worksInfos.forEach(this::warnIfEnumMissing);
 
         return worksInfos.stream()
                 .collect(Collectors.toMap(
@@ -134,7 +137,17 @@ public class WorksPersistenceAdaptor implements LoadWorksPort {
         if (worksInfo.isEmpty()) {
             throw UnknownWorksException.EXCEPTION;
         }
+        warnIfEnumMissing(worksInfo.get());
         return worksInfo.get();
+    }
+
+    private void warnIfEnumMissing(WorksInfo works) {
+        if (works.worksType() != null && works.genre() != null) return;
+        log.atWarn()
+                .addKeyValue("worksId", works.worksId())
+                .addKeyValue("worksTypeMissing", works.worksType() == null)
+                .addKeyValue("genreMissing", works.genre() == null)
+                .log(">>> [Works] enum 컬럼 값 없음");
     }
 
     // 관심 작품 리스트 조회 용

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/dto/StandardWorksInfo.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/dto/StandardWorksInfo.java
@@ -18,8 +18,8 @@ public record StandardWorksInfo(
                 worksInfo.thumbnailUrl(),
                 worksInfo.worksName(),
                 worksInfo.artistName(),
-                worksInfo.worksType().getDbValue(),
-                worksInfo.genre().getDbValue()
+                worksInfo.worksType() != null ? worksInfo.worksType().getDbValue() : null,
+                worksInfo.genre() != null ? worksInfo.genre().getDbValue() : null
         );
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/dto/WorksDetailResponseDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/dto/WorksDetailResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
+import java.util.Objects;
 
 @Builder
 public record WorksDetailResponseDto(
@@ -32,16 +33,18 @@ public record WorksDetailResponseDto(
         return WorksDetailResponseDto.builder()
                 .worksId(works.getId())
                 .worksName(works.getWorksName())
-                .worksType(works.getWorksType().getDbValue())
+                .worksType(works.getWorksType() != null ? works.getWorksType().getDbValue() : null)
                 .thumbnailUrl(works.getThumbnailUrl())
                 .author(works.getAuthor())
                 .illustrator(resolveIllustrator(works.getAuthor(), works.getIllustrator()))
                 .originalAuthor(works.getOriginalAuthor())
-                .genre(works.getGenre().getDbValue())
+                .genre(works.getGenre() != null ? works.getGenre().getDbValue() : null)
                 .platforms(works.getPlatforms().stream()
-                        .map(wp -> wp.getPlatform().getDbValue())
+                        .map(WorksPlatform::getPlatform)
+                        .filter(Objects::nonNull)
+                        .map(Platform::getDbValue)
                         .toList())
-                .ageClassification(works.getAgeClassification().getDbValue())
+                .ageClassification(works.getAgeClassification() != null ? works.getAgeClassification().getDbValue() : null)
                 .avgRating(roundAvgRating(works.getAvgRating()))
                 .reviewCount(reviewCount)
                 .description(works.getDescription())

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/works/service/WorksService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/works/service/WorksService.java
@@ -5,14 +5,17 @@ import com.storix.domain.domains.topicroom.application.port.LoadTopicRoomPort;
 import com.storix.domain.domains.user.application.port.LoadUserPort;
 import com.storix.domain.domains.works.application.port.LoadWorksPort;
 import com.storix.domain.domains.works.application.usecase.WorksUseCase;
+import com.storix.domain.domains.works.domain.AgeClassification;
 import com.storix.domain.domains.works.domain.Works;
 import com.storix.domain.domains.works.dto.WorksDetailResponseDto;
 import com.storix.domain.domains.topicroom.exception.UnverifiedException;
 import com.storix.domain.domains.user.exception.auth.LoginRequiredException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class WorksService implements WorksUseCase {
@@ -29,8 +32,17 @@ public class WorksService implements WorksUseCase {
 
         Works works = loadWorksPort.findByIdWithHashtags(worksId);
 
+        if (works.getWorksType() == null || works.getGenre() == null || works.getAgeClassification() == null) {
+            log.atWarn()
+                    .addKeyValue("worksId", worksId)
+                    .addKeyValue("worksTypeMissing", works.getWorksType() == null)
+                    .addKeyValue("genreMissing", works.getGenre() == null)
+                    .addKeyValue("ageClassificationMissing", works.getAgeClassification() == null)
+                    .log(">>> [Works] enum 컬럼 값 없음");
+        }
+
         // 18세 이용가 작품인지 확인
-        if ("18세 이용가".equals(works.getAgeClassification().getDbValue())) {
+        if (works.getAgeClassification() == AgeClassification.AGE_18) {
 
             // 비로그인 유저
             if (userId == null) {


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] `getDbValue()` 호출부 중 null 가드가 없던 6개 지점에 방어 추가
> - [x] `WorksService`의 `"18세 이용가".equals(...)` 문자열 비교를 `== AgeClassification.AGE_18` enum 직접 비교로 변경
> - [x] `WorksDetailResponseDto`의 platforms 매핑에서 null 원소 제거
> - [x] worksId를 아는 두 경로에 enum 누락 감지 WARN 로그 추가

### 원인

`GenreConverter`는 컬럼 값이 null이거나 **빈 문자열**이면 null을 반환한다. 엔티티에 `nullable = false`가 걸려 있어도 빈 문자열은 NOT NULL 제약을 통과하므로 이 상태가 만들어진다.

이후 `works.getGenre().getDbValue()` 호출부에서 NPE가 발생했다.

```
java.lang.NullPointerException: Cannot invoke "Genre.getDbValue()"
because the return value of "Works.getGenre()" is null
	at WorksDetailResponseDto.from(WorksDetailResponseDto.java:40)
```

피드 목록은 `findWorksInfoByIds`가 `IN` 절로 작품을 일괄 조회하므로, **작품 한 건이 깨지면 그 페이지 전체가 500**이 된다.

### 수정 지점

| 파일 | 필드 |
|---|---|
| `BoardWorksInfo` | worksType, genre |
| `WorksDetailResponseDto` | worksType, genre, ageClassification, platforms |
| `WorksService` | ageClassification (enum 비교로 변경) |
| `StandardWorksInfo` | worksType, genre |
| `StandardLibraryWorksInfo` | worksType, genre, rating |
| `FavoriteWorksWithReviewInfo` | worksType |

가드 스타일은 기존에 이미 방어돼 있던 `ExplorationWorksResponseDto`, `TopicRoomResponseDto`와 동일한 삼항 패턴으로 맞췄다.

### 로그

가드만 넣으면 데이터가 깨진 사실이 드러나지 않으므로, worksId를 아는 지점에 감지 로그를 추가했다.

- `WorksPersistenceAdaptor` — projection 경로 (피드·라이브러리·프로필·토픽룸)
- `WorksService` — 엔티티 경로 (작품 상세)

```
WARN  >>> [Works] enum 컬럼 값 없음
      worksId=15655 worksTypeMissing=false genreMissing=true
```

컨버터는 컬럼 값만 보고 worksId를 모르므로 로그 위치에서 제외했다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #191 

## 🖇️ 기타
