### PR TITLE
Fix: [앱 이벤트] 당첨자 확정 전후 데이터 변경 차단

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminAppEventController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminAppEventController.java
@@ -55,7 +55,13 @@ public class AdminAppEventController {
     }
 
     @PutMapping("/{appEventId}")
-    @Operation(summary = "앱 이벤트 수정")
+    @Operation(
+            summary = "앱 이벤트 수정",
+            description = """
+                    당첨자가 확정된 이벤트는 추첨 근거가 되는 값(eventType, startAt, endAt, hasWinner, attendanceRewards)을 수정할 수 없습니다. (409)
+                    이름·설명·프로모션 노출 위치는 확정 이후에도 수정할 수 있습니다.
+                    """
+    )
     public CustomResponse<AppEventResponse> updateAppEvent(
             @PathVariable Long appEventId,
             @Valid @RequestBody AppEventRequest req
@@ -81,10 +87,11 @@ public class AdminAppEventController {
                     이미 확정된 이벤트에 다시 호출하면 재추첨 없이 확정된 당첨자를 반환하며, 이때 alreadyFinalized=true 입니다.
                     확정된 당첨자는 관리자 알림(대상 EVENT_WINNERS) 발송 대상이 됩니다.
 
-                    이벤트 진행 중에도 호출할 수 있으나 (조기 종료 시), 확정 이후의 참여는 반영되지 않습니다.
+                    종료된 이벤트만 확정할 수 있습니다. 아직 끝나지 않은 이벤트를 확정하면 남은 기간의 참여가 영구히 제외되기 때문입니다.
+                    조기에 확정하려면 PATCH /api/v1/admin/app-events/{appEventId}/cancel 로 먼저 강제 종료해주세요.
                     출석 이벤트의 응모권 통계까지 함께 보려면 GET /api/v1/admin/attendance-events/{appEventId}/winners 를 호출해주세요!
 
-                    존재하지 않는 이벤트면 404, 당첨자를 뽑지 않는 이벤트(hasWinner=false)면 400,
+                    존재하지 않는 이벤트면 404, 당첨자를 뽑지 않는 이벤트(hasWinner=false)거나 아직 종료되지 않은 이벤트면 400,
                     당첨자 확정 로직이 구현되지 않은 이벤트 종류면 500.
                     """
     )

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationRequest.java
@@ -74,6 +74,12 @@ public record AdminNotificationRequest(
         return targetAudience != AdminNotificationTargetAudience.EVENT_WINNERS || eventTargetId != null;
     }
 
+    @AssertTrue(message = "이벤트 당첨자 발송(EVENT_WINNERS)은 외부 링크(EXTERNAL) 이동만 지원합니다.")
+    private boolean isExternalWhenEventWinners() {
+        return targetAudience != AdminNotificationTargetAudience.EVENT_WINNERS
+                || targetType == AdminNotificationTargetType.EXTERNAL;
+    }
+
     @AssertTrue(message = "타겟 타입에 필요한 값이 없습니다. (APP_EVENT: eventTargetId, EXTERNAL: targetLink)")
     private boolean isTargetConsistent() {
         if (targetType == null) return true;

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationResponse.java
@@ -27,6 +27,7 @@ public record AdminNotificationResponse(
         @Schema(description = "발송 방식 (IMMEDIATE: 즉시 발송, SCHEDULED: 예약 발송)")
         AdminNotificationSendType sendType,
 
+        @Schema(description = "예약 발송 시각 (KST)", example = "2026-07-04 14:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime scheduledAt,
 
@@ -45,9 +46,11 @@ public record AdminNotificationResponse(
         @Schema(description = "이동할 앱 외부 URL (targetType=EXTERNAL 일 때만, 그 외 null)")
         String targetLink,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime createdAt,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime updatedAt
 ) {

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationSummaryResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationSummaryResponse.java
@@ -27,7 +27,8 @@ public record AdminNotificationSummaryResponse(
         @Schema(description = "발송 방식 (IMMEDIATE: 즉시 발송, SCHEDULED: 예약 발송)")
         AdminNotificationSendType sendType,
 
-        @Schema(description = "발송 일시 (KST). 예약 발송(SCHEDULED)은 지정한 예약 시각, 즉시 발송(IMMEDIATE)은 발송 시점이 기록됩니다.")
+        @Schema(description = "발송 일시 (KST). 예약 발송(SCHEDULED)은 지정한 예약 시각, 즉시 발송(IMMEDIATE)은 발송 시점이 기록됩니다.",
+                example = "2026-07-04 14:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime scheduledAt,
 

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -109,6 +109,7 @@ public enum ErrorCode {
     ADMIN_NOTIFICATION_NOT_CANCELABLE(HttpStatus.BAD_REQUEST, "ADMIN_NOTIFICATION_ERROR_008", "발송 예정 상태에서만 취소할 수 있습니다."),
     ADMIN_NOTIFICATION_NOT_REBROADCASTABLE(HttpStatus.BAD_REQUEST, "ADMIN_NOTIFICATION_ERROR_009", "발송 실패 상태에서만 재발송할 수 있습니다."),
     ADMIN_NOTIFICATION_MARKETING_NIGHT_BLOCKED(HttpStatus.BAD_REQUEST, "ADMIN_NOTIFICATION_ERROR_010", "야간(21시~익일 8시)에는 마케팅 알림을 발송할 수 없습니다."),
+    ADMIN_NOTIFICATION_EVENT_NO_WINNER(HttpStatus.BAD_REQUEST, "ADMIN_NOTIFICATION_ERROR_011", "당첨자를 뽑지 않는 이벤트는 당첨자 발송(EVENT_WINNERS) 대상으로 지정할 수 없습니다."),
 
     // Event Popup error
     EVENT_POPUP_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT_POPUP_ERROR_001", "존재하지 않는 이벤트 팝업입니다."),
@@ -134,6 +135,7 @@ public enum ErrorCode {
     ADMIN_APP_EVENT_INVALID_ATTENDANCE_REWARDS(HttpStatus.BAD_REQUEST, "ADMIN_APP_EVENT_ERROR_005", "출석 응모권 지급 기준은 출석일 1 이상, 응모권 0 이상이며 출석일이 늘수록 누적 응모권이 줄어들 수 없습니다."),
     ADMIN_APP_EVENT_OVERLAPPING_TYPE(HttpStatus.CONFLICT, "ADMIN_APP_EVENT_ERROR_006", "같은 종류의 이벤트를 같은 기간에 두 개 이상 진행할 수 없습니다."),
     ADMIN_APP_EVENT_INVALID_PERIOD_BOUNDARY(HttpStatus.BAD_REQUEST, "ADMIN_APP_EVENT_ERROR_007", "이벤트 종류별 기준 시각에 시작/종료 일시를 맞춰야 합니다. (출석 체크 00:00, 오늘의 스토리 카드 06:00)"),
+    ADMIN_APP_EVENT_FINALIZED_NOT_MODIFIABLE(HttpStatus.CONFLICT, "ADMIN_APP_EVENT_ERROR_008", "당첨자가 확정된 이벤트는 이벤트 종류, 기간, 당첨자 추첨 여부, 출석 응모권 지급 기준을 수정할 수 없습니다."),
 
     // App Event error
     APP_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "APP_EVENT_ERROR_001", "존재하지 않는 앱 이벤트입니다."),
@@ -142,6 +144,7 @@ public enum ErrorCode {
     APP_EVENT_WINNER_FINALIZER_NOT_IMPLEMENTED(HttpStatus.INTERNAL_SERVER_ERROR, "APP_EVENT_ERROR_004", "당첨자 이벤트(hasWinner=true)는 종료 시 당첨자 확정(EventWinnerFinalizer) 구현이 필수입니다."),
     APP_EVENT_NO_WINNER(HttpStatus.BAD_REQUEST, "APP_EVENT_ERROR_005", "당첨자를 뽑지 않는 이벤트입니다."),
     APP_EVENT_INVALID_WINNER_COUNT(HttpStatus.BAD_REQUEST, "APP_EVENT_ERROR_006", "추첨 인원은 1명 이상이어야 합니다."),
+    APP_EVENT_NOT_ENDED(HttpStatus.BAD_REQUEST, "APP_EVENT_ERROR_007", "종료된 이벤트만 당첨자를 확정할 수 있습니다. 조기 확정이 필요하면 이벤트를 먼저 강제 종료해주세요."),
 
     // Attendance Event error
     ATTENDANCE_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ATTENDANCE_EVENT_ERROR_001", "진행 중인 출석 이벤트가 없습니다."),

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/AppEventWinnerAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/AppEventWinnerAdaptor.java
@@ -18,6 +18,10 @@ public class AppEventWinnerAdaptor {
         return appEventWinnerRepository.findWinnerUserIds(appEventId, lastUserId, pageable);
     }
 
+    public boolean existsWinner(Long appEventId) {
+        return appEventWinnerRepository.existsByAppEventId(appEventId);
+    }
+
     public List<EventWinner> findWinners(Long appEventId) {
         return appEventWinnerRepository.findWinners(appEventId);
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AppEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AppEvent.java
@@ -135,6 +135,11 @@ public class AppEvent extends BaseTimeEntity {
         return !now.isBefore(startAt) && now.isBefore(endAt);
     }
 
+    // end_at은 exclusive 경계라 그 시점부터 종료로 본다
+    public boolean isEndedAt(LocalDateTime now) {
+        return !now.isBefore(endAt);
+    }
+
     // 이벤트 종류별 기준 시각(출석 자정 / 스토리 카드 06:00)으로 계산한 서비스 날짜
     public LocalDate serviceDateOf(LocalDateTime now) {
         return eventType.serviceDateOf(now);

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
@@ -23,9 +23,11 @@ public record AppEventResponse(
         @Schema(description = "이벤트 종류 (GENERAL / ATTENDANCE / STORY_CARD)")
         AppEventType eventType,
 
+        @Schema(description = "이벤트 시작 시각", example = "2026-07-01 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime startAt,
 
+        @Schema(description = "이벤트 종료 시각(exclusive)", example = "2026-08-01 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime endAt,
 
@@ -41,9 +43,11 @@ public record AppEventResponse(
         @Schema(description = "출석 이벤트 응모권 지급 기준 (키=누적 출석일, 값=누적 지급 응모권). 미지정 시 빈 값")
         Map<Integer, Integer> attendanceRewards,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime createdAt,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime updatedAt
 ) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/BannerResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/BannerResponse.java
@@ -25,18 +25,22 @@ public record BannerResponse(
 
         String imageUrl,
 
+        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayStartAt,
 
+        @Schema(description = "노출 종료 시각", example = "2026-06-30 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayEndAt,
 
         @Schema(description = "배너 상태")
         BannerStatus status,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime createdAt,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime updatedAt
 ) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/PopupResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/PopupResponse.java
@@ -33,18 +33,22 @@ public record PopupResponse(
 
         String ctaText,
 
+        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayStartAt,
 
+        @Schema(description = "노출 종료 시각", example = "2026-06-30 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayEndAt,
 
         @Schema(description = "팝업 상태")
         PopupStatus status,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime createdAt,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime updatedAt
 ) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AppEventFinalizedNotModifiableException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AppEventFinalizedNotModifiableException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.event.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class AppEventFinalizedNotModifiableException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new AppEventFinalizedNotModifiableException();
+
+    private AppEventFinalizedNotModifiableException() { super(ErrorCode.ADMIN_APP_EVENT_FINALIZED_NOT_MODIFIABLE); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AppEventNotEndedException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AppEventNotEndedException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.event.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class AppEventNotEndedException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new AppEventNotEndedException();
+
+    private AppEventNotEndedException() { super(ErrorCode.APP_EVENT_NOT_ENDED); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/AppEventWinnerRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/AppEventWinnerRepository.java
@@ -26,6 +26,9 @@ public interface AppEventWinnerRepository extends JpaRepository<AppEventWinner, 
             Pageable pageable
     );
 
+    // 확정 여부 판정용
+    boolean existsByAppEventId(Long appEventId);
+
     // 확정된 당첨자를 뽑힌 순서대로
     @Query("""
         SELECT new com.storix.domain.domains.event.dto.EventWinner(w.userId, w.drawOrder)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
@@ -1,12 +1,14 @@
 package com.storix.domain.domains.event.service;
 
 import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
+import com.storix.domain.domains.event.adaptor.AppEventWinnerAdaptor;
 import com.storix.domain.domains.event.domain.AppEvent;
 import com.storix.domain.domains.event.domain.AppEventType;
 import com.storix.domain.domains.event.dto.AppEventCommand;
 import com.storix.domain.domains.event.dto.AppEventResponse;
 import com.storix.domain.domains.event.exception.AppEventInvalidAttendanceRewardsException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodBoundaryException;
+import com.storix.domain.domains.event.exception.AppEventFinalizedNotModifiableException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodException;
 import com.storix.domain.domains.event.exception.AppEventNameRequiredException;
 import com.storix.domain.domains.event.exception.AppEventOverlappingTypeException;
@@ -29,6 +31,7 @@ public class AppEventService {
     private static final int APP_EVENT_PAGE_SIZE = 10;
 
     private final AppEventAdaptor appEventAdaptor;
+    private final AppEventWinnerAdaptor appEventWinnerAdaptor;
     private final PopupService popupService;
     private final BannerService bannerService;
 
@@ -65,6 +68,7 @@ public class AppEventService {
         if (periodChanged || eventType != appEvent.getEventType()) {
             validatePeriodBoundary(eventType, cmd.startAt(), cmd.endAt());
         }
+        validateDrawBasisImmutable(appEvent, cmd, eventType);
         validateNoOverlap(eventType, cmd.startAt(), cmd.endAt(), appEventId);
         appEvent.update(
                 cmd.name(),
@@ -135,6 +139,22 @@ public class AppEventService {
         }
         if (appEventAdaptor.lockAndCheckOverlappingByType(eventType, startAt, endAt, excludeAppEventId)) {
             throw AppEventOverlappingTypeException.EXCEPTION;
+        }
+    }
+
+    // 확정된 당첨자가 있으면 추첨 근거가 되는 값은 잠근다.
+    private void validateDrawBasisImmutable(AppEvent appEvent, AppEventCommand cmd, AppEventType eventType) {
+        if (!appEventWinnerAdaptor.existsWinner(appEvent.getId())) {
+            return;
+        }
+        Map<Integer, Integer> rewards = cmd.attendanceRewards() == null ? Map.of() : cmd.attendanceRewards();
+        boolean drawBasisChanged = eventType != appEvent.getEventType()
+                || !appEvent.getStartAt().equals(cmd.startAt())
+                || !appEvent.getEndAt().equals(cmd.endAt())
+                || appEvent.isHasWinner() != cmd.hasWinner()
+                || !appEvent.getAttendanceRewards().equals(rewards);
+        if (drawBasisChanged) {
+            throw AppEventFinalizedNotModifiableException.EXCEPTION;
         }
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/winner/AppEventFinalizeService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/winner/AppEventFinalizeService.java
@@ -7,6 +7,7 @@ import com.storix.domain.domains.event.dto.AppEventWinnerDrawResponse;
 import com.storix.domain.domains.event.dto.EventWinner;
 import com.storix.domain.domains.event.exception.AppEventInvalidWinnerCountException;
 import com.storix.domain.domains.event.exception.AppEventNoWinnerException;
+import com.storix.domain.domains.event.exception.AppEventNotEndedException;
 import com.storix.domain.domains.event.exception.EventWinnerFinalizerNotImplementedException;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -49,6 +51,12 @@ public class AppEventFinalizeService {
                     .addKeyValue("winnerCount", confirmed.size())
                     .log(">>> [AppEvent] 이미 확정된 이벤트 - 재추첨 없이 반환");
             return toResponse(appEventId, true, confirmed);
+        }
+
+        // 추첨은 되돌릴 수 없어 진행 중 확정 시 남은 기간 참여자가 영구 제외된다.
+        // 조기 확정이 필요하면 이벤트를 강제 종료해 end_at을 당긴 뒤 확정한다
+        if (!event.isEndedAt(LocalDateTime.now())) {
+            throw AppEventNotEndedException.EXCEPTION;
         }
 
         EventWinnerFinalizer finalizer = finalizers.stream()

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/exception/AdminNotificationEventNoWinnerException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/exception/AdminNotificationEventNoWinnerException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.notification.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class AdminNotificationEventNoWinnerException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new AdminNotificationEventNoWinnerException();
+
+    private AdminNotificationEventNoWinnerException() { super(ErrorCode.ADMIN_NOTIFICATION_EVENT_NO_WINNER); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/AdminNotificationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/AdminNotificationService.java
@@ -1,8 +1,11 @@
 package com.storix.domain.domains.notification.service;
 
+import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
 import com.storix.domain.domains.notification.adaptor.AdminNotificationAdaptor;
 import com.storix.domain.domains.notification.domain.AdminNotification;
+import com.storix.domain.domains.notification.domain.AdminNotificationTargetAudience;
 import com.storix.domain.domains.notification.dto.AdminNotificationCommand;
+import com.storix.domain.domains.notification.exception.AdminNotificationEventNoWinnerException;
 import com.storix.domain.domains.notification.exception.AdminNotificationNotCancelableException;
 import com.storix.domain.domains.notification.exception.AdminNotificationNotUpdatableException;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +22,11 @@ public class AdminNotificationService {
     private static final int NOTIFICATION_PAGE_SIZE = 10;
 
     private final AdminNotificationAdaptor adminNotificationAdaptor;
+    private final AppEventAdaptor appEventAdaptor;
 
     @Transactional
     public Long create(AdminNotificationCommand cmd, Long assigneeAdminId) {
+        validateEventWinnersTarget(cmd);
         return adminNotificationAdaptor.save(AdminNotification.builder()
                 .title(cmd.title())
                 .content(cmd.content())
@@ -42,6 +47,7 @@ public class AdminNotificationService {
         if (!adminNotification.isScheduled()) {
             throw AdminNotificationNotUpdatableException.EXCEPTION;
         }
+        validateEventWinnersTarget(cmd);
 
         adminNotification.update(
                 cmd.title(),
@@ -55,6 +61,17 @@ public class AdminNotificationService {
                 cmd.targetLink()
         );
         return adminNotification;
+    }
+
+    // 당첨자 발송은 대상 이벤트가 당첨자를 뽑는 이벤트일 때만 허용한다.
+    // hasWinner=false 인데 과거에 확정된 당첨자 행이 남아 있으면 그대로 발송돼버린다
+    private void validateEventWinnersTarget(AdminNotificationCommand cmd) {
+        if (cmd.targetAudience() != AdminNotificationTargetAudience.EVENT_WINNERS || cmd.eventTargetId() == null) {
+            return;
+        }
+        if (!appEventAdaptor.findById(cmd.eventTargetId()).isHasWinner()) {
+            throw AdminNotificationEventNoWinnerException.EXCEPTION;
+        }
     }
 
     @Transactional(readOnly = true)

--- a/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AppEventServiceTest.java
+++ b/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AppEventServiceTest.java
@@ -1,11 +1,13 @@
 package com.storix.domain.domains.event.service;
 
 import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
+import com.storix.domain.domains.event.adaptor.AppEventWinnerAdaptor;
 import com.storix.domain.domains.event.domain.AppEvent;
 import com.storix.domain.domains.event.domain.AppEventStatus;
 import com.storix.domain.domains.event.domain.AppEventType;
 import com.storix.domain.domains.event.dto.AppEventCommand;
 import com.storix.domain.domains.event.dto.AppEventResponse;
+import com.storix.domain.domains.event.exception.AppEventFinalizedNotModifiableException;
 import com.storix.domain.domains.event.exception.AppEventInvalidAttendanceRewardsException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodBoundaryException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodException;
@@ -44,6 +46,9 @@ class AppEventServiceTest {
 
     @Mock
     private AppEventAdaptor appEventAdaptor;
+
+    @Mock
+    private AppEventWinnerAdaptor appEventWinnerAdaptor;
 
     @Mock
     private PopupService popupService;
@@ -375,6 +380,95 @@ class AppEventServiceTest {
                     .isEqualTo(AppEventStatus.ENDED);
             assertThat(AppEventStatus.resolve(NOW.minusDays(5), NOW.minusDays(1), NOW))
                     .isEqualTo(AppEventStatus.ENDED);
+        }
+    }
+
+    // 확정된 당첨자를 어떤 기준으로 뽑았는지 사후에 재현할 수 있어야 한다
+    @Nested
+    @DisplayName("당첨자 확정 이후 수정 제한")
+    class FinalizedImmutability {
+
+        private final LocalDateTime START = LocalDate.of(2026, 8, 1).atStartOfDay();
+        private final LocalDateTime END = LocalDate.of(2026, 8, 11).atStartOfDay();
+
+        private AppEventCommand commandOf(String name, LocalDateTime startAt, LocalDateTime endAt,
+                                          boolean hasWinner, Map<Integer, Integer> rewards) {
+            return new AppEventCommand(name, "설명", AppEventType.ATTENDANCE, startAt, endAt, hasWinner, Set.of(), rewards);
+        }
+
+        private void givenFinalizedEvent(boolean hasWinner, Map<Integer, Integer> rewards) {
+            AppEvent e = AppEvent.builder()
+                    .name("출석 이벤트").description("설명")
+                    .eventType(AppEventType.ATTENDANCE)
+                    .startAt(START).endAt(END)
+                    .hasWinner(hasWinner)
+                    .attendanceRewards(rewards)
+                    .build();
+            ReflectionTestUtils.setField(e, "id", ID);
+            given(appEventAdaptor.findById(ID)).willReturn(e);
+            given(appEventWinnerAdaptor.existsWinner(ID)).willReturn(true);
+        }
+
+        @Test
+        @DisplayName("기간을 바꾸면 409")
+        void rejects_period_change() {
+            givenFinalizedEvent(true, Map.of(1, 1));
+
+            assertThatThrownBy(() -> appEventService.update(
+                    ID, commandOf("출석 이벤트", START, END.plusDays(7), true, Map.of(1, 1))))
+                    .isInstanceOf(AppEventFinalizedNotModifiableException.class);
+        }
+
+        @Test
+        @DisplayName("응모권 지급표를 바꾸면 409")
+        void rejects_rewards_change() {
+            givenFinalizedEvent(true, Map.of(1, 1));
+
+            assertThatThrownBy(() -> appEventService.update(
+                    ID, commandOf("출석 이벤트", START, END, true, Map.of(1, 5))))
+                    .isInstanceOf(AppEventFinalizedNotModifiableException.class);
+        }
+
+        // hasWinner를 내려도 당첨자 행은 남아 당첨 알림이 계속 나갈 수 있다
+        @Test
+        @DisplayName("hasWinner를 내리면 409")
+        void rejects_has_winner_change() {
+            givenFinalizedEvent(true, Map.of(1, 1));
+
+            assertThatThrownBy(() -> appEventService.update(
+                    ID, commandOf("출석 이벤트", START, END, false, Map.of(1, 1))))
+                    .isInstanceOf(AppEventFinalizedNotModifiableException.class);
+        }
+
+        @Test
+        @DisplayName("이름·설명만 바꾸는 수정은 확정 이후에도 허용한다")
+        void allows_name_change() {
+            givenFinalizedEvent(true, Map.of(1, 1));
+
+            AppEventResponse updated = appEventService.update(
+                    ID, commandOf("출석 이벤트 (수정)", START, END, true, Map.of(1, 1)));
+
+            assertThat(updated.name()).isEqualTo("출석 이벤트 (수정)");
+        }
+
+        @Test
+        @DisplayName("확정 전이면 추첨 근거 값도 자유롭게 바꾼다")
+        void allows_everything_before_finalize() {
+            AppEvent e = AppEvent.builder()
+                    .name("출석 이벤트").description("설명")
+                    .eventType(AppEventType.ATTENDANCE)
+                    .startAt(START).endAt(END)
+                    .hasWinner(true)
+                    .attendanceRewards(Map.of(1, 1))
+                    .build();
+            ReflectionTestUtils.setField(e, "id", ID);
+            given(appEventAdaptor.findById(ID)).willReturn(e);
+            given(appEventWinnerAdaptor.existsWinner(ID)).willReturn(false);
+
+            AppEventResponse updated = appEventService.update(
+                    ID, commandOf("출석 이벤트", START, END.plusDays(7), true, Map.of(1, 5)));
+
+            assertThat(updated.attendanceRewards()).containsEntry(1, 5);
         }
     }
 }

--- a/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/winner/AppEventFinalizeServiceTest.java
+++ b/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/winner/AppEventFinalizeServiceTest.java
@@ -8,6 +8,7 @@ import com.storix.domain.domains.event.dto.AppEventWinnerDrawResponse;
 import com.storix.domain.domains.event.dto.EventWinner;
 import com.storix.domain.domains.event.exception.AppEventInvalidWinnerCountException;
 import com.storix.domain.domains.event.exception.AppEventNoWinnerException;
+import com.storix.domain.domains.event.exception.AppEventNotEndedException;
 import com.storix.domain.domains.event.exception.EventWinnerFinalizerNotImplementedException;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,7 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -38,8 +39,9 @@ import static org.mockito.Mockito.verify;
 class AppEventFinalizeServiceTest {
 
     private static final Long EVENT_ID = 100L;
-    private static final LocalDate START = LocalDate.of(2026, 7, 20);
-    private static final LocalDate END = LocalDate.of(2026, 8, 2);
+    // 종료 여부 판정이 실행 시점 기준이라 기간도 현재 기준으로 잡는다
+    private static final LocalDateTime STARTED_AT = LocalDateTime.now().minusDays(14);
+    private static final LocalDateTime ENDED_AT = LocalDateTime.now().minusDays(1);
 
     @Mock
     private EventWinnerFinalizer finalizer;
@@ -61,11 +63,11 @@ class AppEventFinalizeServiceTest {
                 List.of(finalizer), appEventWinnerService, appEventAdaptor, userAdaptor);
     }
 
-    private AppEvent event(boolean hasWinner) {
+    private AppEvent event(boolean hasWinner, LocalDateTime endAt) {
         AppEvent e = AppEvent.builder()
                 .name("14일 출석 이벤트").description("설명")
                 .eventType(AppEventType.ATTENDANCE)
-                .startAt(START.atStartOfDay()).endAt(END.plusDays(1).atStartOfDay())
+                .startAt(STARTED_AT).endAt(endAt)
                 .hasWinner(hasWinner)
                 .build();
         ReflectionTestUtils.setField(e, "id", EVENT_ID);
@@ -73,7 +75,12 @@ class AppEventFinalizeServiceTest {
     }
 
     private void givenEvent(boolean hasWinner) {
-        given(appEventAdaptor.findByIdForUpdate(EVENT_ID)).willReturn(event(hasWinner));
+        given(appEventAdaptor.findByIdForUpdate(EVENT_ID)).willReturn(event(hasWinner, ENDED_AT));
+    }
+
+    private void givenOngoingEvent() {
+        given(appEventAdaptor.findByIdForUpdate(EVENT_ID))
+                .willReturn(event(true, LocalDateTime.now().plusDays(3)));
     }
 
     @Test
@@ -150,6 +157,34 @@ class AppEventFinalizeServiceTest {
                 .isInstanceOf(AppEventNoWinnerException.class);
 
         verify(appEventWinnerService, never()).saveWinners(anyLong(), anyList());
+    }
+
+    // 추첨은 되돌릴 수 없어 진행 중 확정은 남은 기간 참여자를 영구 제외시킨다
+    @Test
+    @DisplayName("아직 종료되지 않은 이벤트면 400을 던지고 추첨하지 않는다")
+    void rejects_not_ended_event() {
+        givenOngoingEvent();
+        given(appEventWinnerService.findWinners(EVENT_ID)).willReturn(List.of());
+
+        assertThatThrownBy(() -> appEventFinalizeService.finalizeWinners(EVENT_ID, 3))
+                .isInstanceOf(AppEventNotEndedException.class);
+
+        verify(finalizer, never()).resolveWinners(any(AppEvent.class), anyInt());
+        verify(appEventWinnerService, never()).saveWinners(anyLong(), anyList());
+    }
+
+    // 확정 이력 조회까지 막으면 당첨자 알림 발송이 끊긴다
+    @Test
+    @DisplayName("종료 전이라도 이미 확정된 이벤트면 저장된 당첨자를 그대로 반환한다")
+    void returns_confirmed_winners_even_before_end() {
+        givenOngoingEvent();
+        given(appEventWinnerService.findWinners(EVENT_ID)).willReturn(List.of(new EventWinner(7L, 1)));
+        given(userAdaptor.findNicknameMapByUserIds(anyList())).willReturn(Map.of(7L, "닉네임7"));
+
+        AppEventWinnerDrawResponse response = appEventFinalizeService.finalizeWinners(EVENT_ID, 3);
+
+        assertThat(response.alreadyFinalized()).isTrue();
+        assertThat(response.winners()).extracting(AppEventDrawWinner::userId).containsExactly(7L);
     }
 
     @Test


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] 종료되지 않은 이벤트의 당첨자 확정을 400으로 차단
> - [x] 당첨자가 확정된 이벤트의 추첨 근거 수정을 409로 차단
> - [x] `hasWinner=false` 이벤트를 `EVENT_WINNERS` 발송 대상으로 지정하지 못하도록 검증
> - [x] 당첨자 발송은 외부 링크(`EXTERNAL`) 이동만 허용
> - [x] 이벤트·알림 응답의 날짜 필드 Swagger example 반영

### 1. 종료되지 않은 이벤트의 당첨자 확정 차단

`AppEventFinalizeService.finalizeWinners`가 `winnerCount`, `hasWinner`, 기존 확정 여부만 검사하고 `end_at`을 보지 않아, 진행 중이거나 시작 전인 이벤트도 확정이 됐습니다. 추첨은 이벤트당 1회뿐이고 되돌릴 수 없어서 한 번 잘못 누르면 남은 기간 참여자가 영구 제외됩니다. 시작 전 이벤트라면 당첨자 0명으로 확정된 뒤 `alreadyFinalized=true`로 굳습니다.

- 종료되지 않았으면 400 (`APP_EVENT_ERROR_007`)
- 조기 확정이 필요하면 `PATCH /api/v1/admin/app-events/{id}/cancel`로 `end_at`을 당긴 뒤 확정하는 흐름으로 통일
- 검사를 "이미 확정됨" 조기 반환 **뒤**에 둬서, 이 수정 이전에 확정된 이벤트의 당첨자 조회는 계속 동작합니다 (당첨자 알림 발송 흐름 유지)

### 2. 확정 이후 추첨 근거 수정 차단

`AppEventService.update`가 확정 여부를 보지 않아 아래가 모두 가능했습니다.

- 확정 후 `attendanceRewards` 변경 → 추첨 근거가 사후에 달라져 당첨자 선정을 재현할 수 없음
- 확정 후 `hasWinner=false` → 당첨자 행은 남아 당첨 알림은 계속 발송 가능
- 종료된 이벤트 기간 연장 → 다시 진행 중이 되지만 재추첨은 안 되므로 연장 기간 참여가 영구 미반영

잠금 기준을 "종료"가 아니라 **"당첨자 확정"**으로 잡았습니다. 종료 기준이면 끝난 이벤트의 오타 수정까지 막히는데, 실제로 보호해야 하는 건 이미 뽑힌 결과의 근거이기 때문입니다.

| 필드 | 확정 후 |
| --- | --- |
| `eventType`, `startAt`, `endAt`, `hasWinner`, `attendanceRewards` | 409 (`ADMIN_APP_EVENT_ERROR_008`) |
| `name`, `description`, `promotionTypes` | 허용 |

### 3. 당첨자 발송 대상·이동 타입 검증

- `EVENT_WINNERS` 대상 지정 시 해당 이벤트가 `hasWinner=true`인지 검증 (`ADMIN_NOTIFICATION_ERROR_011`). 발송 시점이 아니라 알림 생성·수정 시점에 막아, "발송했는데 0명"이 아니라 즉시 400으로 알 수 있게 했습니다.
- `EVENT_WINNERS` 발송은 `targetType=EXTERNAL`만 허용. 당첨자에게는 경품 수령 폼 등 외부 페이지로 보내야 하므로 `APP_EVENT`(자사 이벤트 화면) 이동을 막습니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #199

## 🖇️ 기타
QA 절차가 한 단계 늘어납니다. 진행 중인 이벤트로 추첨을 테스트하려면 `PATCH /app-events/{id}/cancel`로 먼저 강제 종료해야 합니다. 강제 종료는 소속 팝업·배너도 함께 종료시키고 캐시를 비웁니다.

같은 회차를 다시 돌리려면 `DELETE FROM app_event_winners WHERE app_event_id = ?`로 확정 상태를 풀면 됩니다.
