### PR TITLE
Fix: [토픽룸] 메시지 저장 후 발행하도록 순서 변경

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/chat/controller/ChatController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/chat/controller/ChatController.java
@@ -30,4 +30,14 @@ public class ChatController {
         AuthUserDetails user = (AuthUserDetails) auth.getPrincipal();
         chatUseCase.sendMessage(user.getUserId(), request);
     }
+
+    // STOMP 는 GlobalExceptionHandler 를 타지 않아 여기서 남기지 않으면 흔적 없이 버려진다
+    @MessageExceptionHandler
+    public void handleMessageException(Exception e, SimpMessageHeaderAccessor accessor) {
+        log.error(">>>> [채팅] 메시지 처리 실패 sessionId={}, destination={}, exceptionType={}, message={}",
+                accessor.getSessionId(),
+                accessor.getDestination(),
+                e.getClass().getSimpleName(),
+                e.getMessage());
+    }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/chat/usecase/ChatUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/chat/usecase/ChatUseCase.java
@@ -28,7 +28,7 @@ public class ChatUseCase {
     private final UserBlockAdaptor userBlockAdaptor;
     private final TopicRoomAdaptor topicRoomAdaptor;
 
-    @Transactional
+    // 트랜잭션은 save 안쪽으로 좁힌다. Redis 발행 동안 DB 커넥션을 붙잡지 않기 위함
     public void sendMessage(Long userId, ChatMessageRequestDto request) {
 
         log.info(">>>> [ChatService] 메시지 전송 시도 - UserID: {}, RoomID: {}", userId, request.roomId());
@@ -39,11 +39,14 @@ public class ChatUseCase {
         // 채팅 메시지 엔티티 변환
         ChatMessage chatMessage = request.toEntity(userId);
 
+        // 저장 먼저 — 실시간 메시지에 실제 id 와 저장 시각을 실어야 한다
+        ChatMessage saved = chatService.save(chatMessage);
+
         // Redis 발행
-        chatService.publishRedis(chatMessage, nickname);
+        chatService.publishRedis(saved, nickname);
 
         // 메시지 전송 후 비동기 처리
-        chatAsyncService.processAfterMessageSent(chatMessage);
+        chatAsyncService.processAfterMessageSent(saved);
 
         log.info(">>>> [ChatService] 처리 완료 - Sender: {}, Content: {}", nickname, chatMessage.getMessage());
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/dto/ChatMessageRequestDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/dto/ChatMessageRequestDto.java
@@ -1,9 +1,12 @@
 package com.storix.domain.domains.chat.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.storix.domain.domains.chat.domain.ChatMessage;
 import com.storix.domain.domains.chat.domain.MessageType;
 import jakarta.validation.constraints.NotNull;
 
+// 필드명이 틀린 요청을 조용히 무시하지 않고 실패시킨다
+@JsonIgnoreProperties(ignoreUnknown = false)
 public record ChatMessageRequestDto(
         @NotNull Long roomId,
         @NotNull String message,

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/service/ChatAsyncService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/service/ChatAsyncService.java
@@ -1,6 +1,5 @@
 package com.storix.domain.domains.chat.service;
 
-import com.storix.domain.domains.chat.adaptor.ChatAdaptor;
 import com.storix.domain.domains.chat.domain.ChatMessage;
 import com.storix.domain.domains.topicroom.adaptor.TopicRoomAdaptor;
 import lombok.RequiredArgsConstructor;
@@ -15,15 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChatAsyncService {
 
-    private final ChatAdaptor chatAdaptor;
     private final TopicRoomAdaptor topicRoomAdaptor;
 
     @Async("chatAsyncExecutor")
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void processAfterMessageSent(ChatMessage chatMessage) {
-
-        // 메시지 저장
-        ChatMessage savedMessage = chatAdaptor.saveMessage(chatMessage);
+    // 저장과 발행은 이미 끝난 상태로 들어온다
+    public void processAfterMessageSent(ChatMessage savedMessage) {
 
         // 토픽룸의 마지막 채팅 정보 갱신
         try {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/service/ChatAsyncService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/service/ChatAsyncService.java
@@ -25,6 +25,7 @@ public class ChatAsyncService {
         try {
             topicRoomAdaptor.updateLastMessage(
                     savedMessage.getRoomId(),
+                    savedMessage.getId(),
                     savedMessage.getMessage(),
                     savedMessage.getMessageType(),
                     savedMessage.getSenderId(),

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/service/ChatService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/service/ChatService.java
@@ -30,6 +30,7 @@ public class ChatService {
     private final UserAdaptor userAdaptor;
     private final ChatAdaptor chatAdaptor;
 
+    @Transactional(readOnly = true)
     public String validateRoomMemberAndGetNickname(Long userId, Long roomId) {
 
         // 토픽룸 존재 여부 검증
@@ -51,6 +52,12 @@ public class ChatService {
         if (!topicRoomAdaptor.existsById(roomId)) {
             throw UnknownTopicRoomException.EXCEPTION;
         }
+    }
+
+    // 발행 전에 저장해야 실시간 메시지에도 실제 id 와 저장 시각이 실린다
+    @Transactional
+    public ChatMessage save(ChatMessage chatMessage) {
+        return chatAdaptor.saveMessage(chatMessage);
     }
 
     public void publishRedis(ChatMessage chatMessage, String nickname) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomAdaptor.java
@@ -22,8 +22,8 @@ public class TopicRoomAdaptor {
     private final TopicRoomRepository topicRoomRepository;
     private final TopicRoomUserRepository topicRoomUserRepository;
 
-    public void updateLastMessage(Long roomId, String message, MessageType messageType, Long senderId, LocalDateTime lastChatTime) {
-        topicRoomRepository.updateLastMessage(roomId, message, messageType, senderId, lastChatTime);
+    public void updateLastMessage(Long roomId, Long messageId, String message, MessageType messageType, Long senderId, LocalDateTime lastChatTime) {
+        topicRoomRepository.updateLastMessage(roomId, messageId, message, messageType, senderId, lastChatTime);
     }
 
     public boolean existsById(Long roomId) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/domain/TopicRoom.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/domain/TopicRoom.java
@@ -60,6 +60,9 @@ public class TopicRoom extends BaseTimeEntity {
     @Column(name = "last_message_sender_id")
     private Long lastMessageSenderId;
 
+    @Column(name = "last_message_id")
+    private Long lastMessageId;
+
     @Column(name = "popularity_score", nullable = false)
     private Double popularityScore;
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomRepository.java
@@ -48,17 +48,21 @@ public interface TopicRoomRepository extends JpaRepository<TopicRoom, Long>, Top
     @Query("UPDATE TopicRoom t SET t.lastChatTime = :lastChatTime WHERE t.id = :roomId")
     void updateLastChatTime(@Param("roomId") Long roomId, @Param("lastChatTime") LocalDateTime lastChatTime);
 
+    // 마지막 채팅 정보 갱신
     @Modifying(clearAutomatically = true)
     @Query("""
         UPDATE TopicRoom t
         SET t.lastMessage = :message,
             t.lastMessageType = :messageType,
             t.lastMessageSenderId = :senderId,
+            t.lastMessageId = :messageId,
             t.lastChatTime = :lastChatTime
         WHERE t.id = :roomId
+          AND (t.lastMessageId IS NULL OR t.lastMessageId < :messageId)
     """)
     void updateLastMessage(
             @Param("roomId") Long roomId,
+            @Param("messageId") Long messageId,
             @Param("message") String message,
             @Param("messageType") MessageType messageType,
             @Param("senderId") Long senderId,

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/WebSocketConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/WebSocketConfig.java
@@ -1,5 +1,7 @@
 package com.storix.infrastructure.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.storix.infrastructure.external.chat.StompHandler;
 import com.storix.infrastructure.external.chat.StompMdcInterceptor;
 import lombok.RequiredArgsConstructor;
@@ -8,14 +10,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.messaging.converter.DefaultContentTypeResolver;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.*;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
+import java.util.List;
 import java.util.Map;
 
 @Configuration
@@ -26,6 +33,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompHandler stompHandler;
     private final StompMdcInterceptor stompMdcInterceptor;
+    private final ObjectMapper objectMapper;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -33,6 +41,20 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setHeartbeatValue(new long[]{10000, 10000})
                 .setTaskScheduler(webSocketHeartbeatScheduler());
         registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public boolean configureMessageConverters(List<MessageConverter> messageConverters) {
+        DefaultContentTypeResolver contentTypeResolver = new DefaultContentTypeResolver();
+        contentTypeResolver.setDefaultMimeType(MimeTypeUtils.APPLICATION_JSON);
+
+        MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+        converter.setObjectMapper(
+                objectMapper.copy().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
+        converter.setContentTypeResolver(contentTypeResolver);
+
+        messageConverters.add(0, converter);
+        return true;
     }
 
     @Bean


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] 채팅 메시지를 저장한 뒤 Redis로 발행하도록 순서 변경
> - [x] `sendMessage`의 트랜잭션 경계를 저장 구간으로 축소
> - [x] 요청 필드명 오타를 무시하지 않고 실패시키도록 변경
> - [x] STOMP 예외 로깅 추가

**저장 전에 발행하고 있어 실시간 payload의 `id`가 `null`로 나갔습니다.**

```
변경 전: publishRedis(chatMessage) → 비동기 saveMessage(chatMessage)
변경 후: save(chatMessage) → publishRedis(saved) → 비동기 후처리
```

FE는 실시간으로 받은 `id`를 모아 과거 내역과 대조해 중복을 거르는데, `id`가 없으니 그 대조가 동작하지 않아 방을 다시 열거나 페이지를 더 불러올 때 같은 메시지가 중복으로 보였습니다.

함께 정리한 것들:

- `sendMessage`에 `@Transactional`이 걸려 있어 Redis 발행이 끝날 때까지 DB 커넥션을 점유했습니다. 트랜잭션을 `ChatService.save` 안쪽으로 좁혔습니다.
  - `@TransactionalEventListener(AFTER_COMMIT)`은 이 문제를 풀지 못합니다. afterCommit 콜백이 `cleanupAfterCompletion()`보다 먼저 실행되어 커넥션이 아직 반환되지 않기 때문입니다.
- 요청 필드명이 틀리면 조용히 무시되어 `messageType`이 `null`로 저장된 이력이 있어 `@JsonIgnoreProperties(ignoreUnknown = false)`를 추가했습니다.
- STOMP 처리 중 예외는 `GlobalExceptionHandler`를 타지 않아 로그 없이 사라졌습니다. `@MessageExceptionHandler`를 추가했습니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 
- #205 

## 🖇️ 기타