### PR TITLE
Fix: [Swagger] multipart 파트 Content-Type 및 날짜 example 미반영

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminBannerController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminBannerController.java
@@ -6,6 +6,9 @@ import com.storix.common.payload.CustomResponse;
 import com.storix.domain.domains.event.dto.BannerResponse;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -28,6 +31,9 @@ public class AdminBannerController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이벤트 배너 생성", description = "multipart 요청: 'data'(application/json) 파트에 배너 정보, 'file' 파트에 이미지. 서버가 이미지를 S3 업로드 후 생성합니다. 활성 배너 노출 기간이 겹치면 생성할 수 없습니다.")
+    @RequestBody(content = @Content(
+            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+            encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
     public CustomResponse<BannerResponse> createBanner(
             @AuthenticationPrincipal AuthUserDetails authUser,
             @Valid @RequestPart("data") BannerRequest req,
@@ -55,6 +61,9 @@ public class AdminBannerController {
 
     @PutMapping(value = "/{bannerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이벤트 배너 수정", description = "multipart 요청: 'data' 파트에 배너 정보, 'file' 파트에 새 이미지(선택). 수정 즉시 앱 active 조회 응답에 반영됩니다.")
+    @RequestBody(content = @Content(
+            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+            encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
     public CustomResponse<BannerResponse> updateBanner(
             @PathVariable Long bannerId,
             @Valid @RequestPart("data") BannerRequest req,

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminPopupController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminPopupController.java
@@ -6,6 +6,9 @@ import com.storix.api.domain.event.controller.dto.PopupRequest;
 import com.storix.domain.domains.event.dto.PopupResponse;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -28,6 +31,9 @@ public class AdminPopupController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이벤트 팝업 생성", description = "multipart 요청: 'data'(application/json) 파트에 팝업 정보, 'file' 파트에 이미지. 서버가 이미지를 S3 업로드 후 생성합니다. 활성 팝업 노출 기간이 겹치면 생성할 수 없습니다.")
+    @RequestBody(content = @Content(
+            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+            encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
     public CustomResponse<PopupResponse> createPopup(
             @AuthenticationPrincipal AuthUserDetails authUser,
             @Valid @RequestPart("data") PopupRequest req,
@@ -55,6 +61,9 @@ public class AdminPopupController {
 
     @PutMapping(value = "/{popupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이벤트 팝업 수정", description = "multipart 요청: 'data' 파트에 팝업 정보, 'file' 파트에 새 이미지(선택 - 없으면 기존 이미지 유지). 수정 즉시 앱 active 조회 응답에 반영됩니다.")
+    @RequestBody(content = @Content(
+            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+            encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
     public CustomResponse<PopupResponse> updatePopup(
             @PathVariable Long popupId,
             @Valid @RequestPart("data") PopupRequest req,

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/AppEventRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/AppEventRequest.java
@@ -34,7 +34,7 @@ public record AppEventRequest(
 
         @Schema(
                 description = "이벤트 시작 시각. ATTENDANCE는 00:00, STORY_CARD는 06:00(카드 초기화 시각)에 맞춰야 합니다.",
-                example = "2026-07-01 00:00"
+                example = "2026-07-01 00:00", type = "string"
         )
         @NotNull(message = "이벤트 시작 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
@@ -43,7 +43,7 @@ public record AppEventRequest(
         @Schema(
                 description = "이벤트 종료 시각(exclusive). 시작 시각과 같은 경계에 맞춰야 하며, "
                         + "마지막 참여일의 다음 경계를 넣습니다. (7/31까지 출석 → 2026-08-01 00:00)",
-                example = "2026-08-01 00:00"
+                example = "2026-08-01 00:00", type = "string"
         )
         @NotNull(message = "이벤트 종료 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/BannerRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/BannerRequest.java
@@ -24,12 +24,12 @@ public record BannerRequest(
         @Size(max = 100, message = "배너 제목은 100자 이하여야 합니다.")
         String bannerTitle,
 
-        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00")
+        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00", type = "string")
         @NotNull(message = "노출 시작 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayStartAt,
 
-        @Schema(description = "노출 종료 시각", example = "2026-06-30 23:59")
+        @Schema(description = "노출 종료 시각", example = "2026-06-30 00:00", type = "string")
         @NotNull(message = "노출 종료 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayEndAt

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/PopupRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/PopupRequest.java
@@ -37,12 +37,12 @@ public record PopupRequest(
         @Size(max = 40, message = "CTA 텍스트는 40자 이하여야 합니다.")
         String ctaText,
 
-        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00")
+        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00", type = "string")
         @NotNull(message = "노출 시작 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayStartAt,
 
-        @Schema(description = "노출 종료 시각", example = "2026-06-30 23:59")
+        @Schema(description = "노출 종료 시각", example = "2026-06-30 00:00", type = "string")
         @NotNull(message = "노출 종료 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayEndAt


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] 팝업·배너 생성/수정 4개 엔드포인트에 `@Encoding` 추가해 `data` 파트를 `application/json` 으로 전송하도록 수정
> - [x] 요청 DTO 날짜 필드 6곳에 `type = "string"` 지정해 `@Schema` example 이 표시되도록 수정
> - [x] 팝업·배너 노출 종료 시각 example 을 `23:59` → `00:00` 으로 정리

### 1. multipart 파트 Content-Type
Swagger UI 에서 `POST /api/v1/admin/popups` 호출 시 `HttpMediaTypeNotSupportedException: Content-Type 'application/octet-stream' is not supported` 로 실패했습니다.

`@RequestPart("data")` JSON 파트에 Content-Type 이 붙지 않아 서블릿이 `application/octet-stream` 으로 처리하고 Jackson 컨버터가 거부한 것입니다. springdoc 이 스펙에 파트별 미디어타입을 내려주지 않아 Swagger UI 가 타입 없이 전송한 게 원인이라, `@Encoding` 으로 명시했습니다.

적용: `AdminPopupController` 생성/수정, `AdminBannerController` 생성/수정

### 2. 날짜 example 미반영
`LocalDateTime` 이 스펙에 `format: date-time` 으로 나가서, `2026-07-01 00:00` 이 RFC 3339 가 아니라는 이유로 버려지고 Swagger 가 문서를 연 시각 기준 ISO 값을 채우고 있었습니다. `@JsonFormat` 은 Jackson 런타임에만 적용되고 스키마 format 은 바꾸지 못합니다.

`type = "string"` 으로 date-time 추론을 끊어 적어둔 example 이 그대로 표시되게 했습니다. 기존에 `AdminNotificationRequest.scheduledAt` 만 이 방식으로 되어 있어 그 필드만 정상 표시되던 상태라, 같은 패턴으로 맞췄습니다.

적용: `AppEventRequest`, `PopupRequest`, `BannerRequest`

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)
- Swagger UI 실제 렌더링 확인이 필요합니다. `@Content` 에 `schema` 를 명시하지 않아 자동 생성 스키마가 유지되는지(= `file` 이 파일 선택 버튼으로 뜨는지) 확인 부탁드립니다. 텍스트 입력으로 뜨면 `schema` 를 함께 지정해야 합니다.
- 팝업·배너 종료 시각 example 을 `2026-06-30 00:00` 으로 두었는데, `AppEventRequest.endAt` 처럼 exclusive 경계(`2026-07-01 00:00`)로 맞추는 게 나을지 의견 주세요.

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #197

## 🖇️ 기타