### PR TITLE
Release v2.4.13

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminAppEventController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminAppEventController.java
@@ -55,7 +55,13 @@ public class AdminAppEventController {
     }
 
     @PutMapping("/{appEventId}")
-    @Operation(summary = "앱 이벤트 수정")
+    @Operation(
+            summary = "앱 이벤트 수정",
+            description = """
+                    당첨자가 확정된 이벤트는 추첨 근거가 되는 값(eventType, startAt, endAt, hasWinner, attendanceRewards)을 수정할 수 없습니다. (409)
+                    이름·설명·프로모션 노출 위치는 확정 이후에도 수정할 수 있습니다.
+                    """
+    )
     public CustomResponse<AppEventResponse> updateAppEvent(
             @PathVariable Long appEventId,
             @Valid @RequestBody AppEventRequest req
@@ -81,10 +87,11 @@ public class AdminAppEventController {
                     이미 확정된 이벤트에 다시 호출하면 재추첨 없이 확정된 당첨자를 반환하며, 이때 alreadyFinalized=true 입니다.
                     확정된 당첨자는 관리자 알림(대상 EVENT_WINNERS) 발송 대상이 됩니다.
 
-                    이벤트 진행 중에도 호출할 수 있으나 (조기 종료 시), 확정 이후의 참여는 반영되지 않습니다.
+                    종료된 이벤트만 확정할 수 있습니다. 아직 끝나지 않은 이벤트를 확정하면 남은 기간의 참여가 영구히 제외되기 때문입니다.
+                    조기에 확정하려면 PATCH /api/v1/admin/app-events/{appEventId}/cancel 로 먼저 강제 종료해주세요.
                     출석 이벤트의 응모권 통계까지 함께 보려면 GET /api/v1/admin/attendance-events/{appEventId}/winners 를 호출해주세요!
 
-                    존재하지 않는 이벤트면 404, 당첨자를 뽑지 않는 이벤트(hasWinner=false)면 400,
+                    존재하지 않는 이벤트면 404, 당첨자를 뽑지 않는 이벤트(hasWinner=false)거나 아직 종료되지 않은 이벤트면 400,
                     당첨자 확정 로직이 구현되지 않은 이벤트 종류면 500.
                     """
     )

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminBannerController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminBannerController.java
@@ -6,6 +6,9 @@ import com.storix.common.payload.CustomResponse;
 import com.storix.domain.domains.event.dto.BannerResponse;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -28,6 +31,9 @@ public class AdminBannerController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이벤트 배너 생성", description = "multipart 요청: 'data'(application/json) 파트에 배너 정보, 'file' 파트에 이미지. 서버가 이미지를 S3 업로드 후 생성합니다. 활성 배너 노출 기간이 겹치면 생성할 수 없습니다.")
+    @RequestBody(content = @Content(
+            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+            encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
     public CustomResponse<BannerResponse> createBanner(
             @AuthenticationPrincipal AuthUserDetails authUser,
             @Valid @RequestPart("data") BannerRequest req,
@@ -55,6 +61,9 @@ public class AdminBannerController {
 
     @PutMapping(value = "/{bannerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이벤트 배너 수정", description = "multipart 요청: 'data' 파트에 배너 정보, 'file' 파트에 새 이미지(선택). 수정 즉시 앱 active 조회 응답에 반영됩니다.")
+    @RequestBody(content = @Content(
+            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+            encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
     public CustomResponse<BannerResponse> updateBanner(
             @PathVariable Long bannerId,
             @Valid @RequestPart("data") BannerRequest req,

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminPopupController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AdminPopupController.java
@@ -6,6 +6,9 @@ import com.storix.api.domain.event.controller.dto.PopupRequest;
 import com.storix.domain.domains.event.dto.PopupResponse;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -28,6 +31,9 @@ public class AdminPopupController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이벤트 팝업 생성", description = "multipart 요청: 'data'(application/json) 파트에 팝업 정보, 'file' 파트에 이미지. 서버가 이미지를 S3 업로드 후 생성합니다. 활성 팝업 노출 기간이 겹치면 생성할 수 없습니다.")
+    @RequestBody(content = @Content(
+            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+            encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
     public CustomResponse<PopupResponse> createPopup(
             @AuthenticationPrincipal AuthUserDetails authUser,
             @Valid @RequestPart("data") PopupRequest req,
@@ -55,6 +61,9 @@ public class AdminPopupController {
 
     @PutMapping(value = "/{popupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이벤트 팝업 수정", description = "multipart 요청: 'data' 파트에 팝업 정보, 'file' 파트에 새 이미지(선택 - 없으면 기존 이미지 유지). 수정 즉시 앱 active 조회 응답에 반영됩니다.")
+    @RequestBody(content = @Content(
+            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+            encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
     public CustomResponse<PopupResponse> updatePopup(
             @PathVariable Long popupId,
             @Valid @RequestPart("data") PopupRequest req,

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AppEventController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/AppEventController.java
@@ -2,6 +2,7 @@ package com.storix.api.domain.event.controller;
 
 import com.storix.api.domain.event.usecase.AppEventUseCase;
 import com.storix.common.payload.CustomResponse;
+import com.storix.domain.domains.event.dto.AppEventPageResponse;
 import com.storix.domain.domains.event.dto.BannerResponse;
 import com.storix.domain.domains.event.dto.OneTimeAppEventResponse;
 import com.storix.domain.domains.event.dto.PopupResponse;
@@ -25,6 +26,24 @@ import java.util.List;
 public class AppEventController {
 
     private final AppEventUseCase appEventUseCase;
+
+    @GetMapping("/{appEventId}")
+    @Operation(
+            summary = "앱 이벤트 상세 조회 (인증 불필요)",
+            description = """
+                    이벤트 상세 웹페이지(storix.kr/event/{appEventId})를 그리는 데 필요한 정보를 반환합니다.
+                    로그인하지 않아도 호출할 수 있으며, eventType 으로 어떤 화면을 그릴지 정하시면 됩니다.
+
+                    운영 설정값(홍보 수단, 응모권 지급 기준 등)은 내려가지 않습니다.
+                    존재하지 않는 이벤트, 그리고 아직 시작하지 않은 이벤트는 404입니다. (오픈 전 내용이 미리 노출되지 않도록)
+                    종료된 이벤트는 조회되며 status=ENDED 로 내려갑니다.
+                    """
+    )
+    public CustomResponse<AppEventPageResponse> getAppEvent(
+            @PathVariable Long appEventId
+    ) {
+        return appEventUseCase.getAppEventPage(appEventId);
+    }
 
     @GetMapping("/popup")
     @Operation(summary = "노출 중인 팝업 조회", description = "현재 노출 가능한 팝업을 반환합니다. 유저가 오늘 '다시 안 보기' 했거나 노출 팝업이 없으면 null.")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/AppEventRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/AppEventRequest.java
@@ -34,7 +34,7 @@ public record AppEventRequest(
 
         @Schema(
                 description = "이벤트 시작 시각. ATTENDANCE는 00:00, STORY_CARD는 06:00(카드 초기화 시각)에 맞춰야 합니다.",
-                example = "2026-07-01 00:00"
+                example = "2026-07-01 00:00", type = "string"
         )
         @NotNull(message = "이벤트 시작 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
@@ -43,7 +43,7 @@ public record AppEventRequest(
         @Schema(
                 description = "이벤트 종료 시각(exclusive). 시작 시각과 같은 경계에 맞춰야 하며, "
                         + "마지막 참여일의 다음 경계를 넣습니다. (7/31까지 출석 → 2026-08-01 00:00)",
-                example = "2026-08-01 00:00"
+                example = "2026-08-01 00:00", type = "string"
         )
         @NotNull(message = "이벤트 종료 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/AppEventRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/AppEventRequest.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
@@ -23,6 +24,15 @@ public record AppEventRequest(
         @Schema(description = "앱 이벤트 설명", example = "앱 출시를 기념한 첫 이벤트입니다.")
         @Size(max = 500, message = "앱 이벤트 설명은 500자 이하여야 합니다.")
         String description,
+
+        @Schema(
+                description = "이벤트 상세 웹페이지가 그릴 화면을 고르는 키. 같은 종류라도 회차마다 구성이 바뀌면 다른 값을 넣습니다. "
+                        + "비우면 종류별 기본 화면을 사용합니다. 쓸 수 있는 값은 프론트와 맞춰주세요.",
+                example = "attendance-2026-08-10"
+        )
+        @Size(max = 50, message = "페이지 키는 50자 이하여야 합니다.")
+        @Pattern(regexp = "^[a-z0-9]+(-[a-z0-9]+)*$", message = "페이지 키는 영소문자, 숫자, 하이픈만 사용할 수 있습니다.")
+        String pageKey,
 
         @Schema(
                 description = "이벤트 종류. ATTENDANCE / STORY_CARD는 전용 API가 이 값으로 진행 중인 이벤트를 찾으므로 "
@@ -68,6 +78,6 @@ public record AppEventRequest(
     }
 
     public AppEventCommand toCommand() {
-        return new AppEventCommand(name, description, eventType, startAt, endAt, hasWinner, promotionTypes, attendanceRewards);
+        return new AppEventCommand(name, description, pageKey, eventType, startAt, endAt, hasWinner, promotionTypes, attendanceRewards);
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/BannerRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/BannerRequest.java
@@ -24,12 +24,12 @@ public record BannerRequest(
         @Size(max = 100, message = "배너 제목은 100자 이하여야 합니다.")
         String bannerTitle,
 
-        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00")
+        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00", type = "string")
         @NotNull(message = "노출 시작 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayStartAt,
 
-        @Schema(description = "노출 종료 시각", example = "2026-06-30 23:59")
+        @Schema(description = "노출 종료 시각", example = "2026-06-30 00:00", type = "string")
         @NotNull(message = "노출 종료 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayEndAt

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/PopupRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/controller/dto/PopupRequest.java
@@ -37,12 +37,12 @@ public record PopupRequest(
         @Size(max = 40, message = "CTA 텍스트는 40자 이하여야 합니다.")
         String ctaText,
 
-        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00")
+        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00", type = "string")
         @NotNull(message = "노출 시작 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayStartAt,
 
-        @Schema(description = "노출 종료 시각", example = "2026-06-30 23:59")
+        @Schema(description = "노출 종료 시각", example = "2026-06-30 00:00", type = "string")
         @NotNull(message = "노출 종료 일시는 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayEndAt

--- a/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AppEventUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/event/usecase/AppEventUseCase.java
@@ -3,9 +3,11 @@ package com.storix.api.domain.event.usecase;
 import com.storix.common.code.SuccessCode;
 import com.storix.common.payload.CustomResponse;
 import com.storix.common.utils.RedisKeyStatic;
+import com.storix.domain.domains.event.dto.AppEventPageResponse;
 import com.storix.domain.domains.event.dto.BannerResponse;
 import com.storix.domain.domains.event.dto.OneTimeAppEventResponse;
 import com.storix.domain.domains.event.dto.PopupResponse;
+import com.storix.domain.domains.event.service.AppEventService;
 import com.storix.domain.domains.event.service.BannerService;
 import com.storix.domain.domains.event.service.EventContentCacheHelper;
 import com.storix.domain.domains.event.service.PopupDismissService;
@@ -24,6 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AppEventUseCase {
 
+    private final AppEventService appEventService;
     private final PopupService eventPopupService;
     private final PopupDismissService popupDismissService;
     private final BannerService eventBannerService;
@@ -32,6 +35,14 @@ public class AppEventUseCase {
     private final UserAppEventCacheHelper userAppEventCacheHelper;
 
     @Value("${AWS_S3_BASE_URL}") private String baseUrl;
+
+    // 이벤트 상세 웹페이지 렌더용 조회
+    public CustomResponse<AppEventPageResponse> getAppEventPage(Long appEventId) {
+
+        return CustomResponse.onSuccess(
+                SuccessCode.APP_EVENT_PAGE_LOAD_SUCCESS,
+                appEventService.getAppEventPage(appEventId));
+    }
 
     // 노출 중인 팝업 조회
     public CustomResponse<PopupResponse> getActivePopup(Long userId) {

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationRequest.java
@@ -74,6 +74,12 @@ public record AdminNotificationRequest(
         return targetAudience != AdminNotificationTargetAudience.EVENT_WINNERS || eventTargetId != null;
     }
 
+    @AssertTrue(message = "이벤트 당첨자 발송(EVENT_WINNERS)은 외부 링크(EXTERNAL) 이동만 지원합니다.")
+    private boolean isExternalWhenEventWinners() {
+        return targetAudience != AdminNotificationTargetAudience.EVENT_WINNERS
+                || targetType == AdminNotificationTargetType.EXTERNAL;
+    }
+
     @AssertTrue(message = "타겟 타입에 필요한 값이 없습니다. (APP_EVENT: eventTargetId, EXTERNAL: targetLink)")
     private boolean isTargetConsistent() {
         if (targetType == null) return true;

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationResponse.java
@@ -27,6 +27,7 @@ public record AdminNotificationResponse(
         @Schema(description = "발송 방식 (IMMEDIATE: 즉시 발송, SCHEDULED: 예약 발송)")
         AdminNotificationSendType sendType,
 
+        @Schema(description = "예약 발송 시각 (KST)", example = "2026-07-04 14:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime scheduledAt,
 
@@ -45,9 +46,11 @@ public record AdminNotificationResponse(
         @Schema(description = "이동할 앱 외부 URL (targetType=EXTERNAL 일 때만, 그 외 null)")
         String targetLink,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime createdAt,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime updatedAt
 ) {

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationSummaryResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/AdminNotificationSummaryResponse.java
@@ -27,7 +27,8 @@ public record AdminNotificationSummaryResponse(
         @Schema(description = "발송 방식 (IMMEDIATE: 즉시 발송, SCHEDULED: 예약 발송)")
         AdminNotificationSendType sendType,
 
-        @Schema(description = "발송 일시 (KST). 예약 발송(SCHEDULED)은 지정한 예약 시각, 즉시 발송(IMMEDIATE)은 발송 시점이 기록됩니다.")
+        @Schema(description = "발송 일시 (KST). 예약 발송(SCHEDULED)은 지정한 예약 시각, 즉시 발송(IMMEDIATE)은 발송 시점이 기록됩니다.",
+                example = "2026-07-04 14:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime scheduledAt,
 

--- a/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/ErrorCode.java
@@ -109,6 +109,7 @@ public enum ErrorCode {
     ADMIN_NOTIFICATION_NOT_CANCELABLE(HttpStatus.BAD_REQUEST, "ADMIN_NOTIFICATION_ERROR_008", "발송 예정 상태에서만 취소할 수 있습니다."),
     ADMIN_NOTIFICATION_NOT_REBROADCASTABLE(HttpStatus.BAD_REQUEST, "ADMIN_NOTIFICATION_ERROR_009", "발송 실패 상태에서만 재발송할 수 있습니다."),
     ADMIN_NOTIFICATION_MARKETING_NIGHT_BLOCKED(HttpStatus.BAD_REQUEST, "ADMIN_NOTIFICATION_ERROR_010", "야간(21시~익일 8시)에는 마케팅 알림을 발송할 수 없습니다."),
+    ADMIN_NOTIFICATION_EVENT_NO_WINNER(HttpStatus.BAD_REQUEST, "ADMIN_NOTIFICATION_ERROR_011", "당첨자를 뽑지 않는 이벤트는 당첨자 발송(EVENT_WINNERS) 대상으로 지정할 수 없습니다."),
 
     // Event Popup error
     EVENT_POPUP_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT_POPUP_ERROR_001", "존재하지 않는 이벤트 팝업입니다."),
@@ -134,6 +135,7 @@ public enum ErrorCode {
     ADMIN_APP_EVENT_INVALID_ATTENDANCE_REWARDS(HttpStatus.BAD_REQUEST, "ADMIN_APP_EVENT_ERROR_005", "출석 응모권 지급 기준은 출석일 1 이상, 응모권 0 이상이며 출석일이 늘수록 누적 응모권이 줄어들 수 없습니다."),
     ADMIN_APP_EVENT_OVERLAPPING_TYPE(HttpStatus.CONFLICT, "ADMIN_APP_EVENT_ERROR_006", "같은 종류의 이벤트를 같은 기간에 두 개 이상 진행할 수 없습니다."),
     ADMIN_APP_EVENT_INVALID_PERIOD_BOUNDARY(HttpStatus.BAD_REQUEST, "ADMIN_APP_EVENT_ERROR_007", "이벤트 종류별 기준 시각에 시작/종료 일시를 맞춰야 합니다. (출석 체크 00:00, 오늘의 스토리 카드 06:00)"),
+    ADMIN_APP_EVENT_FINALIZED_NOT_MODIFIABLE(HttpStatus.CONFLICT, "ADMIN_APP_EVENT_ERROR_008", "당첨자가 확정된 이벤트는 이벤트 종류, 기간, 당첨자 추첨 여부, 출석 응모권 지급 기준을 수정할 수 없습니다."),
 
     // App Event error
     APP_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "APP_EVENT_ERROR_001", "존재하지 않는 앱 이벤트입니다."),
@@ -142,6 +144,7 @@ public enum ErrorCode {
     APP_EVENT_WINNER_FINALIZER_NOT_IMPLEMENTED(HttpStatus.INTERNAL_SERVER_ERROR, "APP_EVENT_ERROR_004", "당첨자 이벤트(hasWinner=true)는 종료 시 당첨자 확정(EventWinnerFinalizer) 구현이 필수입니다."),
     APP_EVENT_NO_WINNER(HttpStatus.BAD_REQUEST, "APP_EVENT_ERROR_005", "당첨자를 뽑지 않는 이벤트입니다."),
     APP_EVENT_INVALID_WINNER_COUNT(HttpStatus.BAD_REQUEST, "APP_EVENT_ERROR_006", "추첨 인원은 1명 이상이어야 합니다."),
+    APP_EVENT_NOT_ENDED(HttpStatus.BAD_REQUEST, "APP_EVENT_ERROR_007", "종료된 이벤트만 당첨자를 확정할 수 있습니다. 조기 확정이 필요하면 이벤트를 먼저 강제 종료해주세요."),
 
     // Attendance Event error
     ATTENDANCE_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ATTENDANCE_EVENT_ERROR_001", "진행 중인 출석 이벤트가 없습니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -44,6 +44,7 @@ public enum SuccessCode {
     APP_EVENT_ACK_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_002", "앱 이벤트 확인 처리에 성공했습니다."),
     APP_EVENT_POPUP_DISMISS_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_003", "팝업 오늘 다시 안 보기 처리에 성공했습니다."),
     APP_EVENT_POPUP_NEVER_SHOW_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_004", "팝업 다시 보지 않기 처리에 성공했습니다."),
+    APP_EVENT_PAGE_LOAD_SUCCESS(HttpStatus.OK, "APP_EVENT_SUCCESS_005", "앱 이벤트 상세 조회에 성공했습니다."),
     ATTENDANCE_EVENT_LOAD_SUCCESS(HttpStatus.OK, "ATTENDANCE_EVENT_SUCCESS_001", "출석 이벤트 현황 조회에 성공했습니다."),
     ATTENDANCE_EVENT_CHECK_IN_SUCCESS(HttpStatus.OK, "ATTENDANCE_EVENT_SUCCESS_002", "출석 체크에 성공했습니다."),
     ATTENDANCE_EVENT_WINNERS_LOAD_SUCCESS(HttpStatus.OK, "ATTENDANCE_EVENT_SUCCESS_004", "출석 이벤트 당첨자 조회에 성공했습니다."),

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/AppEventWinnerAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/adaptor/AppEventWinnerAdaptor.java
@@ -18,6 +18,10 @@ public class AppEventWinnerAdaptor {
         return appEventWinnerRepository.findWinnerUserIds(appEventId, lastUserId, pageable);
     }
 
+    public boolean existsWinner(Long appEventId) {
+        return appEventWinnerRepository.existsByAppEventId(appEventId);
+    }
+
     public List<EventWinner> findWinners(Long appEventId) {
         return appEventWinnerRepository.findWinners(appEventId);
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AppEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AppEvent.java
@@ -135,6 +135,11 @@ public class AppEvent extends BaseTimeEntity {
         return !now.isBefore(startAt) && now.isBefore(endAt);
     }
 
+    // end_at은 exclusive 경계라 그 시점부터 종료로 본다
+    public boolean isEndedAt(LocalDateTime now) {
+        return !now.isBefore(endAt);
+    }
+
     // 이벤트 종류별 기준 시각(출석 자정 / 스토리 카드 06:00)으로 계산한 서비스 날짜
     public LocalDate serviceDateOf(LocalDateTime now) {
         return eventType.serviceDateOf(now);

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AppEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/domain/AppEvent.java
@@ -37,6 +37,11 @@ public class AppEvent extends BaseTimeEntity {
     @Column(name = "description", length = 500)
     private String description;
 
+    // 상세 웹페이지가 그릴 화면을 고르는 키. 같은 종류라도 회차마다 구성이 다를 수 있어 회차별로 지정한다.
+    // URL에 쓰지 않으므로 나중에 바꿔도 이미 나간 링크는 살아 있다
+    @Column(name = "page_key", length = 50)
+    private String pageKey;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "event_type", nullable = false, length = 20)
     private AppEventType eventType;
@@ -77,6 +82,7 @@ public class AppEvent extends BaseTimeEntity {
     @Builder
     public AppEvent(String name,
                     String description,
+                    String pageKey,
                     AppEventType eventType,
                     LocalDateTime startAt,
                     LocalDateTime endAt,
@@ -86,6 +92,7 @@ public class AppEvent extends BaseTimeEntity {
                     Long assigneeAdminId) {
         this.name = name;
         this.description = description;
+        this.pageKey = pageKey;
         this.eventType = eventType == null ? AppEventType.GENERAL : eventType;
         this.startAt = startAt;
         this.endAt = endAt;
@@ -101,6 +108,7 @@ public class AppEvent extends BaseTimeEntity {
 
     public void update(String name,
                        String description,
+                       String pageKey,
                        AppEventType eventType,
                        LocalDateTime startAt,
                        LocalDateTime endAt,
@@ -109,6 +117,7 @@ public class AppEvent extends BaseTimeEntity {
                        Map<Integer, Integer> attendanceRewards) {
         this.name = name;
         this.description = description;
+        this.pageKey = pageKey;
         if (eventType != null) {
             this.eventType = eventType;
         }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventCommand.java
@@ -10,6 +10,7 @@ import java.util.Set;
 public record AppEventCommand(
         String name,
         String description,
+        String pageKey,
         AppEventType eventType,
         LocalDateTime startAt,
         LocalDateTime endAt,

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventPageResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventPageResponse.java
@@ -1,0 +1,54 @@
+package com.storix.domain.domains.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.storix.domain.domains.event.domain.AppEvent;
+import com.storix.domain.domains.event.domain.AppEventStatus;
+import com.storix.domain.domains.event.domain.AppEventType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+// 상세 웹페이지 렌더용. 비로그인도 조회하므로 홍보 수단이나 응모권 지급표 같은 운영값은 담지 않는다
+@Builder
+public record AppEventPageResponse(
+        Long id,
+
+        String name,
+
+        String description,
+
+        @Schema(description = "이벤트 종류 (GENERAL / ATTENDANCE / STORY_CARD)")
+        AppEventType eventType,
+
+        @Schema(
+                description = "그릴 화면을 고르는 키. 같은 종류라도 회차마다 구성이 다를 수 있으니 이 값을 우선 보고, "
+                        + "비어 있거나 모르는 값이면 eventType 기준 기본 화면으로 넘어가주세요.",
+                example = "attendance-2026-08-10"
+        )
+        String pageKey,
+
+        @Schema(description = "이벤트 시작 시각", example = "2026-07-01 00:00", type = "string")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        LocalDateTime startAt,
+
+        @Schema(description = "이벤트 종료 시각(exclusive)", example = "2026-08-01 00:00", type = "string")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        LocalDateTime endAt,
+
+        @Schema(description = "기간으로 파생 계산되는 상태 (SCHEDULED / ACTIVE / ENDED)")
+        AppEventStatus status
+) {
+    public static AppEventPageResponse from(AppEvent appEvent) {
+        return AppEventPageResponse.builder()
+                .id(appEvent.getId())
+                .name(appEvent.getName())
+                .description(appEvent.getDescription())
+                .eventType(appEvent.getEventType())
+                .pageKey(appEvent.getPageKey())
+                .startAt(appEvent.getStartAt())
+                .endAt(appEvent.getEndAt())
+                .status(AppEventStatus.resolve(appEvent.getStartAt(), appEvent.getEndAt(), LocalDateTime.now()))
+                .build();
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
@@ -20,6 +20,9 @@ public record AppEventResponse(
 
         String description,
 
+        @Schema(description = "이벤트 상세 웹페이지가 그릴 화면을 고르는 키. 비어 있으면 종류별 기본 화면", example = "attendance-2026-08-10")
+        String pageKey,
+
         @Schema(description = "이벤트 종류 (GENERAL / ATTENDANCE / STORY_CARD)")
         AppEventType eventType,
 
@@ -56,6 +59,7 @@ public record AppEventResponse(
                 .id(appEvent.getId())
                 .name(appEvent.getName())
                 .description(appEvent.getDescription())
+                .pageKey(appEvent.getPageKey())
                 .eventType(appEvent.getEventType())
                 .startAt(appEvent.getStartAt())
                 .endAt(appEvent.getEndAt())

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/AppEventResponse.java
@@ -23,9 +23,11 @@ public record AppEventResponse(
         @Schema(description = "이벤트 종류 (GENERAL / ATTENDANCE / STORY_CARD)")
         AppEventType eventType,
 
+        @Schema(description = "이벤트 시작 시각", example = "2026-07-01 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime startAt,
 
+        @Schema(description = "이벤트 종료 시각(exclusive)", example = "2026-08-01 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime endAt,
 
@@ -41,9 +43,11 @@ public record AppEventResponse(
         @Schema(description = "출석 이벤트 응모권 지급 기준 (키=누적 출석일, 값=누적 지급 응모권). 미지정 시 빈 값")
         Map<Integer, Integer> attendanceRewards,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime createdAt,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime updatedAt
 ) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/BannerResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/BannerResponse.java
@@ -25,18 +25,22 @@ public record BannerResponse(
 
         String imageUrl,
 
+        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayStartAt,
 
+        @Schema(description = "노출 종료 시각", example = "2026-06-30 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayEndAt,
 
         @Schema(description = "배너 상태")
         BannerStatus status,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime createdAt,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime updatedAt
 ) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/PopupResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/dto/PopupResponse.java
@@ -33,18 +33,22 @@ public record PopupResponse(
 
         String ctaText,
 
+        @Schema(description = "노출 시작 시각", example = "2026-06-25 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayStartAt,
 
+        @Schema(description = "노출 종료 시각", example = "2026-06-30 00:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime displayEndAt,
 
         @Schema(description = "팝업 상태")
         PopupStatus status,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime createdAt,
 
+        @Schema(example = "2026-06-20 10:00", type = "string")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime updatedAt
 ) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AppEventFinalizedNotModifiableException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AppEventFinalizedNotModifiableException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.event.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class AppEventFinalizedNotModifiableException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new AppEventFinalizedNotModifiableException();
+
+    private AppEventFinalizedNotModifiableException() { super(ErrorCode.ADMIN_APP_EVENT_FINALIZED_NOT_MODIFIABLE); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AppEventNotEndedException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/exception/AppEventNotEndedException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.event.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class AppEventNotEndedException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new AppEventNotEndedException();
+
+    private AppEventNotEndedException() { super(ErrorCode.APP_EVENT_NOT_ENDED); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/AppEventWinnerRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/repository/AppEventWinnerRepository.java
@@ -26,6 +26,9 @@ public interface AppEventWinnerRepository extends JpaRepository<AppEventWinner, 
             Pageable pageable
     );
 
+    // 확정 여부 판정용
+    boolean existsByAppEventId(Long appEventId);
+
     // 확정된 당첨자를 뽑힌 순서대로
     @Query("""
         SELECT new com.storix.domain.domains.event.dto.EventWinner(w.userId, w.drawOrder)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
@@ -3,14 +3,17 @@ package com.storix.domain.domains.event.service;
 import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
 import com.storix.domain.domains.event.adaptor.AppEventWinnerAdaptor;
 import com.storix.domain.domains.event.domain.AppEvent;
+import com.storix.domain.domains.event.domain.AppEventStatus;
 import com.storix.domain.domains.event.domain.AppEventType;
 import com.storix.domain.domains.event.dto.AppEventCommand;
+import com.storix.domain.domains.event.dto.AppEventPageResponse;
 import com.storix.domain.domains.event.dto.AppEventResponse;
 import com.storix.domain.domains.event.exception.AppEventInvalidAttendanceRewardsException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodBoundaryException;
 import com.storix.domain.domains.event.exception.AppEventFinalizedNotModifiableException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodException;
 import com.storix.domain.domains.event.exception.AppEventNameRequiredException;
+import com.storix.domain.domains.event.exception.AppEventNotFoundException;
 import com.storix.domain.domains.event.exception.AppEventOverlappingTypeException;
 import com.storix.domain.domains.event.exception.AppEventPeriodRequiredException;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +48,7 @@ public class AppEventService {
         AppEvent saved = appEventAdaptor.save(AppEvent.builder()
                 .name(cmd.name())
                 .description(cmd.description())
+                .pageKey(cmd.pageKey())
                 .eventType(eventType)
                 .startAt(cmd.startAt())
                 .endAt(cmd.endAt())
@@ -73,6 +77,7 @@ public class AppEventService {
         appEvent.update(
                 cmd.name(),
                 cmd.description(),
+                cmd.pageKey(),
                 eventType,
                 cmd.startAt(),
                 cmd.endAt(),
@@ -91,6 +96,17 @@ public class AppEventService {
     @Transactional(readOnly = true)
     public AppEventResponse getAppEvent(Long appEventId) {
         return AppEventResponse.from(appEventAdaptor.findById(appEventId));
+    }
+
+    // 시작 전 이벤트는 없는 것으로 취급한다. id를 훑어 오픈 전 내용을 미리 보면 안 된다
+    @Transactional(readOnly = true)
+    public AppEventPageResponse getAppEventPage(Long appEventId) {
+        AppEvent appEvent = appEventAdaptor.findById(appEventId);
+        if (AppEventStatus.resolve(appEvent.getStartAt(), appEvent.getEndAt(), LocalDateTime.now())
+                == AppEventStatus.SCHEDULED) {
+            throw AppEventNotFoundException.EXCEPTION;
+        }
+        return AppEventPageResponse.from(appEvent);
     }
 
     @Transactional(readOnly = true)

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/AppEventService.java
@@ -1,12 +1,14 @@
 package com.storix.domain.domains.event.service;
 
 import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
+import com.storix.domain.domains.event.adaptor.AppEventWinnerAdaptor;
 import com.storix.domain.domains.event.domain.AppEvent;
 import com.storix.domain.domains.event.domain.AppEventType;
 import com.storix.domain.domains.event.dto.AppEventCommand;
 import com.storix.domain.domains.event.dto.AppEventResponse;
 import com.storix.domain.domains.event.exception.AppEventInvalidAttendanceRewardsException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodBoundaryException;
+import com.storix.domain.domains.event.exception.AppEventFinalizedNotModifiableException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodException;
 import com.storix.domain.domains.event.exception.AppEventNameRequiredException;
 import com.storix.domain.domains.event.exception.AppEventOverlappingTypeException;
@@ -29,6 +31,7 @@ public class AppEventService {
     private static final int APP_EVENT_PAGE_SIZE = 10;
 
     private final AppEventAdaptor appEventAdaptor;
+    private final AppEventWinnerAdaptor appEventWinnerAdaptor;
     private final PopupService popupService;
     private final BannerService bannerService;
 
@@ -65,6 +68,7 @@ public class AppEventService {
         if (periodChanged || eventType != appEvent.getEventType()) {
             validatePeriodBoundary(eventType, cmd.startAt(), cmd.endAt());
         }
+        validateDrawBasisImmutable(appEvent, cmd, eventType);
         validateNoOverlap(eventType, cmd.startAt(), cmd.endAt(), appEventId);
         appEvent.update(
                 cmd.name(),
@@ -135,6 +139,22 @@ public class AppEventService {
         }
         if (appEventAdaptor.lockAndCheckOverlappingByType(eventType, startAt, endAt, excludeAppEventId)) {
             throw AppEventOverlappingTypeException.EXCEPTION;
+        }
+    }
+
+    // 확정된 당첨자가 있으면 추첨 근거가 되는 값은 잠근다.
+    private void validateDrawBasisImmutable(AppEvent appEvent, AppEventCommand cmd, AppEventType eventType) {
+        if (!appEventWinnerAdaptor.existsWinner(appEvent.getId())) {
+            return;
+        }
+        Map<Integer, Integer> rewards = cmd.attendanceRewards() == null ? Map.of() : cmd.attendanceRewards();
+        boolean drawBasisChanged = eventType != appEvent.getEventType()
+                || !appEvent.getStartAt().equals(cmd.startAt())
+                || !appEvent.getEndAt().equals(cmd.endAt())
+                || appEvent.isHasWinner() != cmd.hasWinner()
+                || !appEvent.getAttendanceRewards().equals(rewards);
+        if (drawBasisChanged) {
+            throw AppEventFinalizedNotModifiableException.EXCEPTION;
         }
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/winner/AppEventFinalizeService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/event/service/winner/AppEventFinalizeService.java
@@ -7,6 +7,7 @@ import com.storix.domain.domains.event.dto.AppEventWinnerDrawResponse;
 import com.storix.domain.domains.event.dto.EventWinner;
 import com.storix.domain.domains.event.exception.AppEventInvalidWinnerCountException;
 import com.storix.domain.domains.event.exception.AppEventNoWinnerException;
+import com.storix.domain.domains.event.exception.AppEventNotEndedException;
 import com.storix.domain.domains.event.exception.EventWinnerFinalizerNotImplementedException;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -49,6 +51,12 @@ public class AppEventFinalizeService {
                     .addKeyValue("winnerCount", confirmed.size())
                     .log(">>> [AppEvent] 이미 확정된 이벤트 - 재추첨 없이 반환");
             return toResponse(appEventId, true, confirmed);
+        }
+
+        // 추첨은 되돌릴 수 없어 진행 중 확정 시 남은 기간 참여자가 영구 제외된다.
+        // 조기 확정이 필요하면 이벤트를 강제 종료해 end_at을 당긴 뒤 확정한다
+        if (!event.isEndedAt(LocalDateTime.now())) {
+            throw AppEventNotEndedException.EXCEPTION;
         }
 
         EventWinnerFinalizer finalizer = finalizers.stream()

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/exception/AdminNotificationEventNoWinnerException.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/exception/AdminNotificationEventNoWinnerException.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.notification.exception;
+
+import com.storix.common.code.ErrorCode;
+import com.storix.common.exception.STORIXCodeException;
+
+public class AdminNotificationEventNoWinnerException extends STORIXCodeException {
+
+    public static final STORIXCodeException EXCEPTION = new AdminNotificationEventNoWinnerException();
+
+    private AdminNotificationEventNoWinnerException() { super(ErrorCode.ADMIN_NOTIFICATION_EVENT_NO_WINNER); }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/AdminNotificationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/AdminNotificationService.java
@@ -1,8 +1,11 @@
 package com.storix.domain.domains.notification.service;
 
+import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
 import com.storix.domain.domains.notification.adaptor.AdminNotificationAdaptor;
 import com.storix.domain.domains.notification.domain.AdminNotification;
+import com.storix.domain.domains.notification.domain.AdminNotificationTargetAudience;
 import com.storix.domain.domains.notification.dto.AdminNotificationCommand;
+import com.storix.domain.domains.notification.exception.AdminNotificationEventNoWinnerException;
 import com.storix.domain.domains.notification.exception.AdminNotificationNotCancelableException;
 import com.storix.domain.domains.notification.exception.AdminNotificationNotUpdatableException;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +22,11 @@ public class AdminNotificationService {
     private static final int NOTIFICATION_PAGE_SIZE = 10;
 
     private final AdminNotificationAdaptor adminNotificationAdaptor;
+    private final AppEventAdaptor appEventAdaptor;
 
     @Transactional
     public Long create(AdminNotificationCommand cmd, Long assigneeAdminId) {
+        validateEventWinnersTarget(cmd);
         return adminNotificationAdaptor.save(AdminNotification.builder()
                 .title(cmd.title())
                 .content(cmd.content())
@@ -42,6 +47,7 @@ public class AdminNotificationService {
         if (!adminNotification.isScheduled()) {
             throw AdminNotificationNotUpdatableException.EXCEPTION;
         }
+        validateEventWinnersTarget(cmd);
 
         adminNotification.update(
                 cmd.title(),
@@ -55,6 +61,17 @@ public class AdminNotificationService {
                 cmd.targetLink()
         );
         return adminNotification;
+    }
+
+    // 당첨자 발송은 대상 이벤트가 당첨자를 뽑는 이벤트일 때만 허용한다.
+    // hasWinner=false 인데 과거에 확정된 당첨자 행이 남아 있으면 그대로 발송돼버린다
+    private void validateEventWinnersTarget(AdminNotificationCommand cmd) {
+        if (cmd.targetAudience() != AdminNotificationTargetAudience.EVENT_WINNERS || cmd.eventTargetId() == null) {
+            return;
+        }
+        if (!appEventAdaptor.findById(cmd.eventTargetId()).isHasWinner()) {
+            throw AdminNotificationEventNoWinnerException.EXCEPTION;
+        }
     }
 
     @Transactional(readOnly = true)

--- a/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AppEventServiceTest.java
+++ b/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AppEventServiceTest.java
@@ -1,11 +1,13 @@
 package com.storix.domain.domains.event.service;
 
 import com.storix.domain.domains.event.adaptor.AppEventAdaptor;
+import com.storix.domain.domains.event.adaptor.AppEventWinnerAdaptor;
 import com.storix.domain.domains.event.domain.AppEvent;
 import com.storix.domain.domains.event.domain.AppEventStatus;
 import com.storix.domain.domains.event.domain.AppEventType;
 import com.storix.domain.domains.event.dto.AppEventCommand;
 import com.storix.domain.domains.event.dto.AppEventResponse;
+import com.storix.domain.domains.event.exception.AppEventFinalizedNotModifiableException;
 import com.storix.domain.domains.event.exception.AppEventInvalidAttendanceRewardsException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodBoundaryException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodException;
@@ -44,6 +46,9 @@ class AppEventServiceTest {
 
     @Mock
     private AppEventAdaptor appEventAdaptor;
+
+    @Mock
+    private AppEventWinnerAdaptor appEventWinnerAdaptor;
 
     @Mock
     private PopupService popupService;
@@ -375,6 +380,95 @@ class AppEventServiceTest {
                     .isEqualTo(AppEventStatus.ENDED);
             assertThat(AppEventStatus.resolve(NOW.minusDays(5), NOW.minusDays(1), NOW))
                     .isEqualTo(AppEventStatus.ENDED);
+        }
+    }
+
+    // 확정된 당첨자를 어떤 기준으로 뽑았는지 사후에 재현할 수 있어야 한다
+    @Nested
+    @DisplayName("당첨자 확정 이후 수정 제한")
+    class FinalizedImmutability {
+
+        private final LocalDateTime START = LocalDate.of(2026, 8, 1).atStartOfDay();
+        private final LocalDateTime END = LocalDate.of(2026, 8, 11).atStartOfDay();
+
+        private AppEventCommand commandOf(String name, LocalDateTime startAt, LocalDateTime endAt,
+                                          boolean hasWinner, Map<Integer, Integer> rewards) {
+            return new AppEventCommand(name, "설명", AppEventType.ATTENDANCE, startAt, endAt, hasWinner, Set.of(), rewards);
+        }
+
+        private void givenFinalizedEvent(boolean hasWinner, Map<Integer, Integer> rewards) {
+            AppEvent e = AppEvent.builder()
+                    .name("출석 이벤트").description("설명")
+                    .eventType(AppEventType.ATTENDANCE)
+                    .startAt(START).endAt(END)
+                    .hasWinner(hasWinner)
+                    .attendanceRewards(rewards)
+                    .build();
+            ReflectionTestUtils.setField(e, "id", ID);
+            given(appEventAdaptor.findById(ID)).willReturn(e);
+            given(appEventWinnerAdaptor.existsWinner(ID)).willReturn(true);
+        }
+
+        @Test
+        @DisplayName("기간을 바꾸면 409")
+        void rejects_period_change() {
+            givenFinalizedEvent(true, Map.of(1, 1));
+
+            assertThatThrownBy(() -> appEventService.update(
+                    ID, commandOf("출석 이벤트", START, END.plusDays(7), true, Map.of(1, 1))))
+                    .isInstanceOf(AppEventFinalizedNotModifiableException.class);
+        }
+
+        @Test
+        @DisplayName("응모권 지급표를 바꾸면 409")
+        void rejects_rewards_change() {
+            givenFinalizedEvent(true, Map.of(1, 1));
+
+            assertThatThrownBy(() -> appEventService.update(
+                    ID, commandOf("출석 이벤트", START, END, true, Map.of(1, 5))))
+                    .isInstanceOf(AppEventFinalizedNotModifiableException.class);
+        }
+
+        // hasWinner를 내려도 당첨자 행은 남아 당첨 알림이 계속 나갈 수 있다
+        @Test
+        @DisplayName("hasWinner를 내리면 409")
+        void rejects_has_winner_change() {
+            givenFinalizedEvent(true, Map.of(1, 1));
+
+            assertThatThrownBy(() -> appEventService.update(
+                    ID, commandOf("출석 이벤트", START, END, false, Map.of(1, 1))))
+                    .isInstanceOf(AppEventFinalizedNotModifiableException.class);
+        }
+
+        @Test
+        @DisplayName("이름·설명만 바꾸는 수정은 확정 이후에도 허용한다")
+        void allows_name_change() {
+            givenFinalizedEvent(true, Map.of(1, 1));
+
+            AppEventResponse updated = appEventService.update(
+                    ID, commandOf("출석 이벤트 (수정)", START, END, true, Map.of(1, 1)));
+
+            assertThat(updated.name()).isEqualTo("출석 이벤트 (수정)");
+        }
+
+        @Test
+        @DisplayName("확정 전이면 추첨 근거 값도 자유롭게 바꾼다")
+        void allows_everything_before_finalize() {
+            AppEvent e = AppEvent.builder()
+                    .name("출석 이벤트").description("설명")
+                    .eventType(AppEventType.ATTENDANCE)
+                    .startAt(START).endAt(END)
+                    .hasWinner(true)
+                    .attendanceRewards(Map.of(1, 1))
+                    .build();
+            ReflectionTestUtils.setField(e, "id", ID);
+            given(appEventAdaptor.findById(ID)).willReturn(e);
+            given(appEventWinnerAdaptor.existsWinner(ID)).willReturn(false);
+
+            AppEventResponse updated = appEventService.update(
+                    ID, commandOf("출석 이벤트", START, END.plusDays(7), true, Map.of(1, 5)));
+
+            assertThat(updated.attendanceRewards()).containsEntry(1, 5);
         }
     }
 }

--- a/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AppEventServiceTest.java
+++ b/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/AppEventServiceTest.java
@@ -7,6 +7,8 @@ import com.storix.domain.domains.event.domain.AppEventStatus;
 import com.storix.domain.domains.event.domain.AppEventType;
 import com.storix.domain.domains.event.dto.AppEventCommand;
 import com.storix.domain.domains.event.dto.AppEventResponse;
+import com.storix.domain.domains.event.exception.AppEventNotFoundException;
+import com.storix.domain.domains.event.dto.AppEventPageResponse;
 import com.storix.domain.domains.event.exception.AppEventFinalizedNotModifiableException;
 import com.storix.domain.domains.event.exception.AppEventInvalidAttendanceRewardsException;
 import com.storix.domain.domains.event.exception.AppEventInvalidPeriodBoundaryException;
@@ -60,7 +62,7 @@ class AppEventServiceTest {
     private AppEventService appEventService;
 
     private AppEventCommand command(LocalDateTime startAt, LocalDateTime endAt) {
-        return new AppEventCommand("앱 출시 이벤트", "설명", null, startAt, endAt, false, Set.of(), Map.of());
+        return new AppEventCommand("앱 출시 이벤트", "설명", null, null, startAt, endAt, false, Set.of(), Map.of());
     }
 
     private AppEvent appEvent(LocalDateTime startAt, LocalDateTime endAt) {
@@ -82,7 +84,7 @@ class AppEventServiceTest {
         private final LocalDateTime END = LocalDate.of(2026, 8, 11).atStartOfDay();
 
         private AppEventCommand typedCommand(AppEventType eventType, LocalDateTime startAt, LocalDateTime endAt) {
-            return new AppEventCommand("출석 이벤트", "설명", eventType, startAt, endAt, false, Set.of(), Map.of());
+            return new AppEventCommand("출석 이벤트", "설명", null, eventType, startAt, endAt, false, Set.of(), Map.of());
         }
 
         @Test
@@ -142,7 +144,7 @@ class AppEventServiceTest {
         private final LocalDate DAY = LocalDate.of(2026, 8, 1);
 
         private AppEventCommand typedCommand(AppEventType eventType, LocalDateTime startAt, LocalDateTime endAt) {
-            return new AppEventCommand("이벤트", "설명", eventType, startAt, endAt, false, Set.of(), Map.of());
+            return new AppEventCommand("이벤트", "설명", null, eventType, startAt, endAt, false, Set.of(), Map.of());
         }
 
         @Test
@@ -268,7 +270,7 @@ class AppEventServiceTest {
         @DisplayName("이름이 비면 예외 - 저장하지 않는다")
         void reject_blank_name() {
             LocalDateTime start = LocalDateTime.now().plusDays(1);
-            AppEventCommand cmd = new AppEventCommand("  ", "설명", null, start, start.plusDays(1), false, Set.of(), Map.of());
+            AppEventCommand cmd = new AppEventCommand("  ", "설명", null, null, start, start.plusDays(1), false, Set.of(), Map.of());
 
             assertThatThrownBy(() -> appEventService.create(cmd, ADMIN_ID))
                     .isInstanceOf(AppEventNameRequiredException.class);
@@ -298,12 +300,83 @@ class AppEventServiceTest {
             LocalDateTime start = LocalDateTime.now().plusDays(1);
             LocalDateTime end = start.plusDays(20);
             Map<Integer, Integer> rewards = Map.of(5, 1, 10, 3, 20, 10);
-            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, start, end, false, Set.of(), rewards);
+            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, null, start, end, false, Set.of(), rewards);
             given(appEventAdaptor.save(any(AppEvent.class))).willAnswer(inv -> inv.getArgument(0));
 
             AppEventResponse saved = appEventService.create(cmd, ADMIN_ID);
 
             assertThat(saved.attendanceRewards()).containsExactlyInAnyOrderEntriesOf(rewards);
+        }
+
+        // 같은 종류라도 회차마다 다른 화면을 그릴 수 있어야 한다
+        @Test
+        @DisplayName("페이지 키를 지정하면 그대로 저장하고, 없으면 null 로 둔다")
+        void create_with_page_key() {
+            LocalDateTime start = LocalDateTime.now().plusDays(1);
+            LocalDateTime end = start.plusDays(20);
+            given(appEventAdaptor.save(any(AppEvent.class))).willAnswer(inv -> inv.getArgument(0));
+
+            AppEventResponse withKey = appEventService.create(
+                    new AppEventCommand("출석 이벤트", "설명", "attendance-2026-08-10", null, start, end, false, Set.of(), Map.of()),
+                    ADMIN_ID);
+            AppEventResponse withoutKey = appEventService.create(
+                    new AppEventCommand("출석 이벤트", "설명", null, null, start, end, false, Set.of(), Map.of()),
+                    ADMIN_ID);
+
+            assertThat(withKey.pageKey()).isEqualTo("attendance-2026-08-10");
+            assertThat(withoutKey.pageKey()).isNull();
+        }
+    }
+
+    // 웹페이지용 공개 조회는 인증이 없으므로 노출 범위를 좁게 잡는다
+    @Nested
+    @DisplayName("getAppEventPage - 이벤트 상세 웹페이지용 공개 조회")
+    class GetAppEventPage {
+
+        private AppEvent appEventOf(LocalDateTime startAt, LocalDateTime endAt) {
+            AppEvent e = AppEvent.builder()
+                    .name("출석 이벤트").description("설명")
+                    .pageKey("attendance-2026-08-10")
+                    .eventType(AppEventType.ATTENDANCE)
+                    .startAt(startAt).endAt(endAt)
+                    .build();
+            ReflectionTestUtils.setField(e, "id", ID);
+            return e;
+        }
+
+        @Test
+        @DisplayName("진행 중인 이벤트는 종류와 페이지 키를 함께 반환한다")
+        void active_event_ok() {
+            LocalDateTime now = LocalDateTime.now();
+            given(appEventAdaptor.findById(ID)).willReturn(appEventOf(now.minusDays(1), now.plusDays(10)));
+
+            AppEventPageResponse page = appEventService.getAppEventPage(ID);
+
+            assertThat(page.id()).isEqualTo(ID);
+            assertThat(page.eventType()).isEqualTo(AppEventType.ATTENDANCE);
+            assertThat(page.pageKey()).isEqualTo("attendance-2026-08-10");
+            assertThat(page.status()).isEqualTo(AppEventStatus.ACTIVE);
+        }
+
+        // 과거 링크로 들어온 유저에게 종료 안내를 보여줄 수 있어야 한다
+        @Test
+        @DisplayName("종료된 이벤트는 status=ENDED 로 조회된다")
+        void ended_event_ok() {
+            LocalDateTime now = LocalDateTime.now();
+            given(appEventAdaptor.findById(ID)).willReturn(appEventOf(now.minusDays(20), now.minusDays(1)));
+
+            assertThat(appEventService.getAppEventPage(ID).status()).isEqualTo(AppEventStatus.ENDED);
+        }
+
+        // id를 훑어 오픈 전 이벤트 내용을 미리 볼 수 있으면 안 된다
+        @Test
+        @DisplayName("아직 시작하지 않은 이벤트는 404를 던진다")
+        void scheduled_event_hidden() {
+            LocalDateTime now = LocalDateTime.now();
+            given(appEventAdaptor.findById(ID)).willReturn(appEventOf(now.plusDays(3), now.plusDays(10)));
+
+            assertThatThrownBy(() -> appEventService.getAppEventPage(ID))
+                    .isInstanceOf(AppEventNotFoundException.class);
         }
 
         @Test
@@ -312,7 +385,7 @@ class AppEventServiceTest {
             LocalDateTime start = LocalDateTime.now().plusDays(1);
             LocalDateTime end = start.plusDays(20);
             Map<Integer, Integer> rewards = Map.of(5, 3, 10, 1); // 10일차 누적이 5일차보다 작음
-            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, start, end, false, Set.of(), rewards);
+            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, null, start, end, false, Set.of(), rewards);
 
             assertThatThrownBy(() -> appEventService.create(cmd, ADMIN_ID))
                     .isInstanceOf(AppEventInvalidAttendanceRewardsException.class);
@@ -325,7 +398,7 @@ class AppEventServiceTest {
             LocalDateTime start = LocalDateTime.now().plusDays(1);
             LocalDateTime end = start.plusDays(20);
             Map<Integer, Integer> rewards = Map.of(0, 1); // 출석일 0
-            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, start, end, false, Set.of(), rewards);
+            AppEventCommand cmd = new AppEventCommand("출석 이벤트", "설명", null, null, start, end, false, Set.of(), rewards);
 
             assertThatThrownBy(() -> appEventService.create(cmd, ADMIN_ID))
                     .isInstanceOf(AppEventInvalidAttendanceRewardsException.class);
@@ -393,7 +466,7 @@ class AppEventServiceTest {
 
         private AppEventCommand commandOf(String name, LocalDateTime startAt, LocalDateTime endAt,
                                           boolean hasWinner, Map<Integer, Integer> rewards) {
-            return new AppEventCommand(name, "설명", AppEventType.ATTENDANCE, startAt, endAt, hasWinner, Set.of(), rewards);
+            return new AppEventCommand(name, "설명", null, AppEventType.ATTENDANCE, startAt, endAt, hasWinner, Set.of(), rewards);
         }
 
         private void givenFinalizedEvent(boolean hasWinner, Map<Integer, Integer> rewards) {

--- a/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/winner/AppEventFinalizeServiceTest.java
+++ b/STORIX-Domain/src/test/java/com/storix/domain/domains/event/service/winner/AppEventFinalizeServiceTest.java
@@ -8,6 +8,7 @@ import com.storix.domain.domains.event.dto.AppEventWinnerDrawResponse;
 import com.storix.domain.domains.event.dto.EventWinner;
 import com.storix.domain.domains.event.exception.AppEventInvalidWinnerCountException;
 import com.storix.domain.domains.event.exception.AppEventNoWinnerException;
+import com.storix.domain.domains.event.exception.AppEventNotEndedException;
 import com.storix.domain.domains.event.exception.EventWinnerFinalizerNotImplementedException;
 import com.storix.domain.domains.user.adaptor.UserAdaptor;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,7 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -38,8 +39,9 @@ import static org.mockito.Mockito.verify;
 class AppEventFinalizeServiceTest {
 
     private static final Long EVENT_ID = 100L;
-    private static final LocalDate START = LocalDate.of(2026, 7, 20);
-    private static final LocalDate END = LocalDate.of(2026, 8, 2);
+    // 종료 여부 판정이 실행 시점 기준이라 기간도 현재 기준으로 잡는다
+    private static final LocalDateTime STARTED_AT = LocalDateTime.now().minusDays(14);
+    private static final LocalDateTime ENDED_AT = LocalDateTime.now().minusDays(1);
 
     @Mock
     private EventWinnerFinalizer finalizer;
@@ -61,11 +63,11 @@ class AppEventFinalizeServiceTest {
                 List.of(finalizer), appEventWinnerService, appEventAdaptor, userAdaptor);
     }
 
-    private AppEvent event(boolean hasWinner) {
+    private AppEvent event(boolean hasWinner, LocalDateTime endAt) {
         AppEvent e = AppEvent.builder()
                 .name("14일 출석 이벤트").description("설명")
                 .eventType(AppEventType.ATTENDANCE)
-                .startAt(START.atStartOfDay()).endAt(END.plusDays(1).atStartOfDay())
+                .startAt(STARTED_AT).endAt(endAt)
                 .hasWinner(hasWinner)
                 .build();
         ReflectionTestUtils.setField(e, "id", EVENT_ID);
@@ -73,7 +75,12 @@ class AppEventFinalizeServiceTest {
     }
 
     private void givenEvent(boolean hasWinner) {
-        given(appEventAdaptor.findByIdForUpdate(EVENT_ID)).willReturn(event(hasWinner));
+        given(appEventAdaptor.findByIdForUpdate(EVENT_ID)).willReturn(event(hasWinner, ENDED_AT));
+    }
+
+    private void givenOngoingEvent() {
+        given(appEventAdaptor.findByIdForUpdate(EVENT_ID))
+                .willReturn(event(true, LocalDateTime.now().plusDays(3)));
     }
 
     @Test
@@ -150,6 +157,34 @@ class AppEventFinalizeServiceTest {
                 .isInstanceOf(AppEventNoWinnerException.class);
 
         verify(appEventWinnerService, never()).saveWinners(anyLong(), anyList());
+    }
+
+    // 추첨은 되돌릴 수 없어 진행 중 확정은 남은 기간 참여자를 영구 제외시킨다
+    @Test
+    @DisplayName("아직 종료되지 않은 이벤트면 400을 던지고 추첨하지 않는다")
+    void rejects_not_ended_event() {
+        givenOngoingEvent();
+        given(appEventWinnerService.findWinners(EVENT_ID)).willReturn(List.of());
+
+        assertThatThrownBy(() -> appEventFinalizeService.finalizeWinners(EVENT_ID, 3))
+                .isInstanceOf(AppEventNotEndedException.class);
+
+        verify(finalizer, never()).resolveWinners(any(AppEvent.class), anyInt());
+        verify(appEventWinnerService, never()).saveWinners(anyLong(), anyList());
+    }
+
+    // 확정 이력 조회까지 막으면 당첨자 알림 발송이 끊긴다
+    @Test
+    @DisplayName("종료 전이라도 이미 확정된 이벤트면 저장된 당첨자를 그대로 반환한다")
+    void returns_confirmed_winners_even_before_end() {
+        givenOngoingEvent();
+        given(appEventWinnerService.findWinners(EVENT_ID)).willReturn(List.of(new EventWinner(7L, 1)));
+        given(userAdaptor.findNicknameMapByUserIds(anyList())).willReturn(Map.of(7L, "닉네임7"));
+
+        AppEventWinnerDrawResponse response = appEventFinalizeService.finalizeWinners(EVENT_ID, 3);
+
+        assertThat(response.alreadyFinalized()).isTrue();
+        assertThat(response.winners()).extracting(AppEventDrawWinner::userId).containsExactly(7L);
     }
 
     @Test

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
@@ -131,6 +131,9 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/auth/admin/slack/callback").permitAll()
                                 .requestMatchers("/api/v1/auth/admin/profile").hasRole("ADMIN")
 
+                                // [App Event] 이벤트 상세 페이지
+                                .requestMatchers(HttpMethod.GET, "/api/v1/app-events/{appEventId:[0-9]+}").permitAll()
+
                                 // [TopicRoom]
                                 .requestMatchers("/ws-stomp/**").permitAll()
 


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] PR #198의 커밋 cherry-pick (Swagger multipart 파트 Content-Type 및 날짜 example 미반영)
> - [x] PR #200의 커밋 cherry-pick (앱 이벤트 당첨자 확정 전후 데이터 변경 차단)
> - [x] PR #202의 커밋 cherry-pick (앱 이벤트 상세 웹페이지용 공개 조회 API)
> - [x] release/v2.4.13 구성

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)
- `app_events.page_key` 컬럼이 추가됩니다. nullable이라 기존 데이터에는 영향이 없습니다.
- 당첨자 확정 가드가 적용되어, 종료되지 않은 이벤트의 확정은 400, 확정된 이벤트의 기간·종류·응모권 지급표 수정은 409가 됩니다.

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #12

## 🖇️ 기타