### PR TITLE
Feat: [앱 이벤트] 이벤트 상세 웹페이지용 공개 조회 API

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AppEventController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AppEventController.java
@@ -2,6 +2,7 @@ package com.storix.api.domain.event.controller;
 
 import com.storix.api.domain.event.usecase.AppEventUseCase;
 import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.event.dto.AppEventPageResponse;
 import com.storix.domain.domains.event.dto.BannerResponse;
 import com.storix.domain.domains.event.dto.OneTimeAppEventResponse;
 import com.storix.domain.domains.event.dto.PopupResponse;
@@ -25,6 +26,24 @@ import java.util.List;
 public class AppEventController {
 
     private final AppEventUseCase appEventUseCase;
+
+    @GetMapping("/{appEventId}")
+    @Operation(
+            summary = "앱 이벤트 상세 조회 (인증 불필요)",
+            description = """
+                    이벤트 상세 웹페이지(storix.kr/event/{appEventId})를 그리는 데 필요한 정보를 반환합니다.
+                    로그인하지 않아도 호출할 수 있으며, eventType 으로 어떤 화면을 그릴지 정하시면 됩니다.
+
+                    운영 설정값(홍보 수단, 응모권 지급 기준 등)은 내려가지 않습니다.
+                    존재하지 않는 이벤트, 그리고 아직 시작하지 않은 이벤트는 404입니다. (오픈 전 내용이 미리 노출되지 않도록)
+                    종료된 이벤트는 조회되며 status=ENDED 로 내려갑니다.
+                    """
+    )
+    public CustomResponse<AppEventPageResponse> getAppEvent(
+            @PathVariable Long appEventId
+    ) {
+        return appEventUseCase.getAppEventPage(appEventId);
+    }
 
     @GetMapping("/popup")
     @Operation(summary = "노출 중인 팝업 조회", description = "현재 노출 가능한 팝업을 반환합니다. 유저가 오늘 '다시 안 보기' 했거나 노출 팝업이 없으면 null.")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/AppEventRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/AppEventRequest.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
@@ -23,6 +24,15 @@ public record AppEventRequest(
         @Schema(description = "앱 이벤트 설명", example = "앱 출시를 기념한 첫 이벤트입니다.")
         @Size(max = 500, message = "앱 이벤트 설명은 500자 이하여야 합니다.")
         String description,
+
+        @Schema(
+                description = "이벤트 상세 웹페이지가 그릴 화면을 고르는 키. 같은 종류라도 회차마다 구성이 바뀌면 다른 값을 넣습니다. "
+                        + "비우면 종류별 기본 화면을 사용합니다. 쓸 수 있는 값은 프론트와 맞춰주세요.",
+                example = "attendance-2026-08-10"
+        )
+        @Size(max = 50, message = "페이지 키는 50자 이하여야 합니다.")
+        @Pattern(regexp = "^[a-z0-9]+(-[a-z0-9]+)*$", message = "페이지 키는 영소문자, 숫자, 하이픈만 사용할 수 있습니다.")
+        String pageKey,
 
         @Schema(
                 description = "이벤트 종류. ATTENDANCE / STORY_CARD는 전용 API가 이 값으로 진행 중인 이벤트를 찾으므로 "
@@ -68,6 +78,6 @@ public record AppEventRequest(
     }
 
     public AppEventCommand toCommand() {
-        return new AppEventCommand(name, description, eventType, startAt, endAt, hasWinner, promotionTypes, attendanceRewards);
+        return new AppEventCommand(name, description, pageKey, eventType, startAt, endAt, hasWinner, promotionTypes, attendanceRewards);
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AppEventUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AppEventUseCase.java
@@ -3,9 +3,11 @@ package com.storix.api.domain.event.usecase;
 import com.storix.common.code.SuccessCode;
 import com.storix.common.payload.CustomResponse;
 import com.storix.common.utils.RedisKeyStatic;
+import com.storix.domain.domains.event.dto.AppEventPageResponse;
 import com.storix.domain.domains.event.dto.BannerResponse;
 import com.storix.domain.domains.event.dto.OneTimeAppEventResponse;
 import com.storix.domain.domains.event.dto.PopupResponse;
+import com.storix.domain.domains.event.service.AppEventService;
 import com.storix.domain.domains.event.service.BannerService;
 import com.storix.domain.domains.event.service.EventContentCacheHelper;
 import com.storix.domain.domains.event.service.PopupDismissService;
@@ -24,6 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AppEventUseCase {
 
+    private final AppEventService appEventService;
     private final PopupService eventPopupService;
     private final PopupDismissService popupDismissService;
     private final BannerService eventBannerService;
@@ -32,6 +35,14 @@ public class AppEventUseCase {
     private final UserAppEventCacheHelper userAppEventCacheHelper;
 
     @Value("${AWS_S3_BASE_URL}") private String baseUrl;
+
+    // 이벤트 상세 웹페이지 렌더용 조회
+    public CustomResponse<AppEventPageResponse> getAppEventPage(Long appEventId) {
+
+        return CustomResponse.onSuccess(
+                SuccessCode.APP_EVENT_PAGE_LOAD_SUCCESS,
+                appEventService.getAppEventPage(appEventId));
+    }
 
     // 노출 중인 팝업 조회
     public CustomResponse<PopupResponse> getActivePopup(Long userId) {

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -44,6 +44,7 @@ public enum SuccessCode {
     APP_EVENT_ACK_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_002", "앱 이벤트 확인 처리에 성공했습니다."),
     APP_EVENT_POPUP_DISMISS_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_003", "팝업 오늘 다시 안 보기 처리에 성공했습니다."),
     APP_EVENT_POPUP_NEVER_SHOW_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_004", "팝업 다시 보지 않기 처리에 성공했습니다."),
+    APP_EVENT_PAGE_LOAD_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_005", "앱 이벤트 상세 조회에 성공했습니다."),
     ATTENDANCE_EVENT_LOAD_SUCCESS(HttpStatus.OK, "ATTENDANCE_EVENT_SUCCESS_001", "출석 이벤트 현황 조회에 성공했습니다."),
     ATTENDANCE_EVENT_CHECK_IN_SUCCESS(HttpStatus.OK, "ATTENDANCE_EVENT_SUCCESS_002", "출석 체크에 성공했습니다."),
     ATTENDANCE_EVENT_WINNERS_LOAD_SUCCESS(HttpStatus.OK, "ATTENDANCE_EVENT_SUCCESS_004", "출석 이벤트 당첨자 조회에 성공했습니다."),

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AppEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AppEvent.java
@@ -37,6 +37,11 @@ public class AppEvent extends BaseTimeEntity {
     @Column(name = "description", length = 500)
     private String description;
 
+    // 상세 웹페이지가 그릴 화면을 고르는 키. 같은 종류라도 회차마다 구성이 다를 수 있어 회차별로 지정한다.
+    // URL에 쓰지 않으므로 나중에 바꿔도 이미 나간 링크는 살아 있다
+    @Column(name = "page_key", length = 50)
+    private String pageKey;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "event_type", nullable = false, length = 20)
     private AppEventType eventType;
@@ -77,6 +82,7 @@ public class AppEvent extends BaseTimeEntity {
     @Builder
     public AppEvent(String name,
                     String description,
+                    String pageKey,
                     AppEventType eventType,
                     LocalDateTime startAt,
                     LocalDateTime endAt,
@@ -86,6 +92,7 @@ public class AppEvent extends BaseTimeEntity {
                     Long assigneeAdminId) {
         this.name = name;
         this.description = description;
+        this.pageKey = pageKey;
         this.eventType = eventType == null ? AppEventType.GENERAL : eventType;
         this.startAt = startAt;
         this.endAt = endAt;
@@ -101,6 +108,7 @@ public class AppEvent extends BaseTimeEntity {
 
     public void update(String name,
                        String description,
+                       String pageKey,
                        AppEventType eventType,
                        LocalDateTime startAt,
                        LocalDateTime endAt,
@@ -109,6 +117,7 @@ public class AppEvent extends BaseTimeEntity {
                        Map<Integer, Integer> attendanceRewards) {
         this.name = name;
         this.description = description;
+        this.pageKey = pageKey;
         if (eventType != null) {
             this.eventType = eventType;
         }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventCommand.java
@@ -10,6 +10,7 @@ import java.util.Set;
 public record AppEventCommand(
         String name,
         String description,
+        String pageKey,
         AppEventType eventType,
         LocalDateTime startAt,
         LocalDateTime endAt,

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventPageResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventPageResponse.java
@@ -1,0 +1,54 @@
+package com.storix.domain.domains.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.storix.domain.domains.event.domain.AppEvent;
+import com.storix.domain.domains.event.domain.AppEventStatus;
+import com.storix.domain.domains.event.domain.AppEventType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+// 상세 웹페이지 렌더용. 비로그인도 조회하므로 홍보 수단이나 응모권 지급표 같은 운영값은 담지 않는다
+@Builder
+public record AppEventPageResponse(
+        Long id,
+
+        String name,
+
+        String description,
+
+        @Schema(description = "이벤트 종류 (GENERAL / ATTENDANCE / STORY_CARD)")
+        AppEventType eventType,
+
+        @Schema(
+                description = "그릴 화면을 고르는 키. 같은 종류라도 회차마다 구성이 다를 수 있으니 이 값을 우선 보고, "
+                        + "비어 있거나 모르는 값이면 eventType 기준 기본 화면으로 넘어가주세요.",
+                example = "attendance-2026-08-10"
+        )
+        String pageKey,
+
+        @Schema(description = "이벤트 시작 시각", example = "2026-07-01 00:00", type = "string")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        LocalDateTime startAt,
+
+        @Schema(description = "이벤트 종료 시각(exclusive)", example = "2026-08-01 00:00", type = "string")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        LocalDateTime endAt,
+
+        @Schema(description = "기간으로 파생 계산되는 상태 (SCHEDULED / ACTIVE / ENDED)")
+        AppEventStatus status
+) {
+    public static AppEventPageResponse from(AppEvent appEvent) {
+        return AppEventPageResponse.builder()
+                .id(appEvent.getId())
+                .name(appEvent.getName())
+                .description(appEvent.getDescription())
+                .eventType(appEvent.getEventType())
+                .pageKey(appEvent.getPageKey())
+                .startAt(appEvent.getStartAt())
+                .endAt(appEvent.getEndAt())
+                .status(AppEventStatus.resolve(appEvent.getStartAt(), appEvent.getEndAt(), LocalDateTime.now()))
+                .build();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
@@ -20,6 +20,9 @@ public record AppEventResponse(
 
         String description,
 
+        @Schema(description = "이벤트 상세 웹페이지가 그릴 화면을 고르는 키. 비어 있으면 종류별 기본 화면", example = "attendance-2026-08-10")
+        String pageKey,
+
         @Schema(description = "이벤트 종류 (GENERAL / ATTENDANCE / STORY_CARD)")
         AppEventType eventType,
 
@@ -56,6 +59,7 @@ public record AppEventResponse(
                 .id(appEvent.getId())
                 .name(appEvent.getName())
                 .description(appEvent.getDescription())
+                .pageKey(appEvent.getPageKey())
                 .eventType(appEvent.getEventType())
                 .startAt(appEvent.getStartAt())
                 .endAt(appEvent.getEndAt())

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
@@ -3,14 +3,17 @@ package com.storix.domain.domains.event.service;
 import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
 import com.storix.domain.domains.event.adaptor.AppEventWinnerAdaptor;
 import com.storix.domain.domains.event.domain.AppEvent;
+import com.storix.domain.domains.event.domain.AppEventStatus;
 import com.storix.domain.domains.event.domain.AppEventType;
 import com.storix.domain.domains.event.dto.AppEventCommand;
+import com.storix.domain.domains.event.dto.AppEventPageResponse;
 import com.storix.domain.domains.event.dto.AppEventResponse;
 import com.storix.domain.domains.event.exception.AppEventInvalidAttendanceRewardsException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodBoundaryException;
 import com.storix.domain.domains.event.exception.AppEventFinalizedNotModifiableException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodException;
 import com.storix.domain.domains.event.exception.AppEventNameRequiredException;
+import com.storix.domain.domains.event.exception.AppEventNotFoundException;
 import com.storix.domain.domains.event.exception.AppEventOverlappingTypeException;
 import com.storix.domain.domains.event.exception.AppEventPeriodRequiredException;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +48,7 @@ public class AppEventService {
         AppEvent saved = appEventAdaptor.save(AppEvent.builder()
                 .name(cmd.name())
                 .description(cmd.description())
+                .pageKey(cmd.pageKey())
                 .eventType(eventType)
                 .startAt(cmd.startAt())
                 .endAt(cmd.endAt())
@@ -73,6 +77,7 @@ public class AppEventService {
         appEvent.update(
                 cmd.name(),
                 cmd.description(),
+                cmd.pageKey(),
                 eventType,
                 cmd.startAt(),
                 cmd.endAt(),
@@ -91,6 +96,17 @@ public class AppEventService {
     @Transactional(readOnly = true)
     public AppEventResponse getAppEvent(Long appEventId) {
         return AppEventResponse.from(appEventAdaptor.findById(appEventId));
+    }
+
+    // 시작 전 이벤트는 없는 것으로 취급한다. id를 훑어 오픈 전 내용을 미리 보면 안 된다
+    @Transactional(readOnly = true)
+    public AppEventPageResponse getAppEventPage(Long appEventId) {
+        AppEvent appEvent = appEventAdaptor.findById(appEventId);
+        if (AppEventStatus.resolve(appEvent.getStartAt(), appEvent.getEndAt(), LocalDateTime.now())
+                == AppEventStatus.SCHEDULED) {
+            throw AppEventNotFoundException.EXCEPTION;
+        }
+        return AppEventPageResponse.from(appEvent);
     }
 
     @Transactional(readOnly = true)

--- a/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AppEventServiceTest.java
+++ b/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AppEventServiceTest.java
@@ -7,6 +7,8 @@ import com.storix.domain.domains.event.domain.AppEventStatus;
 import com.storix.domain.domains.event.domain.AppEventType;
 import com.storix.domain.domains.event.dto.AppEventCommand;
 import com.storix.domain.domains.event.dto.AppEventResponse;
+import com.storix.domain.domains.event.exception.AppEventNotFoundException;
+import com.storix.domain.domains.event.dto.AppEventPageResponse;
 import com.storix.domain.domains.event.exception.AppEventFinalizedNotModifiableException;
 import com.storix.domain.domains.event.exception.AppEventInvalidAttendanceRewardsException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodBoundaryException;
@@ -60,7 +62,7 @@ class AppEventServiceTest {
     private AppEventService appEventService;
 
     private AppEventCommand command(LocalDateTime startAt, LocalDateTime endAt) {
-        return new AppEventCommand("앱 출시 이벤트", "설명", null, startAt, endAt, false, Set.of(), Map.of());
+        return new AppEventCommand("앱 출시 이벤트", "설명", null, null, startAt, endAt, false, Set.of(), Map.of());
     }
 
     private AppEvent appEvent(LocalDateTime startAt, LocalDateTime endAt) {
@@ -82,7 +84,7 @@ class AppEventServiceTest {
         private final LocalDateTime END = LocalDate.of(2026, 8, 11).atStartOfDay();
 
         private AppEventCommand typedCommand(AppEventType eventType, LocalDateTime startAt, LocalDateTime endAt) {
-            return new AppEventCommand("출석 이벤트", "설명", eventType, startAt, endAt, false, Set.of(), Map.of());
+            return new AppEventCommand("출석 이벤트", "설명", null, eventType, startAt, endAt, false, Set.of(), Map.of());
         }
 
         @Test
@@ -142,7 +144,7 @@ class AppEventServiceTest {
         private final LocalDate DAY = LocalDate.of(2026, 8, 1);
 
         private AppEventCommand typedCommand(AppEventType eventType, LocalDateTime startAt, LocalDateTime endAt) {
-            return new AppEventCommand("이벤트", "설명", eventType, startAt, endAt, false, Set.of(), Map.of());
+            return new AppEventCommand("이벤트", "설명", null, eventType, startAt, endAt, false, Set.of(), Map.of());
         }
 
         @Test
@@ -268,7 +270,7 @@ class AppEventServiceTest {
         @DisplayName("이름이 비면 예외 - 저장하지 않는다")
         void reject_blank_name() {
             LocalDateTime start = LocalDateTime.now().plusDays(1);
-            AppEventCommand cmd = new AppEventCommand("  ", "설명", null, start, start.plusDays(1), false, Set.of(), Map.of());
+            AppEventCommand cmd = new AppEventCommand("  ", "설명", null, null, start, start.plusDays(1), false, Set.of(), Map.of());
 
             assertThatThrownBy(() -> appEventService.create(cmd, ADMIN_ID))
                     .isInstanceOf(AppEventNameRequiredException.class);
@@ -298,12 +300,83 @@ class AppEventServiceTest {
             LocalDateTime start = LocalDateTime.now().plusDays(1);
             LocalDateTime end = start.plusDays(20);
             Map<Integer, Integer> rewards = Map.of(5, 1, 10, 3, 20, 10);
-            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, start, end, false, Set.of(), rewards);
+            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, null, start, end, false, Set.of(), rewards);
             given(appEventAdaptor.save(any(AppEvent.class))).willAnswer(inv -> inv.getArgument(0));
 
             AppEventResponse saved = appEventService.create(cmd, ADMIN_ID);
 
             assertThat(saved.attendanceRewards()).containsExactlyInAnyOrderEntriesOf(rewards);
+        }
+
+        // 같은 종류라도 회차마다 다른 화면을 그릴 수 있어야 한다
+        @Test
+        @DisplayName("페이지 키를 지정하면 그대로 저장하고, 없으면 null 로 둔다")
+        void create_with_page_key() {
+            LocalDateTime start = LocalDateTime.now().plusDays(1);
+            LocalDateTime end = start.plusDays(20);
+            given(appEventAdaptor.save(any(AppEvent.class))).willAnswer(inv -> inv.getArgument(0));
+
+            AppEventResponse withKey = appEventService.create(
+                    new AppEventCommand("출석 이벤트", "설명", "attendance-2026-08-10", null, start, end, false, Set.of(), Map.of()),
+                    ADMIN_ID);
+            AppEventResponse withoutKey = appEventService.create(
+                    new AppEventCommand("출석 이벤트", "설명", null, null, start, end, false, Set.of(), Map.of()),
+                    ADMIN_ID);
+
+            assertThat(withKey.pageKey()).isEqualTo("attendance-2026-08-10");
+            assertThat(withoutKey.pageKey()).isNull();
+        }
+    }
+
+    // 웹페이지용 공개 조회는 인증이 없으므로 노출 범위를 좁게 잡는다
+    @Nested
+    @DisplayName("getAppEventPage - 이벤트 상세 웹페이지용 공개 조회")
+    class GetAppEventPage {
+
+        private AppEvent appEventOf(LocalDateTime startAt, LocalDateTime endAt) {
+            AppEvent e = AppEvent.builder()
+                    .name("출석 이벤트").description("설명")
+                    .pageKey("attendance-2026-08-10")
+                    .eventType(AppEventType.ATTENDANCE)
+                    .startAt(startAt).endAt(endAt)
+                    .build();
+            ReflectionTestUtils.setField(e, "id", ID);
+            return e;
+        }
+
+        @Test
+        @DisplayName("진행 중인 이벤트는 종류와 페이지 키를 함께 반환한다")
+        void active_event_ok() {
+            LocalDateTime now = LocalDateTime.now();
+            given(appEventAdaptor.findById(ID)).willReturn(appEventOf(now.minusDays(1), now.plusDays(10)));
+
+            AppEventPageResponse page = appEventService.getAppEventPage(ID);
+
+            assertThat(page.id()).isEqualTo(ID);
+            assertThat(page.eventType()).isEqualTo(AppEventType.ATTENDANCE);
+            assertThat(page.pageKey()).isEqualTo("attendance-2026-08-10");
+            assertThat(page.status()).isEqualTo(AppEventStatus.ACTIVE);
+        }
+
+        // 과거 링크로 들어온 유저에게 종료 안내를 보여줄 수 있어야 한다
+        @Test
+        @DisplayName("종료된 이벤트는 status=ENDED 로 조회된다")
+        void ended_event_ok() {
+            LocalDateTime now = LocalDateTime.now();
+            given(appEventAdaptor.findById(ID)).willReturn(appEventOf(now.minusDays(20), now.minusDays(1)));
+
+            assertThat(appEventService.getAppEventPage(ID).status()).isEqualTo(AppEventStatus.ENDED);
+        }
+
+        // id를 훑어 오픈 전 이벤트 내용을 미리 볼 수 있으면 안 된다
+        @Test
+        @DisplayName("아직 시작하지 않은 이벤트는 404를 던진다")
+        void scheduled_event_hidden() {
+            LocalDateTime now = LocalDateTime.now();
+            given(appEventAdaptor.findById(ID)).willReturn(appEventOf(now.plusDays(3), now.plusDays(10)));
+
+            assertThatThrownBy(() -> appEventService.getAppEventPage(ID))
+                    .isInstanceOf(AppEventNotFoundException.class);
         }
 
         @Test
@@ -312,7 +385,7 @@ class AppEventServiceTest {
             LocalDateTime start = LocalDateTime.now().plusDays(1);
             LocalDateTime end = start.plusDays(20);
             Map<Integer, Integer> rewards = Map.of(5, 3, 10, 1); // 10일차 누적이 5일차보다 작음
-            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, start, end, false, Set.of(), rewards);
+            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, null, start, end, false, Set.of(), rewards);
 
             assertThatThrownBy(() -> appEventService.create(cmd, ADMIN_ID))
                     .isInstanceOf(AppEventInvalidAttendanceRewardsException.class);
@@ -325,7 +398,7 @@ class AppEventServiceTest {
             LocalDateTime start = LocalDateTime.now().plusDays(1);
             LocalDateTime end = start.plusDays(20);
             Map<Integer, Integer> rewards = Map.of(0, 1); // 출석일 0
-            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, start, end, false, Set.of(), rewards);
+            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, null, start, end, false, Set.of(), rewards);
 
             assertThatThrownBy(() -> appEventService.create(cmd, ADMIN_ID))
                     .isInstanceOf(AppEventInvalidAttendanceRewardsException.class);
@@ -393,7 +466,7 @@ class AppEventServiceTest {
 
         private AppEventCommand commandOf(String name, LocalDateTime startAt, LocalDateTime endAt,
                                           boolean hasWinner, Map<Integer, Integer> rewards) {
-            return new AppEventCommand(name, "설명", AppEventType.ATTENDANCE, startAt, endAt, hasWinner, Set.of(), rewards);
+            return new AppEventCommand(name, "설명", null, AppEventType.ATTENDANCE, startAt, endAt, hasWinner, Set.of(), rewards);
         }
 
         private void givenFinalizedEvent(boolean hasWinner, Map<Integer, Integer> rewards) {

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
@@ -131,6 +131,9 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/auth/admin/slack/callback").permitAll()
                                 .requestMatchers("/api/v1/auth/admin/profile").hasRole("ADMIN")
 
+                                // [App Event] 이벤트 상세 페이지
+                                .requestMatchers(HttpMethod.GET, "/api/v1/app-events/{appEventId:[0-9]+}").permitAll()
+
                                 // [TopicRoom]
                                 .requestMatchers("/ws-stomp/**").permitAll()
 


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] `GET /api/v1/app-events/{appEventId}` 공개 조회 API 추가 (인증 불필요)
> - [x] 아직 시작하지 않은 이벤트는 404 처리
> - [x] `app_events.page_key` 컬럼 추가 및 생성/수정 입력, 응답 노출

### 1. 이벤트 상세 웹페이지용 공개 조회 API

앱 이벤트 상세를 웹페이지(`storix.kr/event/{appEventId}`)로 제공하기 위한 준비입니다. 공개 API에는 팝업·배너·칭호 조회만 있어서 웹페이지가 자기 이벤트 정보를 가져올 방법이 없었습니다.

```
GET /api/v1/app-events/7      — 인증 불필요
```
```json
{
  "id": 7,
  "name": "출석 체크 이벤트",
  "description": "...",
  "pageKey": "attendance-2026-08-10",
  "eventType": "ATTENDANCE",
  "startAt": "2026-08-01 00:00",
  "endAt": "2026-09-01 00:00",
  "status": "ACTIVE"
}
```

웹페이지는 `eventType`으로 어떤 화면을 그릴지 정하면 됩니다. `appEventId`가 dev/prod에서 서로 달라도 각 환경의 랜딩이 각자 API를 보므로 문제가 없습니다.

운영 설정값(`promotionTypes`, `attendanceRewards`, `hasWinner`)은 응답에 담지 않았습니다. 비로그인이 호출할 수 있는 API라 페이지를 그리는 데 필요한 값만 내보냅니다.

보안 매처는 숫자 id만 잡도록 `{appEventId:[0-9]+}`로 제한했습니다. 그러지 않으면 `/popup`·`/banner`·`/title` 같은 인증 필요 경로까지 열립니다.

### 2. 시작 전 이벤트 404

id가 auto_increment라 1부터 훑으면 아직 오픈하지 않은 이벤트의 이름·설명·기간이 노출됩니다. `SCHEDULED` 상태면 404로 막았습니다.

종료된 이벤트는 그대로 조회됩니다. 과거 링크로 들어온 유저에게 종료 안내를 보여줘야 하기 때문입니다.

기획자 검수는 dev에서 시작 시각을 앞당겨 `ACTIVE`로 만들어 확인하면 됩니다.

### 3. pageKey

같은 종류(예: 출석)라도 회차마다 구성이 바뀔 수 있는데, 웹페이지 컴포넌트가 하나뿐이면 새 화면을 배포하는 순간 **진행 중인 회차까지 함께 바뀝니다.** `pageKey`가 있으면 새 화면을 미리 배포해두고 그 값이 지정된 이벤트에만 적용할 수 있습니다.

- nullable — 비우면 프론트가 `eventType` 기준 기본 화면을 사용합니다. 기존 이벤트 백필이 필요 없습니다
- 수정 가능 — URL에 노출되지 않으므로 나중에 값을 바꿔도 이미 나간 팝업·푸시 링크가 죽지 않습니다
- 형식 검증만 백엔드가 합니다 (`^[a-z0-9]+(-[a-z0-9]+)*$`, 50자). 어떤 키가 어떤 화면인지는 컴포넌트를 만드는 프론트가 정합니다

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)
- 공개 응답에 `name`, `description`을 남겨뒀습니다. `description`에 운영 메모가 들어갈 수 있어 뺄지 고민했는데, 웹페이지가 쓸 수 있어 우선 유지했습니다.
- `pageKey` 형식을 `attendance-2026-08-10`처럼 시작일 기준으로 잡는 걸 예시로 넣었습니다. 실제 값 규칙은 프론트와 맞추면 됩니다.

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #201

## 🖇️ 기타
팝업·배너·알림에서 웹페이지로 보내는 `targetLink` 조립은 이 PR에 없습니다. 랜딩에 `/event/:appEventId` 라우팅이 올라간 뒤에 붙여야 합니다. 지금 내보내면 앱이 웹뷰를 열고 404를 띄웁니다.

랜딩 쪽에 필요한 작업은 세 가지입니다.
1. dev 배포 분리 + `VITE_API_BASE_URL` 주입 (현재 배포 번들은 prod API 고정)
2. `vercel.json`에 `/event/(.*)` rewrite 추가
3. `main.jsx`에서 id 파싱 → 위 API 호출 → `pageKey` → `eventType` 순으로 화면 선택
