### PR TITLE
Feat: [토픽룸] 채팅 알림

### DIFF
--- a/STORIX-Api/src/main/java/com/storix/api/domain/chat/usecase/ChatUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/chat/usecase/ChatUseCase.java
@@ -46,7 +46,7 @@ public class ChatUseCase {
         chatService.publishRedis(saved, nickname);
 
         // 메시지 전송 후 비동기 처리
-        chatAsyncService.processAfterMessageSent(saved);
+        chatAsyncService.processAfterMessageSent(saved, nickname);
 
         log.info(">>>> [ChatService] 처리 완료 - Sender: {}, Content: {}", nickname, chatMessage.getMessage());
     }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package com.storix.api.domain.notification.controller;
 
+import com.storix.api.domain.notification.controller.dto.BadgeCountResponse;
 import com.storix.api.domain.notification.controller.dto.FcmSendRequest;
 import com.storix.api.domain.notification.controller.dto.MarketingConsentRequest;
 import com.storix.api.domain.notification.controller.dto.NotificationDispatchTestRequest;
@@ -54,6 +55,18 @@ public class NotificationController {
             @AuthenticationPrincipal AuthUserDetails authUser
     ) {
         return notificationUseCase.getUnreadCount(authUser.getUserId());
+    }
+
+    // 2-1. 앱 아이콘 배지 개수 조회
+    @GetMapping("/badge-count")
+    @Operation(summary = "앱 아이콘 배지 개수 조회",
+            description = "알림함 미읽음 + 토픽룸 미읽음 합산값을 반환합니다. 상한은 없습니다.  \n" +
+                    "푸시에 실리는 값과 동일하며, 읽음 처리 후나 앱 포그라운드 복귀 시 배지를 다시 맞추는 데 사용합니다.  \n" +
+                    "비로그인 상태로 호출하면 0을 반환합니다.")
+    public CustomResponse<BadgeCountResponse> getBadgeCount(
+            @AuthenticationPrincipal AuthUserDetails authUser
+    ) {
+        return notificationUseCase.getBadgeCount(authUser != null ? authUser.getUserId() : null);
     }
 
     // 3. 단건 알림 읽음 처리

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/BadgeCountResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/controller/dto/BadgeCountResponse.java
@@ -1,0 +1,10 @@
+package com.storix.api.domain.notification.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BadgeCountResponse(
+
+        @Schema(description = "앱 아이콘에 표시할 배지 숫자. 알림함 미읽음 + 토픽룸 미읽음, 상한 없음", example = "23")
+        long badgeCount
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/NotificationUseCase.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/notification/usecase/NotificationUseCase.java
@@ -2,6 +2,7 @@ package com.storix.api.domain.notification.usecase;
 
 import com.storix.common.annotation.UseCase;
 import com.storix.common.code.SuccessCode;
+import com.storix.api.domain.notification.controller.dto.BadgeCountResponse;
 import com.storix.common.payload.CustomResponse;
 import com.storix.domain.domains.notification.dto.NotificationResponseDto;
 import com.storix.domain.domains.notification.service.NotificationService;
@@ -25,6 +26,11 @@ public class NotificationUseCase {
     public CustomResponse<Long> getUnreadCount(Long userId) {
         long count = notificationService.getUnreadCount(userId);
         return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_COUNT_SUCCESS, count);
+    }
+
+    public CustomResponse<BadgeCountResponse> getBadgeCount(Long userId) {
+        long count = (userId == null) ? 0L : notificationService.getBadgeCount(userId);
+        return CustomResponse.onSuccess(SuccessCode.NOTIFICATION_BADGE_COUNT_SUCCESS, new BadgeCountResponse(count));
     }
 
     // 단건 알림 읽음 처리

--- a/STORIX-Api/src/main/java/com/storix/api/domain/topicroom/TopicRoomController.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/topicroom/TopicRoomController.java
@@ -7,6 +7,10 @@ import com.storix.domain.domains.topicroom.dto.TopicRoomPreviewResponseDto;
 import com.storix.domain.domains.topicroom.dto.TopicRoomReportRequestDto;
 import com.storix.domain.domains.topicroom.dto.TopicRoomResponseDto;
 import com.storix.domain.domains.topicroom.dto.TopicRoomUserResponseDto;
+import com.storix.api.domain.topicroom.dto.TopicRoomNotificationRequest;
+import com.storix.api.domain.topicroom.dto.TopicRoomNotificationResponse;
+import com.storix.api.domain.topicroom.dto.TopicRoomUnreadResponse;
+import com.storix.domain.domains.topicroom.service.TopicRoomUnreadService;
 import com.storix.domain.domains.topicroom.service.TopicRoomUserService;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.common.payload.CustomResponse;
@@ -33,6 +37,7 @@ public class TopicRoomController {
 
     private final TopicRoomUseCase topicRoomUseCase;
     private final TopicRoomUserService topicRoomUserService;
+    private final TopicRoomUnreadService topicRoomUnreadService;
 
     // 1. 참여 목록
     @GetMapping("/me")
@@ -138,5 +143,53 @@ public class TopicRoomController {
         return CustomResponse.onSuccess(
                 SuccessCode.SUCCESS,
                 topicRoomUserService.getRoomMembers(roomId));
+    }
+
+    // 10. 읽음 처리
+    @PostMapping("/{roomId}/read")
+    @Operation(summary = "토픽룸 읽음 처리", description = "토픽룸 진입 시 호출합니다. 해당 방의 읽지 않은 메시지를 모두 읽음 처리해 뱃지를 제거합니다.")
+    public CustomResponse<String> markRead(
+            @AuthenticationPrincipal AuthUserDetails authUser,
+            @PathVariable Long roomId) {
+
+        topicRoomUnreadService.markRoomRead(authUser.getUserId(), roomId);
+
+        return CustomResponse.onSuccess(SuccessCode.SUCCESS);
+    }
+
+    // 11. 미읽음 존재 여부
+    @GetMapping("/unread")
+    @Operation(summary = "토픽룸 미읽음 여부 조회", description = "참여 중인 토픽룸 전체에 읽지 않은 메시지가 있는지 반환합니다. 소통 탭 상단 Red Dot 표시용입니다.")
+    public CustomResponse<TopicRoomUnreadResponse> hasUnread(
+            @AuthenticationPrincipal AuthUserDetails authUser) {
+
+        return CustomResponse.onSuccess(
+                SuccessCode.SUCCESS,
+                new TopicRoomUnreadResponse(topicRoomUnreadService.hasAnyUnread(authUser.getUserId())));
+    }
+
+    // 12. 토픽룸별 알림 설정
+    @PatchMapping("/{roomId}/notification")
+    @Operation(summary = "토픽룸 채팅 알림 설정", description = "토픽룸별 채팅 푸시 알림을 켜거나 끕니다. 기본값은 ON이며, 방을 나가면 설정도 함께 사라집니다.")
+    public CustomResponse<String> changeNotification(
+            @AuthenticationPrincipal AuthUserDetails authUser,
+            @PathVariable Long roomId,
+            @Valid @RequestBody TopicRoomNotificationRequest request) {
+
+        topicRoomUserService.changeNotification(authUser.getUserId(), roomId, request.enabled());
+
+        return CustomResponse.onSuccess(SuccessCode.SUCCESS);
+    }
+
+    @GetMapping("/{roomId}/notification")
+    @Operation(summary = "토픽룸 채팅 알림 설정 조회", description = "해당 토픽룸의 채팅 푸시 알림 설정 상태를 반환합니다.")
+    public CustomResponse<TopicRoomNotificationResponse> getNotification(
+            @AuthenticationPrincipal AuthUserDetails authUser,
+            @PathVariable Long roomId) {
+
+        return CustomResponse.onSuccess(
+                SuccessCode.SUCCESS,
+                new TopicRoomNotificationResponse(
+                        topicRoomUserService.isNotificationEnabled(authUser.getUserId(), roomId)));
     }
 }

--- a/STORIX-Api/src/main/java/com/storix/api/domain/topicroom/dto/TopicRoomNotificationRequest.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/topicroom/dto/TopicRoomNotificationRequest.java
@@ -1,0 +1,12 @@
+package com.storix.api.domain.topicroom.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record TopicRoomNotificationRequest(
+
+        @Schema(description = "토픽룸 채팅 알림 수신 여부 (true: ON, false: OFF)", example = "true")
+        @NotNull(message = "알림 설정 값을 보내주세요.")
+        Boolean enabled
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/topicroom/dto/TopicRoomNotificationResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/topicroom/dto/TopicRoomNotificationResponse.java
@@ -1,0 +1,10 @@
+package com.storix.api.domain.topicroom.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TopicRoomNotificationResponse(
+
+        @Schema(description = "토픽룸 채팅 알림 수신 여부", example = "true")
+        boolean enabled
+) {
+}

--- a/STORIX-Api/src/main/java/com/storix/api/domain/topicroom/dto/TopicRoomUnreadResponse.java
+++ b/STORIX-Api/src/main/java/com/storix/api/domain/topicroom/dto/TopicRoomUnreadResponse.java
@@ -1,0 +1,10 @@
+package com.storix.api.domain.topicroom.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TopicRoomUnreadResponse(
+
+        @Schema(description = "참여 중인 토픽룸에 읽지 않은 메시지가 있는지 여부", example = "true")
+        boolean hasUnread
+) {
+}

--- a/STORIX-Batch/src/main/java/com/storix/batch/config/BatchSchedulingConfig.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/config/BatchSchedulingConfig.java
@@ -1,0 +1,20 @@
+package com.storix.batch.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class BatchSchedulingConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);
+        scheduler.setThreadNamePrefix("BatchScheduler-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        return scheduler;
+    }
+}

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/TopicRoomChatPushFlushScheduler.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/TopicRoomChatPushFlushScheduler.java
@@ -1,0 +1,70 @@
+package com.storix.batch.scheduler;
+
+import com.storix.domain.domains.topicroom.application.port.TopicRoomPushBatchPort;
+import com.storix.domain.domains.topicroom.dto.RoomLastMessageId;
+import com.storix.domain.domains.topicroom.service.TopicRoomChatPushService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TopicRoomChatPushFlushScheduler {
+
+    private static final int FLUSH_LIMIT = 100;
+    private static final Duration RECOVERY_LOOKBACK = Duration.ofMinutes(5);
+
+    private final TopicRoomPushBatchPort topicRoomPushBatchPort;
+    private final TopicRoomChatPushFlusher topicRoomChatPushFlusher;
+    private final TopicRoomChatPushService topicRoomChatPushService;
+
+    @Scheduled(fixedDelay = 1000)
+    public void flush() {
+        List<Long> dueRoomIds = topicRoomPushBatchPort.pollDueRoomIds(FLUSH_LIMIT);
+        if (dueRoomIds.isEmpty()) return;
+
+        for (Long roomId : dueRoomIds) {
+            try {
+                if (!topicRoomPushBatchPort.tryAcquireSendSlot(roomId)) continue;
+
+                // 발송이 1초 틱을 잡지 않도록 방 단위로 떼어낸다. 게이트와 회수는 여기서 끝내둔다
+                topicRoomChatPushFlusher.flush(roomId, topicRoomPushBatchPort.drain(roomId));
+            } catch (Exception e) {
+                log.error(">>>> [TopicRoomPush] flush 실패 roomId={}, cause={}", roomId, e.getMessage(), e);
+            }
+        }
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    public void recoverMissedRooms() {
+        List<Long> activeRoomIds = topicRoomChatPushService.findRecentlyActiveRoomIds(
+                LocalDateTime.now().minus(RECOVERY_LOOKBACK));
+        if (activeRoomIds.isEmpty()) return;
+
+        Map<Long, Long> lastMessageIds = topicRoomChatPushService.findLastMessageIds(activeRoomIds).stream()
+                .collect(Collectors.toMap(RoomLastMessageId::roomId, RoomLastMessageId::messageId));
+
+        int recovered = 0;
+        for (Map.Entry<Long, Long> entry : lastMessageIds.entrySet()) {
+            Long anchor = topicRoomPushBatchPort.findLastPushedMessageId(entry.getKey());
+
+            // 앵커가 없으면 이미 보냈는지 판단할 수 없어 건드리지 않는다
+            if (anchor == null || entry.getValue() <= anchor) continue;
+
+            // 이미 대기열에 있으면 묶음 창에서 정상 대기 중인 것이라 복구가 아니다
+            if (topicRoomPushBatchPort.enqueue(entry.getKey())) recovered++;
+        }
+
+        if (recovered > 0) {
+            log.warn(">>>> [TopicRoomPush] 누락 복구 대기열 등록 rooms={}", recovered);
+        }
+    }
+}

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/TopicRoomChatPushFlusher.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/TopicRoomChatPushFlusher.java
@@ -50,6 +50,7 @@ public class TopicRoomChatPushFlusher {
             topicRoomChatPushSender.send(roomId, anchor, upTo, senderId, senderNickname, lastMessage);
             topicRoomPushBatchPort.markPushed(roomId, upTo);
         } catch (Exception e) {
+            topicRoomPushBatchPort.enqueue(roomId);
             log.error(">>>> [TopicRoomPush] flush 실패 roomId={}, cause={}", roomId, e.getMessage(), e);
         }
     }

--- a/STORIX-Batch/src/main/java/com/storix/batch/scheduler/TopicRoomChatPushFlusher.java
+++ b/STORIX-Batch/src/main/java/com/storix/batch/scheduler/TopicRoomChatPushFlusher.java
@@ -1,0 +1,56 @@
+package com.storix.batch.scheduler;
+
+import com.storix.domain.domains.chat.dto.ChatMessageResponseDto;
+import com.storix.domain.domains.topicroom.application.port.TopicRoomPushBatchPort;
+import com.storix.domain.domains.topicroom.dto.PendingChatPush;
+import com.storix.domain.domains.topicroom.service.TopicRoomChatPushService;
+import com.storix.infrastructure.external.topicroom.TopicRoomChatPushSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TopicRoomChatPushFlusher {
+
+    private final TopicRoomPushBatchPort topicRoomPushBatchPort;
+    private final TopicRoomChatPushSender topicRoomChatPushSender;
+    private final TopicRoomChatPushService topicRoomChatPushService;
+
+    @Async("topicRoomPushExecutor")
+    public void flush(Long roomId, PendingChatPush pending) {
+        try {
+            Long upTo = topicRoomChatPushService.findLastMessageId(roomId);
+            if (upTo == null) return;
+
+            Long anchor = topicRoomPushBatchPort.findLastPushedMessageId(roomId);
+            if (anchor != null && upTo <= anchor) return;
+
+            Long senderId;
+            String senderNickname;
+            String lastMessage;
+
+            if (pending != null) {
+                senderId = pending.lastSenderId();
+                senderNickname = pending.lastSenderNickname();
+                lastMessage = pending.lastMessage();
+            } else {
+                ChatMessageResponseDto latest = topicRoomChatPushService.findLatestMessage(roomId);
+                if (latest == null) return;
+                senderId = latest.senderId();
+                senderNickname = latest.senderName();
+                lastMessage = latest.message();
+            }
+
+            log.info(">>>> [TopicRoomPush] 묶음 flush roomId={}, anchor={}, upTo={}, recovered={}",
+                    roomId, anchor, upTo, pending == null);
+
+            topicRoomChatPushSender.send(roomId, anchor, upTo, senderId, senderNickname, lastMessage);
+            topicRoomPushBatchPort.markPushed(roomId, upTo);
+        } catch (Exception e) {
+            log.error(">>>> [TopicRoomPush] flush 실패 roomId={}, cause={}", roomId, e.getMessage(), e);
+        }
+    }
+}

--- a/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
+++ b/STORIX-Common/src/main/java/com/storix/common/code/SuccessCode.java
@@ -20,6 +20,7 @@ public enum SuccessCode {
     NOTIFICATION_PREFERENCE_UPDATE_SUCCESS(HttpStatus.OK, "NOTI2007", "알림 설정이 변경되었습니다."),
     NOTIFICATION_TEST_PUSH_SUCCESS(HttpStatus.OK, "NOTI2008", "테스트 푸시 알림 전송에 성공했습니다."),
     NOTIFICATION_MARKETING_CONSENT_UPDATE_SUCCESS(HttpStatus.OK, "NOTI2009", "마케팅 알림 동의 상태가 변경되었습니다."),
+    NOTIFICATION_BADGE_COUNT_SUCCESS(HttpStatus.OK, "NOTI2010", "앱 아이콘 배지 개수를 성공적으로 조회했습니다."),
 
     // Event success
     ADMIN_NOTIFICATION_CREATE_SUCCESS(HttpStatus.CREATED, "ADMIN_NOTIFICATION_SUCCESS_001", "운영자 알림 생성에 성공했습니다."),

--- a/STORIX-Common/src/main/java/com/storix/common/utils/RedisKeyStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/RedisKeyStatic.java
@@ -86,6 +86,18 @@ public final class RedisKeyStatic {
         }
     }
 
+    // 토픽룸 채팅 알림 — 대기열만 단일 키, 나머지는 {prefix}{roomId}
+    public static final class TopicRoom {
+        public static final String ONLINE_PREFIX = "topic-room:online:";
+        public static final String PUSH_GATE_PREFIX = "topic-room:push:gate:";
+        public static final String PUSH_PENDING_PREFIX = "topic-room:push:pending:";
+        public static final String PUSH_QUEUE = "topic-room:push:queue";
+        public static final String PUSH_ANCHOR_PREFIX = "topic-room:push:anchor:";
+
+        private TopicRoom() {
+        }
+    }
+
     // pub/sub 채널
     public static final class Channel {
         public static final String CHAT_ROOM_PREFIX = "room:";

--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -139,8 +139,6 @@ public class STORIXStatic {
         public static final int CONTENT_PREVIEW_MAX = 10;
         public static final String CONTENT_PREVIEW_SUFFIX = "...";
 
-        // 토픽룸 목록 뱃지 — 초과분은 99+ 로 표시
-        public static final int TOPIC_ROOM_BADGE_MAX = 99;
     }
 
     // 사용자 이력 — 마케팅 동의/거부 모달 표시 문구

--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -135,9 +135,12 @@ public class STORIXStatic {
         // 본문 템플릿 — 마케팅/광고 (운영자 입력 + 고정 suffix '(수신거부 : 설정)')
         public static final String TPL_MARKETING = "%s (수신거부 : 설정)";
 
-        // 댓글 본문 미리보기 — 10자 노출 후 ...
+        // 댓글·채팅 본문 미리보기 — 10자 노출 후 ...
         public static final int CONTENT_PREVIEW_MAX = 10;
         public static final String CONTENT_PREVIEW_SUFFIX = "...";
+
+        // 토픽룸 목록 뱃지 — 초과분은 99+ 로 표시
+        public static final int TOPIC_ROOM_BADGE_MAX = 99;
     }
 
     // 사용자 이력 — 마케팅 동의/거부 모달 표시 문구

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/adaptor/ChatAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/adaptor/ChatAdaptor.java
@@ -4,9 +4,13 @@ import com.storix.domain.domains.chat.domain.ChatMessage;
 import com.storix.domain.domains.chat.domain.MessageType;
 import com.storix.domain.domains.chat.dto.ChatMessageResponseDto;
 import com.storix.domain.domains.chat.repository.ChatRepository;
+import com.storix.domain.domains.topicroom.dto.RoomLastMessageId;
+import com.storix.domain.domains.topicroom.dto.RoomUnreadCount;
+import com.storix.domain.domains.topicroom.dto.UserUnreadCount;
 import com.storix.domain.domains.user.dto.AdminUserContentItemResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
@@ -65,5 +69,61 @@ public class ChatAdaptor {
             return chatRepository.findAllByRoomIdOrderByCreatedAtDesc(roomId, pageable);
         }
         return chatRepository.findAllByRoomIdExcludingBlockedOrderByCreatedAtDesc(roomId, blockedIds, pageable);
+    }
+
+    public List<RoomUnreadCount> countUnreadByRoomIds(Long userId, List<Long> roomIds) {
+        if (roomIds.isEmpty()) {
+            return List.of();
+        }
+        return chatRepository.countUnreadByRoomIds(userId, roomIds, MessageType.TALK);
+    }
+
+    public long countTotalUnread(Long userId) {
+        return chatRepository.countTotalUnreadByUserId(userId, MessageType.TALK);
+    }
+
+    public boolean existsUnread(Long userId) {
+        return chatRepository.existsUnreadByUserId(userId, MessageType.TALK);
+    }
+
+    public Long findLastMessageId(Long roomId) {
+        return chatRepository.findLastMessageIdByRoomId(roomId);
+    }
+
+    public List<RoomLastMessageId> findLastMessageIdsByRoomIds(List<Long> roomIds) {
+        if (roomIds.isEmpty()) {
+            return List.of();
+        }
+        return chatRepository.findLastMessageIdsByRoomIds(roomIds, MessageType.TALK);
+    }
+
+    public ChatMessageResponseDto findLatestMessage(Long roomId) {
+        return chatRepository.findLatestByRoomId(roomId, MessageType.TALK, PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .orElse(null);
+    }
+
+    public List<UserUnreadCount> countUnreadByRoomForUsers(Long roomId, List<Long> userIds) {
+        if (userIds.isEmpty()) {
+            return List.of();
+        }
+        return chatRepository.countUnreadByRoomForUsers(roomId, userIds, MessageType.TALK);
+    }
+
+    public List<UserUnreadCount> countMessagesAfterForUsers(
+            Long roomId, List<Long> userIds, Long afterMessageId, Long upToMessageId) {
+        if (userIds.isEmpty()) {
+            return List.of();
+        }
+        return chatRepository.countMessagesAfterForUsers(
+                roomId, userIds, afterMessageId, upToMessageId, MessageType.TALK);
+    }
+
+    public List<UserUnreadCount> countTotalUnreadByUserIds(List<Long> userIds) {
+        if (userIds.isEmpty()) {
+            return List.of();
+        }
+        return chatRepository.countTotalUnreadByUserIds(userIds, MessageType.TALK);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/domain/ChatMessage.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/domain/ChatMessage.java
@@ -18,6 +18,10 @@ import java.time.LocalDateTime;
                 @Index(
                         name = "idx_room_created",
                         columnList = "roomId, createdAt"
+                ),
+                @Index(
+                        name = "idx_room_id_sender",
+                        columnList = "roomId, id, senderId"
                 )
         }
 )

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/repository/ChatRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/repository/ChatRepository.java
@@ -262,7 +262,8 @@ public interface ChatRepository extends JpaRepository<ChatMessage, Long> {
                   SELECT 1 FROM UserBlock b
                   WHERE b.blockerId = tu.userId AND b.blockedUserId = m.senderId
               )
-              AND (tu.lastReadMessageId IS NULL OR m.id > tu.lastReadMessageId)
+              AND ((tu.lastReadMessageId IS NOT NULL AND m.id > tu.lastReadMessageId)
+                OR (tu.lastReadMessageId IS NULL AND m.createdAt > tu.createdAt))
             GROUP BY tu.userId
             """)
     List<UserUnreadCount> countMessagesAfterForUsers(

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/repository/ChatRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/repository/ChatRepository.java
@@ -3,6 +3,9 @@ package com.storix.domain.domains.chat.repository;
 import com.storix.domain.domains.chat.domain.ChatMessage;
 import com.storix.domain.domains.chat.domain.MessageType;
 import com.storix.domain.domains.chat.dto.ChatMessageResponseDto;
+import com.storix.domain.domains.topicroom.dto.RoomLastMessageId;
+import com.storix.domain.domains.topicroom.dto.RoomUnreadCount;
+import com.storix.domain.domains.topicroom.dto.UserUnreadCount;
 import com.storix.domain.domains.user.dto.AdminUserContentItemResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -159,4 +162,169 @@ public interface ChatRepository extends JpaRepository<ChatMessage, Long> {
             @Param("blockedIds") List<Long> blockedIds,
             Pageable pageable
     );
+
+    @Query("""
+            SELECT new com.storix.domain.domains.topicroom.dto.RoomUnreadCount(m.roomId, COUNT(m.id))
+            FROM ChatMessage m
+            JOIN TopicRoomUser tu ON tu.topicRoom.id = m.roomId AND tu.userId = :userId
+            WHERE m.roomId IN :roomIds
+              AND m.deleted = false
+              AND m.messageType = :messageType
+              AND m.senderId <> :userId
+              AND NOT EXISTS (
+                  SELECT 1 FROM UserBlock b
+                  WHERE b.blockerId = tu.userId AND b.blockedUserId = m.senderId
+              )
+              AND ((tu.lastReadMessageId IS NOT NULL AND m.id > tu.lastReadMessageId)
+                OR (tu.lastReadMessageId IS NULL AND m.createdAt > tu.createdAt))
+            GROUP BY m.roomId
+            """)
+    List<RoomUnreadCount> countUnreadByRoomIds(
+            @Param("userId") Long userId,
+            @Param("roomIds") List<Long> roomIds,
+            @Param("messageType") MessageType messageType
+    );
+
+    @Query("""
+            SELECT COUNT(m.id)
+            FROM ChatMessage m
+            JOIN TopicRoomUser tu ON tu.topicRoom.id = m.roomId AND tu.userId = :userId
+            WHERE m.deleted = false
+              AND m.messageType = :messageType
+              AND m.senderId <> :userId
+              AND NOT EXISTS (
+                  SELECT 1 FROM UserBlock b
+                  WHERE b.blockerId = tu.userId AND b.blockedUserId = m.senderId
+              )
+              AND ((tu.lastReadMessageId IS NOT NULL AND m.id > tu.lastReadMessageId)
+                OR (tu.lastReadMessageId IS NULL AND m.createdAt > tu.createdAt))
+            """)
+    long countTotalUnreadByUserId(
+            @Param("userId") Long userId,
+            @Param("messageType") MessageType messageType
+    );
+
+    @Query("""
+            SELECT COUNT(m.id) > 0
+            FROM ChatMessage m
+            JOIN TopicRoomUser tu ON tu.topicRoom.id = m.roomId AND tu.userId = :userId
+            WHERE m.deleted = false
+              AND m.messageType = :messageType
+              AND m.senderId <> :userId
+              AND NOT EXISTS (
+                  SELECT 1 FROM UserBlock b
+                  WHERE b.blockerId = tu.userId AND b.blockedUserId = m.senderId
+              )
+              AND ((tu.lastReadMessageId IS NOT NULL AND m.id > tu.lastReadMessageId)
+                OR (tu.lastReadMessageId IS NULL AND m.createdAt > tu.createdAt))
+            """)
+    boolean existsUnreadByUserId(
+            @Param("userId") Long userId,
+            @Param("messageType") MessageType messageType
+    );
+
+    // 차단 여부가 유저마다 달라 NOT EXISTS 로 각자 기준을 적용
+    @Query("""
+            SELECT new com.storix.domain.domains.topicroom.dto.UserUnreadCount(tu.userId, COUNT(m.id))
+            FROM ChatMessage m
+            JOIN TopicRoomUser tu ON tu.topicRoom.id = m.roomId
+            WHERE m.roomId = :roomId
+              AND tu.userId IN :userIds
+              AND m.deleted = false
+              AND m.messageType = :messageType
+              AND m.senderId <> tu.userId
+              AND NOT EXISTS (
+                  SELECT 1 FROM UserBlock b
+                  WHERE b.blockerId = tu.userId AND b.blockedUserId = m.senderId
+              )
+              AND ((tu.lastReadMessageId IS NOT NULL AND m.id > tu.lastReadMessageId)
+                OR (tu.lastReadMessageId IS NULL AND m.createdAt > tu.createdAt))
+            GROUP BY tu.userId
+            """)
+    List<UserUnreadCount> countUnreadByRoomForUsers(
+            @Param("roomId") Long roomId,
+            @Param("userIds") List<Long> userIds,
+            @Param("messageType") MessageType messageType
+    );
+
+    @Query("""
+            SELECT new com.storix.domain.domains.topicroom.dto.UserUnreadCount(tu.userId, COUNT(m.id))
+            FROM ChatMessage m
+            JOIN TopicRoomUser tu ON tu.topicRoom.id = m.roomId
+            WHERE m.roomId = :roomId
+              AND tu.userId IN :userIds
+              AND m.id > :afterMessageId
+              AND m.id <= :upToMessageId
+              AND m.deleted = false
+              AND m.messageType = :messageType
+              AND m.senderId <> tu.userId
+              AND NOT EXISTS (
+                  SELECT 1 FROM UserBlock b
+                  WHERE b.blockerId = tu.userId AND b.blockedUserId = m.senderId
+              )
+              AND (tu.lastReadMessageId IS NULL OR m.id > tu.lastReadMessageId)
+            GROUP BY tu.userId
+            """)
+    List<UserUnreadCount> countMessagesAfterForUsers(
+            @Param("roomId") Long roomId,
+            @Param("userIds") List<Long> userIds,
+            @Param("afterMessageId") Long afterMessageId,
+            @Param("upToMessageId") Long upToMessageId,
+            @Param("messageType") MessageType messageType
+    );
+
+    @Query("""
+            SELECT new com.storix.domain.domains.topicroom.dto.UserUnreadCount(tu.userId, COUNT(m.id))
+            FROM ChatMessage m
+            JOIN TopicRoomUser tu ON tu.topicRoom.id = m.roomId
+            WHERE tu.userId IN :userIds
+              AND m.deleted = false
+              AND m.messageType = :messageType
+              AND m.senderId <> tu.userId
+              AND NOT EXISTS (
+                  SELECT 1 FROM UserBlock b
+                  WHERE b.blockerId = tu.userId AND b.blockedUserId = m.senderId
+              )
+              AND ((tu.lastReadMessageId IS NOT NULL AND m.id > tu.lastReadMessageId)
+                OR (tu.lastReadMessageId IS NULL AND m.createdAt > tu.createdAt))
+            GROUP BY tu.userId
+            """)
+    List<UserUnreadCount> countTotalUnreadByUserIds(
+            @Param("userIds") List<Long> userIds,
+            @Param("messageType") MessageType messageType
+    );
+
+    @Query("""
+            SELECT new com.storix.domain.domains.topicroom.dto.RoomLastMessageId(m.roomId, MAX(m.id))
+            FROM ChatMessage m
+            WHERE m.roomId IN :roomIds
+              AND m.deleted = false
+              AND m.messageType = :messageType
+            GROUP BY m.roomId
+            """)
+    List<RoomLastMessageId> findLastMessageIdsByRoomIds(
+            @Param("roomIds") List<Long> roomIds,
+            @Param("messageType") MessageType messageType
+    );
+
+    @Query("SELECT new com.storix.domain.domains.chat.dto.ChatMessageResponseDto(" +
+            "   m.id, m.roomId, m.senderId, " +
+            "   COALESCE(" + com.storix.common.utils.STORIXStatic.NICK_NAME_DISPLAY_CASE_WHEN + ", '알 수 없음'), " +
+            "   m.message, m.messageType, m.createdAt) " +
+            "FROM ChatMessage m " +
+            "LEFT JOIN User u ON m.senderId = u.id " +
+            "WHERE m.roomId = :roomId AND m.deleted = false AND m.messageType = :messageType " +
+            "ORDER BY m.id DESC")
+    List<ChatMessageResponseDto> findLatestByRoomId(
+            @Param("roomId") Long roomId,
+            @Param("messageType") MessageType messageType,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT MAX(m.id)
+            FROM ChatMessage m
+            WHERE m.roomId = :roomId AND m.deleted = false
+            """)
+    Long findLastMessageIdByRoomId(@Param("roomId") Long roomId);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/service/ChatAsyncService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/service/ChatAsyncService.java
@@ -1,9 +1,12 @@
 package com.storix.domain.domains.chat.service;
 
 import com.storix.domain.domains.chat.domain.ChatMessage;
+import com.storix.domain.domains.chat.domain.MessageType;
 import com.storix.domain.domains.topicroom.adaptor.TopicRoomAdaptor;
+import com.storix.domain.domains.topicroom.event.TopicRoomChatPushEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -15,11 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatAsyncService {
 
     private final TopicRoomAdaptor topicRoomAdaptor;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Async("chatAsyncExecutor")
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     // 저장과 발행은 이미 끝난 상태로 들어온다
-    public void processAfterMessageSent(ChatMessage savedMessage) {
+    public void processAfterMessageSent(ChatMessage savedMessage, String senderNickname) {
 
         // 토픽룸의 마지막 채팅 정보 갱신
         try {
@@ -37,5 +41,14 @@ public class ChatAsyncService {
             log.warn(">>>> [ChatAsyncService] 토픽룸 최신 메시지 업데이트 실패 (RoomID: {}, MsgID: {}): {}",
                     savedMessage.getRoomId(), savedMessage.getId(), e.getMessage());
         }
+
+        if (savedMessage.getMessageType() != MessageType.TALK) return;
+
+        eventPublisher.publishEvent(new TopicRoomChatPushEvent(
+                savedMessage.getRoomId(),
+                savedMessage.getId(),
+                savedMessage.getSenderId(),
+                senderNickname,
+                savedMessage.getMessage()));
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationSetting.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationSetting.java
@@ -41,6 +41,10 @@ public class NotificationSetting extends BaseTimeEntity {
     @Column(name = "hot_topic_room_enabled", nullable = false)
     private boolean hotTopicRoomEnabled;
 
+    // 알림함에 적재되지 않아 NotificationType 없이 단독 판정
+    @Column(name = "topic_room_chat_enabled", nullable = false, columnDefinition = "tinyint(1) not null default 1")
+    private boolean topicRoomChatEnabled;
+
     // 마케팅/광고 수신 여부
     @Column(name = "marketing_enabled", nullable = false)
     private boolean marketingEnabled;
@@ -62,6 +66,7 @@ public class NotificationSetting extends BaseTimeEntity {
         p.replyOnCommentEnabled = true;
         p.todayFeedEnabled = true;
         p.hotTopicRoomEnabled = true;
+        p.topicRoomChatEnabled = true;
         p.marketingEnabled = false;
         p.operationPolicyEnabled = true;
         return p;
@@ -77,6 +82,7 @@ public class NotificationSetting extends BaseTimeEntity {
                        Boolean replyOnCommentEnabled,
                        Boolean todayFeedEnabled,
                        Boolean hotTopicRoomEnabled,
+                       Boolean topicRoomChatEnabled,
                        Boolean operationPolicyEnabled) {
         if (likeFeedEnabled != null) this.likeFeedEnabled = likeFeedEnabled;
         if (likeReviewEnabled != null) this.likeReviewEnabled = likeReviewEnabled;
@@ -85,6 +91,7 @@ public class NotificationSetting extends BaseTimeEntity {
         if (replyOnCommentEnabled != null) this.replyOnCommentEnabled = replyOnCommentEnabled;
         if (todayFeedEnabled != null) this.todayFeedEnabled = todayFeedEnabled;
         if (hotTopicRoomEnabled != null) this.hotTopicRoomEnabled = hotTopicRoomEnabled;
+        if (topicRoomChatEnabled != null) this.topicRoomChatEnabled = topicRoomChatEnabled;
         if (operationPolicyEnabled != null) this.operationPolicyEnabled = operationPolicyEnabled;
     }
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationSettingResponse.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/NotificationSettingResponse.java
@@ -2,7 +2,6 @@ package com.storix.domain.domains.notification.dto;
 
 import com.storix.domain.domains.notification.domain.NotificationSetting;
 
-// 추후 알림 뎁스 세분화를 위한 테이블 컬럼 유지 (9개 -> 4개 상위 분류)
 public record NotificationSettingResponse(
         boolean myActivityEnabled,
         boolean contentCommunityEnabled,
@@ -13,7 +12,7 @@ public record NotificationSettingResponse(
         return new NotificationSettingResponse(
                 s.isLikeFeedEnabled() && s.isLikeReviewEnabled() && s.isLikeCommentEnabled()
                         && s.isCommentOnFeedEnabled() && s.isReplyOnCommentEnabled(),
-                s.isTodayFeedEnabled() && s.isHotTopicRoomEnabled(),
+                s.isTodayFeedEnabled() && s.isHotTopicRoomEnabled() && s.isTopicRoomChatEnabled(),
                 s.isMarketingEnabled(),
                 s.isOperationPolicyEnabled()
         );

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingCommand.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingCommand.java
@@ -8,6 +8,7 @@ public record UpdateNotificationSettingCommand(
         Boolean replyOnCommentEnabled,
         Boolean todayFeedEnabled,
         Boolean hotTopicRoomEnabled,
+        Boolean topicRoomChatEnabled,
         Boolean operationPolicyEnabled
 ) {
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingRequest.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/dto/UpdateNotificationSettingRequest.java
@@ -2,14 +2,13 @@ package com.storix.domain.domains.notification.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-// 추후 알림 뎁스 세분화를 위한 테이블 컬럼 유지 (8개 -> 3개 상위 분류)
 // 이벤트/혜택(마케팅) 동의는 법적 추적 대상 -> marketing-consent 별도 API 로 분리
 public record UpdateNotificationSettingRequest(
 
         @Schema(description = "내 활동 알림 — 피드/리뷰/댓글/답댓글/댓글 좋아요", example = "true")
         Boolean myActivityEnabled,
 
-        @Schema(description = "콘텐츠/커뮤니티 알림 — 오늘의 피드/HOT 토픽룸 선정", example = "true")
+        @Schema(description = "콘텐츠/커뮤니티 알림 — 오늘의 피드/HOT 토픽룸 선정/토픽룸 채팅", example = "true")
         Boolean contentCommunityEnabled,
 
         @Schema(description = "운영/정책 알림 — 신고 처리/이용 제한/약관 업데이트 등", example = "true")
@@ -22,6 +21,7 @@ public record UpdateNotificationSettingRequest(
                 myActivityEnabled,
                 myActivityEnabled,
                 myActivityEnabled,
+                contentCommunityEnabled,
                 contentCommunityEnabled,
                 contentCommunityEnabled,
                 operationPolicyEnabled

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/event/NotificationEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/event/NotificationEvent.java
@@ -189,8 +189,10 @@ public record NotificationEvent(
     private static String preview(String text) {
         if (text == null) return "";
         int max = STORIXStatic.Notification.CONTENT_PREVIEW_MAX;
-        return text.length() > max
-                ? text.substring(0, max) + STORIXStatic.Notification.CONTENT_PREVIEW_SUFFIX
-                : text;
+        if (text.codePointCount(0, text.length()) <= max) return text;
+
+        // 이모지가 잘려 깨지지 않게 코드포인트로 센다
+        return text.substring(0, text.offsetByCodePoints(0, max))
+                + STORIXStatic.Notification.CONTENT_PREVIEW_SUFFIX;
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationDispatchService.java
@@ -1,5 +1,6 @@
 package com.storix.domain.domains.notification.service;
 
+import com.storix.domain.domains.chat.adaptor.ChatAdaptor;
 import com.storix.domain.domains.notification.adaptor.NotificationAdaptor;
 import com.storix.domain.domains.notification.adaptor.NotificationSettingAdaptor;
 import com.storix.domain.domains.notification.domain.Notification;
@@ -25,6 +26,7 @@ public class NotificationDispatchService {
 
     private final UserAdaptor userAdaptor;
     private final UserBlockAdaptor userBlockAdaptor;
+    private final ChatAdaptor chatAdaptor;
     private final NotificationAdaptor notificationAdaptor;
     private final NotificationSettingAdaptor notificationSettingAdaptor;
 
@@ -81,8 +83,9 @@ public class NotificationDispatchService {
             return DispatchResult.inAppOnly(saved.getId());
         }
 
-        // 뱃지 표시용 미읽음 총합 — 방금 저장한 알림 포함
-        int unreadCount = notificationAdaptor.countUnreadByUserId(event.recipientUserId());
+        // 뱃지 표시용 미읽음 총합 — 방금 저장한 알림 포함, 토픽룸 채팅 미읽음까지 합산
+        int unreadCount = notificationAdaptor.countUnreadByUserId(event.recipientUserId())
+                + (int) chatAdaptor.countTotalUnread(event.recipientUserId());
         return DispatchResult.pushTo(saved.getId(), tokens, unreadCount);
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationService.java
@@ -1,5 +1,6 @@
 package com.storix.domain.domains.notification.service;
 
+import com.storix.domain.domains.chat.adaptor.ChatAdaptor;
 import com.storix.domain.domains.notification.adaptor.NotificationAdaptor;
 import com.storix.domain.domains.notification.domain.Notification;
 import com.storix.domain.domains.notification.dto.NotificationResponseDto;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationAdaptor notificationAdaptor;
+    private final ChatAdaptor chatAdaptor;
 
     // 1. 전체 알림 목록 조회 (커서 기반)
     @Transactional(readOnly = true)
@@ -30,6 +32,13 @@ public class NotificationService {
     @Transactional(readOnly = true)
     public int getUnreadCount(Long userId) {
         return notificationAdaptor.countUnreadByUserId(userId);
+    }
+
+    // 2-1. 앱 아이콘 배지 — 알림함 미읽음 + 토픽룸 미읽음, 푸시에 싣는 값과 동일
+    @Transactional(readOnly = true)
+    public long getBadgeCount(Long userId) {
+        return notificationAdaptor.countUnreadByUserId(userId)
+                + chatAdaptor.countTotalUnread(userId);
     }
 
     // 3. 단건 알림 읽음 처리

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationSettingService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/service/NotificationSettingService.java
@@ -31,6 +31,7 @@ public class NotificationSettingService {
                 cmd.replyOnCommentEnabled(),
                 cmd.todayFeedEnabled(),
                 cmd.hotTopicRoomEnabled(),
+                cmd.topicRoomChatEnabled(),
                 cmd.operationPolicyEnabled()
         );
         return setting;

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/adaptor/TopicRoomAdaptor.java
@@ -49,6 +49,10 @@ public class TopicRoomAdaptor {
         return topicRoomUserRepository.findJoinedRoomIdsByUserIdAndRoomIds(userId, roomIds);
     }
 
+    public int advanceReadCursor(Long userId, Long roomId, Long messageId) {
+        return topicRoomUserRepository.advanceReadCursor(userId, roomId, messageId);
+    }
+
     public TopicRoomUser findByUserIdAndRoomId(Long userId, Long roomId) {
         return topicRoomUserRepository.findByUserIdAndTopicRoomId(userId, roomId)
                 .orElseThrow(() -> UnknownTopicRoomUserException.EXCEPTION);
@@ -60,6 +64,18 @@ public class TopicRoomAdaptor {
 
     public List<Long> findAllJoinedRoomIdsByUserId(Long userId) {
         return topicRoomUserRepository.findAllJoinedRoomIdsByUserId(userId);
+    }
+
+    public List<Long> findChatPushTargetUserIds(Long roomId, Long senderId) {
+        return topicRoomUserRepository.findChatPushTargetUserIds(roomId, senderId);
+    }
+
+    public String findTopicRoomNameById(Long roomId) {
+        return topicRoomRepository.findTopicRoomNameById(roomId);
+    }
+
+    public List<Long> findRoomIdsByLastChatTimeAfter(LocalDateTime since) {
+        return topicRoomRepository.findRoomIdsByLastChatTimeAfter(since);
     }
 
     public Integer findActiveUserNumberById(Long roomId) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/application/port/TopicRoomPresencePort.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/application/port/TopicRoomPresencePort.java
@@ -1,0 +1,12 @@
+package com.storix.domain.domains.topicroom.application.port;
+
+import java.util.Set;
+
+public interface TopicRoomPresencePort {
+
+    void enter(Long roomId, Long userId, String sessionId);
+
+    void leave(Long roomId, Long userId, String sessionId);
+
+    Set<Long> findOnlineUserIds(Long roomId);
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/application/port/TopicRoomPushBatchPort.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/application/port/TopicRoomPushBatchPort.java
@@ -1,0 +1,22 @@
+package com.storix.domain.domains.topicroom.application.port;
+
+import com.storix.domain.domains.topicroom.dto.PendingChatPush;
+
+import java.util.List;
+
+public interface TopicRoomPushBatchPort {
+
+    boolean tryAcquireSendSlot(Long roomId);
+
+    void accumulate(Long roomId, Long messageId, Long senderId, String senderNickname, String message);
+
+    boolean enqueue(Long roomId);
+
+    List<Long> pollDueRoomIds(int limit);
+
+    PendingChatPush drain(Long roomId);
+
+    Long findLastPushedMessageId(Long roomId);
+
+    void markPushed(Long roomId, Long messageId);
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/domain/TopicRoomUser.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/domain/TopicRoomUser.java
@@ -37,10 +37,22 @@ public class TopicRoomUser extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private TopicRoomRole role;
 
+    @Column(name = "last_read_message_id")
+    private Long lastReadMessageId;
+
+    @Column(name = "notification_enabled", nullable = false, columnDefinition = "tinyint(1) not null default 1")
+    private boolean notificationEnabled;
+
     @Builder
     public TopicRoomUser(TopicRoom topicRoom, Long userId, TopicRoomRole role) {
         this.topicRoom = topicRoom;
         this.userId = userId;
         this.role = role;
+        this.notificationEnabled = true;
+    }
+
+    /** 비즈니스 메서드 */
+    public void changeNotification(boolean enabled) {
+        this.notificationEnabled = enabled;
     }
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/PendingChatPush.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/PendingChatPush.java
@@ -1,0 +1,9 @@
+package com.storix.domain.domains.topicroom.dto;
+
+public record PendingChatPush(
+        Long lastMessageId,
+        Long lastSenderId,
+        String lastSenderNickname,
+        String lastMessage
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/RoomLastMessageId.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/RoomLastMessageId.java
@@ -1,0 +1,4 @@
+package com.storix.domain.domains.topicroom.dto;
+
+public record RoomLastMessageId(Long roomId, Long messageId) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/RoomUnreadCount.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/RoomUnreadCount.java
@@ -1,0 +1,4 @@
+package com.storix.domain.domains.topicroom.dto;
+
+public record RoomUnreadCount(Long roomId, Long unreadCount) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/TopicRoomChatPushTarget.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/TopicRoomChatPushTarget.java
@@ -1,0 +1,11 @@
+package com.storix.domain.domains.topicroom.dto;
+
+import java.util.List;
+
+public record TopicRoomChatPushTarget(
+        Long userId,
+        List<String> tokens,
+        int batchMessageCount,
+        int badgeCount
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/TopicRoomResponseDto.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/TopicRoomResponseDto.java
@@ -22,6 +22,8 @@ public class TopicRoomResponseDto {
     private Integer activeUserNumber;
     private String lastChatTime;
     private Boolean isJoined;
+    private Integer unreadCount;
+    private Boolean notificationEnabled;
 
     public TopicRoomResponseDto(Long topicRoomId, String topicRoomName, WorksType worksType, String worksName,
                                 String thumbnailUrl, Integer activeUserNumber, LocalDateTime lastChatTime, boolean isJoined) {
@@ -33,6 +35,7 @@ public class TopicRoomResponseDto {
         this.activeUserNumber = activeUserNumber;
         this.lastChatTime = formatTimeAgo(lastChatTime); // 시간 포맷팅 로직 적용
         this.isJoined = isJoined;
+        this.unreadCount = 0;
     }
 
     public static TopicRoomResponseDto from(TopicRoom room, TopicRoomWorksInfo worksInfo, boolean isJoined) {
@@ -45,11 +48,17 @@ public class TopicRoomResponseDto {
                 .activeUserNumber(room.getActiveUserNumber())
                 .lastChatTime(formatTimeAgo(room.getLastChatTime()))
                 .isJoined(isJoined)
+                .unreadCount(0)
                 .build();
     }
 
     public void markAsJoined(boolean status) {
         this.isJoined = status;
+    }
+
+    public void applyJoinedRoomState(int unreadCount, boolean notificationEnabled) {
+        this.unreadCount = unreadCount;
+        this.notificationEnabled = notificationEnabled;
     }
 
     private static String formatTimeAgo(LocalDateTime time) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/UserUnreadCount.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/dto/UserUnreadCount.java
@@ -1,0 +1,4 @@
+package com.storix.domain.domains.topicroom.dto;
+
+public record UserUnreadCount(Long userId, Long unreadCount) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/event/TopicRoomChatPushEvent.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/event/TopicRoomChatPushEvent.java
@@ -1,0 +1,10 @@
+package com.storix.domain.domains.topicroom.event;
+
+public record TopicRoomChatPushEvent(
+        Long roomId,
+        Long messageId,
+        Long senderId,
+        String senderNickname,
+        String message
+) {
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomRepository.java
@@ -56,7 +56,8 @@ public interface TopicRoomRepository extends JpaRepository<TopicRoom, Long>, Top
             t.lastMessageType = :messageType,
             t.lastMessageSenderId = :senderId,
             t.lastMessageId = :messageId,
-            t.lastChatTime = :lastChatTime
+            t.lastChatTime = :lastChatTime,
+            t.updatedAt = CURRENT_TIMESTAMP
         WHERE t.id = :roomId
           AND (t.lastMessageId IS NULL OR t.lastMessageId < :messageId)
     """)
@@ -81,4 +82,10 @@ public interface TopicRoomRepository extends JpaRepository<TopicRoom, Long>, Top
 
     @Query("SELECT tr FROM TopicRoom tr WHERE tr.activeUserNumber > 1")
     List<TopicRoom> findAllActiveRooms();
+
+    @Query("SELECT t.topicRoomName FROM TopicRoom t WHERE t.id = :roomId")
+    String findTopicRoomNameById(@Param("roomId") Long roomId);
+
+    @Query("SELECT t.id FROM TopicRoom t WHERE t.lastChatTime > :since")
+    List<Long> findRoomIdsByLastChatTimeAfter(@Param("since") LocalDateTime since);
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomUserRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/repository/TopicRoomUserRepository.java
@@ -49,4 +49,32 @@ public interface TopicRoomUserRepository extends JpaRepository<TopicRoomUser, Lo
     List<RoomMember> findMembersByRoomIds(@Param("roomIds") List<Long> roomIds);
 
     Optional<TopicRoomUser> findByUserIdAndTopicRoomId(Long userId, Long topicRoomId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE TopicRoomUser tu SET tu.lastReadMessageId = :messageId, tu.updatedAt = CURRENT_TIMESTAMP "
+            + "WHERE tu.userId = :userId AND tu.topicRoom.id = :roomId "
+            + "AND (tu.lastReadMessageId IS NULL OR tu.lastReadMessageId < :messageId)")
+    int advanceReadCursor(@Param("userId") Long userId,
+                          @Param("roomId") Long roomId,
+                          @Param("messageId") Long messageId);
+
+    @Query("""
+            SELECT tu.userId
+            FROM TopicRoomUser tu
+            JOIN NotificationSetting ns ON ns.userId = tu.userId
+            JOIN User u ON u.id = tu.userId
+            WHERE tu.topicRoom.id = :roomId
+              AND tu.userId <> :senderId
+              AND tu.notificationEnabled = true
+              AND ns.topicRoomChatEnabled = true
+              AND u.accountState = com.storix.domain.domains.user.domain.AccountState.NORMAL
+              AND NOT EXISTS (
+                  SELECT 1 FROM UserBlock b
+                  WHERE b.blockerId = tu.userId AND b.blockedUserId = :senderId
+              )
+            """)
+    List<Long> findChatPushTargetUserIds(
+            @Param("roomId") Long roomId,
+            @Param("senderId") Long senderId
+    );
 }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomChatPushService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomChatPushService.java
@@ -1,0 +1,108 @@
+package com.storix.domain.domains.topicroom.service;
+
+import com.storix.domain.domains.chat.adaptor.ChatAdaptor;
+import com.storix.domain.domains.chat.dto.ChatMessageResponseDto;
+import com.storix.domain.domains.notification.adaptor.NotificationAdaptor;
+import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
+import com.storix.domain.domains.pushdevice.dto.ActivePushToken;
+import com.storix.domain.domains.topicroom.adaptor.TopicRoomAdaptor;
+import com.storix.domain.domains.topicroom.application.port.TopicRoomPresencePort;
+import com.storix.domain.domains.topicroom.dto.RoomLastMessageId;
+import com.storix.domain.domains.topicroom.dto.TopicRoomChatPushTarget;
+import com.storix.domain.domains.topicroom.dto.UserUnreadCount;
+import com.storix.domain.domains.user.adaptor.UserAdaptor;
+import com.storix.domain.domains.user.dto.StandardProfileInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TopicRoomChatPushService {
+
+    private final TopicRoomAdaptor topicRoomAdaptor;
+    private final TopicRoomPresencePort topicRoomPresencePort;
+    private final PushDeviceAdaptor pushDeviceAdaptor;
+    private final NotificationAdaptor notificationAdaptor;
+    private final ChatAdaptor chatAdaptor;
+    private final UserAdaptor userAdaptor;
+
+    @Transactional(readOnly = true)
+    public List<TopicRoomChatPushTarget> resolveTargets(
+            Long roomId, Long senderId, Long afterMessageId, Long upToMessageId) {
+        List<Long> candidates = topicRoomAdaptor.findChatPushTargetUserIds(roomId, senderId);
+        if (candidates.isEmpty()) return List.of();
+
+        Set<Long> online = topicRoomPresencePort.findOnlineUserIds(roomId);
+        List<Long> offline = candidates.stream().filter(id -> !online.contains(id)).toList();
+        if (offline.isEmpty()) return List.of();
+
+        Map<Long, Long> batchCount = toCountMap(afterMessageId == null
+                ? chatAdaptor.countUnreadByRoomForUsers(roomId, offline)
+                : chatAdaptor.countMessagesAfterForUsers(roomId, offline, afterMessageId, upToMessageId));
+        List<Long> receiverIds = offline.stream()
+                .filter(id -> batchCount.getOrDefault(id, 0L) > 0)
+                .toList();
+        if (receiverIds.isEmpty()) return List.of();
+
+        Map<Long, List<String>> tokensByUser = pushDeviceAdaptor.findActiveTokensByUserIds(receiverIds).stream()
+                .collect(Collectors.groupingBy(
+                        ActivePushToken::userId,
+                        Collectors.mapping(ActivePushToken::fcmToken, Collectors.toList())));
+        if (tokensByUser.isEmpty()) return List.of();
+
+        List<Long> reachable = List.copyOf(tokensByUser.keySet());
+        Map<Long, Integer> inboxUnread = notificationAdaptor.countUnreadByUserIds(reachable);
+        Map<Long, Long> topicRoomUnread = toCountMap(chatAdaptor.countTotalUnreadByUserIds(reachable));
+
+        return tokensByUser.entrySet().stream()
+                .map(entry -> new TopicRoomChatPushTarget(
+                        entry.getKey(),
+                        entry.getValue(),
+                        batchCount.getOrDefault(entry.getKey(), 0L).intValue(),
+                        inboxUnread.getOrDefault(entry.getKey(), 0)
+                                + topicRoomUnread.getOrDefault(entry.getKey(), 0L).intValue()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public String findRoomName(Long roomId) {
+        return topicRoomAdaptor.findTopicRoomNameById(roomId);
+    }
+
+    @Transactional(readOnly = true)
+    public Long findLastMessageId(Long roomId) {
+        return chatAdaptor.findLastMessageId(roomId);
+    }
+
+    @Transactional(readOnly = true)
+    public ChatMessageResponseDto findLatestMessage(Long roomId) {
+        return chatAdaptor.findLatestMessage(roomId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> findRecentlyActiveRoomIds(LocalDateTime since) {
+        return topicRoomAdaptor.findRoomIdsByLastChatTimeAfter(since);
+    }
+
+    @Transactional(readOnly = true)
+    public List<RoomLastMessageId> findLastMessageIds(List<Long> roomIds) {
+        return chatAdaptor.findLastMessageIdsByRoomIds(roomIds);
+    }
+
+    @Transactional(readOnly = true)
+    public String findSenderProfileImageUrl(Long senderId) {
+        StandardProfileInfo info = userAdaptor.findStandardProfileInfoByUserIds(List.of(senderId)).get(senderId);
+        return info == null ? null : info.profileImageUrl();
+    }
+
+    private Map<Long, Long> toCountMap(List<UserUnreadCount> counts) {
+        return counts.stream().collect(Collectors.toMap(UserUnreadCount::userId, UserUnreadCount::unreadCount));
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -1,6 +1,5 @@
 package com.storix.domain.domains.topicroom.service;
 
-import com.storix.common.utils.STORIXStatic;
 import com.storix.domain.domains.bannedword.adaptor.BannedWordAdaptor;
 import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
 import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
@@ -105,8 +104,7 @@ public class TopicRoomService implements TopicRoomUseCase {
                     }
                     TopicRoomResponseDto dto = TopicRoomResponseDto.from(room, worksInfo, true);
                     dto.applyJoinedRoomState(
-                            Math.min(unreadMap.getOrDefault(room.getId(), 0),
-                                    STORIXStatic.Notification.TOPIC_ROOM_BADGE_MAX),
+                            unreadMap.getOrDefault(room.getId(), 0),
                             participation.isNotificationEnabled());
                     return dto;
                 })

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomService.java
@@ -1,5 +1,6 @@
 package com.storix.domain.domains.topicroom.service;
 
+import com.storix.common.utils.STORIXStatic;
 import com.storix.domain.domains.bannedword.adaptor.BannedWordAdaptor;
 import com.storix.domain.domains.genrescore.event.GenreScoreEventType;
 import com.storix.domain.domains.genrescore.publisher.GenreScorePublisher;
@@ -15,7 +16,6 @@ import com.storix.domain.domains.search.dto.SearchResponseWrapperDto;
 import com.storix.domain.domains.search.dto.TrendingItem;
 import com.storix.domain.domains.search.service.SearchHistoryService;
 import com.storix.domain.domains.topicroom.adaptor.TopicRoomAdaptor;
-import com.storix.domain.domains.topicroom.application.port.LoadTopicRoomUserPort;
 import com.storix.domain.domains.topicroom.application.port.LoadTopicRoomPort;
 import com.storix.domain.domains.topicroom.application.port.RecordTopicRoomPort;
 import com.storix.domain.domains.topicroom.application.usecase.TopicRoomUseCase;
@@ -74,6 +74,7 @@ public class TopicRoomService implements TopicRoomUseCase {
     private final WorksAdaptor worksAdaptor;
     private final TopicRoomActiveUserNumberPublisher activeUserNumberPublisher;
     private final NotificationPublisher notificationPublisher;
+    private final TopicRoomUnreadService topicRoomUnreadService;
 
     @Override
     public Slice<TopicRoomResponseDto> getMyJoinedRooms(Long userId, Pageable pageable) {
@@ -89,6 +90,11 @@ public class TopicRoomService implements TopicRoomUseCase {
         // works 정보를 한 번에 조회하여 Map으로 변환
         Map<Long, TopicRoomWorksInfo> worksMap = worksAdaptor.loadWorksMapByIds(worksIds);
 
+        List<Long> roomIds = participations.stream()
+                .map(p -> p.getTopicRoom().getId())
+                .toList();
+        Map<Long, Integer> unreadMap = topicRoomUnreadService.getUnreadCounts(userId, roomIds);
+
         List<TopicRoomResponseDto> content = participations.getContent().stream()
                 .map(participation -> {
                     TopicRoom room = participation.getTopicRoom();
@@ -97,7 +103,12 @@ public class TopicRoomService implements TopicRoomUseCase {
                         logMissingWorksInfo(room);
                         return null;
                     }
-                    return TopicRoomResponseDto.from(room, worksInfo, true);
+                    TopicRoomResponseDto dto = TopicRoomResponseDto.from(room, worksInfo, true);
+                    dto.applyJoinedRoomState(
+                            Math.min(unreadMap.getOrDefault(room.getId(), 0),
+                                    STORIXStatic.Notification.TOPIC_ROOM_BADGE_MAX),
+                            participation.isNotificationEnabled());
+                    return dto;
                 })
                 .filter(Objects::nonNull)
                 .toList();

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomUnreadService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomUnreadService.java
@@ -1,0 +1,49 @@
+package com.storix.domain.domains.topicroom.service;
+
+import com.storix.domain.domains.chat.adaptor.ChatAdaptor;
+import com.storix.domain.domains.topicroom.adaptor.TopicRoomAdaptor;
+import com.storix.domain.domains.topicroom.dto.RoomUnreadCount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TopicRoomUnreadService {
+
+    private final ChatAdaptor chatAdaptor;
+    private final TopicRoomAdaptor topicRoomAdaptor;
+
+    @Transactional(readOnly = true)
+    public Map<Long, Integer> getUnreadCounts(Long userId, List<Long> roomIds) {
+        if (roomIds.isEmpty()) {
+            return Map.of();
+        }
+        return chatAdaptor.countUnreadByRoomIds(userId, roomIds).stream()
+                .collect(Collectors.toMap(RoomUnreadCount::roomId, r -> r.unreadCount().intValue()));
+    }
+
+    @Transactional(readOnly = true)
+    public long getTotalUnread(Long userId) {
+        return chatAdaptor.countTotalUnread(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasAnyUnread(Long userId) {
+        return chatAdaptor.existsUnread(userId);
+    }
+
+    @Transactional
+    public void markRoomRead(Long userId, Long roomId) {
+        topicRoomAdaptor.findByUserIdAndRoomId(userId, roomId);
+
+        Long lastMessageId = chatAdaptor.findLastMessageId(roomId);
+        if (lastMessageId == null) return;
+
+        topicRoomAdaptor.advanceReadCursor(userId, roomId, lastMessageId);
+    }
+}

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomUserService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomUserService.java
@@ -1,5 +1,6 @@
 package com.storix.domain.domains.topicroom.service;
 
+import com.storix.domain.domains.topicroom.adaptor.TopicRoomAdaptor;
 import com.storix.domain.domains.topicroom.application.port.LoadTopicRoomPort;
 import com.storix.domain.domains.topicroom.application.port.LoadTopicRoomUserPort;
 import com.storix.domain.domains.topicroom.dto.TopicRoomUserResponseDto;
@@ -22,6 +23,7 @@ public class TopicRoomUserService {
     private final LoadTopicRoomUserPort loadTopicRoomUserPort;
     private final LoadTopicRoomPort loadTopicRoomPort;
     private final UserAdaptor userAdaptor;
+    private final TopicRoomAdaptor topicRoomAdaptor;
 
     // 특정 토픽룸에 참여 중인 멤버들의 프로필 목록 조회
     @Transactional(readOnly = true)
@@ -49,5 +51,16 @@ public class TopicRoomUserService {
                         info.profileImageUrl() // S3 BaseUrl이 적용된 URL
                 ))
                 .toList();
+    }
+
+    // 토픽룸별 채팅 알림 ON/OFF (기본값 ON)
+    @Transactional
+    public void changeNotification(Long userId, Long roomId, boolean enabled) {
+        topicRoomAdaptor.findByUserIdAndRoomId(userId, roomId).changeNotification(enabled);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isNotificationEnabled(Long userId, Long roomId) {
+        return topicRoomAdaptor.findByUserIdAndRoomId(userId, roomId).isNotificationEnabled();
     }
 }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/AsyncConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/AsyncConfig.java
@@ -79,6 +79,16 @@ public class AsyncConfig {
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("ChatAsync-");
         executor.setTaskDecorator(mdcTaskDecorator());
+
+        // 버리면 토픽룸 최신 메시지가 안 바뀌고 푸시 이벤트도 안 나간다
+        executor.setRejectedExecutionHandler((r, exec) -> {
+            recordRejected("chatAsync");
+            log.warn(">>> [Chat] queue overflow - running on caller thread (pool={}, queue={}/{})",
+                    exec.getPoolSize(), exec.getQueue().size(), exec.getQueue().remainingCapacity());
+            if (!exec.isShutdown()) {
+                r.run();
+            }
+        });
         executor.initialize();
         return executor;
     }
@@ -127,6 +137,28 @@ public class AsyncConfig {
         executor.setRejectedExecutionHandler((r, exec) -> {
             recordRejected("notificationConsumer");
             log.warn(">>> [Notification] queue overflow - running on caller thread (pool={}, queue={}/{})",
+                    exec.getPoolSize(), exec.getQueue().size(), exec.getQueue().remainingCapacity());
+            if (!exec.isShutdown()) {
+                r.run();
+            }
+        });
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(name = "topicRoomPushExecutor")
+    public Executor topicRoomPushExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(16);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("TopicRoomPush-");
+        executor.setTaskDecorator(mdcTaskDecorator()); // MDC 전파
+
+        // 버려도 앵커가 안 옮겨져 sweep 이 줍긴 하지만 그만큼 발송이 밀린다
+        executor.setRejectedExecutionHandler((r, exec) -> {
+            recordRejected("topicRoomPush");
+            log.warn(">>> [TopicRoomPush] queue overflow - running on caller thread (pool={}, queue={}/{})",
                     exec.getPoolSize(), exec.getQueue().size(), exec.getQueue().remainingCapacity());
             if (!exec.isShutdown()) {
                 r.run();

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/config/SecurityConfig.java
@@ -134,6 +134,10 @@ public class SecurityConfig {
                                 // [App Event] 이벤트 상세 페이지
                                 .requestMatchers(HttpMethod.GET, "/api/v1/app-events/{appEventId:[0-9]+}").permitAll()
 
+                                // [Notification] 배지 개수 — 비로그인은 0 을 받도록 인가만 열어둔다
+                                // JWT 필터는 그대로 타야 토큰이 있을 때 userId 가 채워진다
+                                .requestMatchers(HttpMethod.GET, "/api/v1/notifications/badge-count").permitAll()
+
                                 // [TopicRoom]
                                 .requestMatchers("/ws-stomp/**").permitAll()
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/StompHandler.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/chat/StompHandler.java
@@ -1,9 +1,11 @@
 package com.storix.infrastructure.external.chat;
 import com.storix.common.utils.RedisKeyStatic;
 
+import com.storix.domain.domains.topicroom.application.port.TopicRoomPresencePort;
 import com.storix.domain.domains.user.adaptor.AuthUserDetails;
 import com.storix.domain.domains.user.domain.Role;
 import com.storix.infrastructure.external.topicroom.RedisTopicRoomActiveUserNumberAdapter;
+import com.storix.infrastructure.external.topicroom.TopicRoomReadMarker;
 import com.storix.infrastructure.external.topicroom.TopicRoomActiveUserNumberRedisSubscriber;
 import com.storix.infrastructure.global.TokenProvider;
 import com.storix.infrastructure.global.dto.AccessTokenInfo;
@@ -12,6 +14,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.messaging.*;
+import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.messaging.simp.stomp.*;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
@@ -31,6 +34,8 @@ public class StompHandler implements ChannelInterceptor {
     private final RedisMessageListenerContainer container;
     private final RedisSubscriber subscriber;
     private final TopicRoomActiveUserNumberRedisSubscriber activeUserNumberSubscriber;
+    private final TopicRoomPresencePort topicRoomPresencePort;
+    private final TopicRoomReadMarker topicRoomReadMarker;
 
     private final Map<String, ChannelTopic> chatTopics = new ConcurrentHashMap<>();
     private final Map<String, AtomicInteger> chatRoomSubscriberCounts = new ConcurrentHashMap<>();
@@ -42,12 +47,16 @@ public class StompHandler implements ChannelInterceptor {
             TokenProvider tp,
             RedisMessageListenerContainer c,
             @Lazy RedisSubscriber s,
-            @Lazy TopicRoomActiveUserNumberRedisSubscriber activeUserNumberSubscriber
+            @Lazy TopicRoomActiveUserNumberRedisSubscriber activeUserNumberSubscriber,
+            TopicRoomPresencePort topicRoomPresencePort,
+            TopicRoomReadMarker topicRoomReadMarker
     ) {
         this.tokenProvider = tp;
         this.container = c;
         this.subscriber = s;
         this.activeUserNumberSubscriber = activeUserNumberSubscriber;
+        this.topicRoomPresencePort = topicRoomPresencePort;
+        this.topicRoomReadMarker = topicRoomReadMarker;
     }
 
     @Override
@@ -75,6 +84,8 @@ public class StompHandler implements ChannelInterceptor {
             handleUnsubscribe(accessor);
         } else if (StompCommand.DISCONNECT.equals(command)) {
             handleDisconnect(accessor);
+        } else if (command == null && SimpMessageType.HEARTBEAT.equals(accessor.getMessageType())) {
+            refreshPresence(accessor.getSessionId());
         }
 
         return message;
@@ -114,13 +125,20 @@ public class StompHandler implements ChannelInterceptor {
 
             if (subId == null) return;
 
+            Long userId = extractUserId(accessor);
+
             // 세션 구독 정보 저장
             sessionSubscriptionMap
                     .computeIfAbsent(sessionId, k -> new ConcurrentHashMap<>())
-                    .put(subId, SubscriptionTarget.chat(roomId));
+                    .put(subId, SubscriptionTarget.chat(roomId, userId));
 
             // 카운트 증가 및 리스너 등록
             increaseChatCounter(roomId);
+
+            // 방을 보고 있는 동안은 채팅 푸시 대상에서 제외
+            markPresence(true, roomId, userId, sessionId);
+
+            markRead(roomId, userId);
         } else if (destination != null
                 && destination.startsWith("/sub/topic-rooms/")
                 && destination.endsWith("/active-users")) {
@@ -146,7 +164,7 @@ public class StompHandler implements ChannelInterceptor {
         if (subscriptions != null && subId != null) {
             SubscriptionTarget target = subscriptions.remove(subId);
             if (target != null) {
-                decreaseCounter(target);
+                decreaseCounter(target, sessionId);
                 log.info(">>>> [STOMP] 구독 해제 완료: Session={}, Type={}, Room={}",
                         sessionId, target.type(), target.roomId());
             }
@@ -160,7 +178,7 @@ public class StompHandler implements ChannelInterceptor {
         if (subscriptions != null) {
             log.info(">>>> [STOMP] 연결 종료 - 전체 구독 정리 시작: Session={}", sessionId);
             for (SubscriptionTarget target : subscriptions.values()) {
-                decreaseCounter(target);
+                decreaseCounter(target, sessionId);
             }
         }
     }
@@ -227,13 +245,57 @@ public class StompHandler implements ChannelInterceptor {
         }
     }
 
-    private void decreaseCounter(SubscriptionTarget target) {
+    private void decreaseCounter(SubscriptionTarget target, String sessionId) {
         if (SubscriptionType.CHAT.equals(target.type())) {
             decreaseChatCounter(target.roomId());
+            markPresence(false, target.roomId(), target.userId(), sessionId);
+
+            markRead(target.roomId(), target.userId());
             return;
         }
 
         decreaseActiveUserNumberCounter(target.roomId());
+    }
+
+    // heartbeat 가 끊기면 접속자에서 자동으로 빠지므로 살아있는 동안 계속 갱신해준다
+    private void refreshPresence(String sessionId) {
+        Map<String, SubscriptionTarget> subscriptions = sessionSubscriptionMap.get(sessionId);
+        if (subscriptions == null) return;
+
+        for (SubscriptionTarget target : subscriptions.values()) {
+            if (SubscriptionType.CHAT.equals(target.type())) {
+                markPresence(true, target.roomId(), target.userId(), sessionId);
+            }
+        }
+    }
+
+    private void markPresence(boolean entered, String roomId, Long userId, String sessionId) {
+        if (userId == null || sessionId == null) return;
+        try {
+            Long parsedRoomId = Long.parseLong(roomId);
+            if (entered) {
+                topicRoomPresencePort.enter(parsedRoomId, userId, sessionId);
+            } else {
+                topicRoomPresencePort.leave(parsedRoomId, userId, sessionId);
+            }
+        } catch (NumberFormatException e) {
+            log.warn(">>>> [STOMP] 잘못된 roomId 형식 roomId={}", roomId);
+        }
+    }
+
+    private void markRead(String roomId, Long userId) {
+        if (userId == null) return;
+        try {
+            topicRoomReadMarker.markRead(userId, Long.parseLong(roomId));
+        } catch (NumberFormatException e) {
+            log.warn(">>>> [STOMP] 잘못된 roomId 형식 roomId={}", roomId);
+        }
+    }
+
+    private Long extractUserId(StompHeaderAccessor accessor) {
+        if (!(accessor.getUser() instanceof Authentication auth)) return null;
+        if (!(auth.getPrincipal() instanceof AuthUserDetails user)) return null;
+        return user.getUserId();
     }
 
     private String extractActiveUserNumberRoomId(String destination) {
@@ -261,13 +323,13 @@ public class StompHandler implements ChannelInterceptor {
         ACTIVE_USERS
     }
 
-    private record SubscriptionTarget(SubscriptionType type, String roomId) {
-        private static SubscriptionTarget chat(String roomId) {
-            return new SubscriptionTarget(SubscriptionType.CHAT, roomId);
+    private record SubscriptionTarget(SubscriptionType type, String roomId, Long userId) {
+        private static SubscriptionTarget chat(String roomId, Long userId) {
+            return new SubscriptionTarget(SubscriptionType.CHAT, roomId, userId);
         }
 
         private static SubscriptionTarget activeUsers(String roomId) {
-            return new SubscriptionTarget(SubscriptionType.ACTIVE_USERS, roomId);
+            return new SubscriptionTarget(SubscriptionType.ACTIVE_USERS, roomId, null);
         }
     }
 }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dto/PushMessage.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dto/PushMessage.java
@@ -1,0 +1,9 @@
+package com.storix.infrastructure.external.notification.dto;
+
+import java.util.Map;
+
+public record PushMessage(
+        String token,
+        Map<String, String> data
+) {
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/fcm/FcmPushExecutor.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/fcm/FcmPushExecutor.java
@@ -2,23 +2,34 @@ package com.storix.infrastructure.external.notification.fcm;
 
 import com.storix.domain.domains.pushdevice.service.PushDispatchService;
 import com.storix.infrastructure.external.notification.dto.MulticastResult;
+import com.storix.infrastructure.external.notification.dto.PushMessage;
+import com.storix.infrastructure.external.notification.exception.FcmTransientException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class FcmPushExecutor {
 
+    private static final int MAX_SEND_ATTEMPTS = 3;
+    private static final long BASE_BACKOFF_MS = 500L;
+    private static final int MAX_BATCH_SIZE = 500;
+
     private final FcmSender fcmSender;
     private final PushDispatchService pushDispatchService;
 
     public MulticastResult sendAndApply(List<String> tokens, Map<String, String> data) {
-        MulticastResult result = fcmSender.sendMulticast(tokens, data);
+        return sendAndApply(tokens, data, null);
+    }
+
+    public MulticastResult sendAndApply(List<String> tokens, Map<String, String> data, String collapseKey) {
+        MulticastResult result = fcmSender.sendMulticast(tokens, data, collapseKey);
         if (!result.invalidTokens().isEmpty()) {
             pushDispatchService.deactivateTokens(result.invalidTokens());
         }
@@ -26,5 +37,66 @@ public class FcmPushExecutor {
             pushDispatchService.markTokensSuccess(result.successTokens());
         }
         return result;
+    }
+
+    public MulticastResult sendEachAndApply(List<PushMessage> messages, String collapseKey) {
+        MulticastResult result = fcmSender.sendEach(messages, collapseKey);
+        if (!result.invalidTokens().isEmpty()) {
+            pushDispatchService.deactivateTokens(result.invalidTokens());
+        }
+        if (!result.successTokens().isEmpty()) {
+            pushDispatchService.markTokensSuccess(result.successTokens());
+        }
+        return result;
+    }
+
+    public void sendEachWithRetry(List<PushMessage> messages, String collapseKey, String logContext) {
+        if (messages == null || messages.isEmpty()) return;
+
+        for (int from = 0; from < messages.size(); from += MAX_BATCH_SIZE) {
+            List<PushMessage> chunk = messages.subList(from, Math.min(from + MAX_BATCH_SIZE, messages.size()));
+            retrying(() -> sendEachAndApply(chunk, collapseKey), logContext);
+        }
+    }
+
+    // 일시 오류만 백오프 재시도
+    public void sendWithRetry(List<String> tokens, Map<String, String> data, String collapseKey, String logContext) {
+        retrying(() -> sendAndApply(tokens, data, collapseKey), logContext);
+    }
+
+    private void retrying(Supplier<MulticastResult> send, String logContext) {
+        FcmTransientException lastTransient = null;
+
+        for (int attempt = 1; attempt <= MAX_SEND_ATTEMPTS; attempt++) {
+            try {
+                MulticastResult result = send.get();
+                if (result.hasTransientFailure()) {
+                    log.warn(">>> [Fcm] 일부 토큰 일시오류 - 재시도 생략(중복발송 방지) {}, failure={}",
+                            logContext, result.failureCount());
+                }
+                return;
+            } catch (FcmTransientException e) {
+                lastTransient = e;
+                if (attempt < MAX_SEND_ATTEMPTS) {
+                    log.warn(">>> [Fcm] 일시오류 재시도 {}/{} {}, code={}",
+                            attempt, MAX_SEND_ATTEMPTS, logContext, e.getMessagingErrorCode());
+                    sleep(BASE_BACKOFF_MS << (attempt - 1)); // 0.5s, 1s
+                }
+            } catch (Exception e) {
+                log.error(">>> [Fcm] 영구 실패(재시도 안 함) {}, cause={}", logContext, e.getMessage());
+                return;
+            }
+        }
+
+        log.error(">>> [Fcm] 일시오류 최종 실패 - 재시도 {}회 소진 {}, code={}",
+                MAX_SEND_ATTEMPTS, logContext, lastTransient.getMessagingErrorCode());
+    }
+
+    private void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/fcm/FcmSender.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/fcm/FcmSender.java
@@ -4,6 +4,7 @@ import com.google.firebase.messaging.AndroidConfig;
 import com.google.firebase.messaging.AndroidNotification;
 import com.google.firebase.messaging.ApnsConfig;
 import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.ApsAlert;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
@@ -12,6 +13,7 @@ import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
 import com.storix.infrastructure.external.notification.dto.MulticastResult;
+import com.storix.infrastructure.external.notification.dto.PushMessage;
 import com.storix.infrastructure.external.notification.dto.SingleSendResult;
 import com.storix.infrastructure.external.notification.dto.TokenClassification;
 import com.storix.infrastructure.external.notification.exception.FcmSendFailedException;
@@ -42,34 +44,26 @@ public class FcmSender {
 
     // 단일 토큰 푸시 발송
     public SingleSendResult sendToToken(String token, Map<String, String> data) {
-        // 1. 화면 표시용 notification + 라우팅용 data 메시지 빌드
-        Message.Builder builder = Message.builder()
-                .setToken(token)
-                .setNotification(displayNotification(data))
-                .setAndroidConfig(highPriorityAndroid())
-                .setApnsConfig(apnsConfig(data));
-        putData(builder::putData, data);
-
         try {
-            // 2. 전송 성공
-            String messageId = firebaseMessaging.send(builder.build());
+            // 1. 전송 성공
+            String messageId = firebaseMessaging.send(buildMessage(token, data, null));
             log.debug(">>>> [FCM] send 성공. messageId={}, token={}", messageId, fcmErrorClassifier.maskToken(token));
             return SingleSendResult.success(messageId);
         } catch (FirebaseMessagingException e) {
             MessagingErrorCode code = e.getMessagingErrorCode();
             recordFailureMetric(code);
-            // 3. 삭제 대상 토큰(UNREGISTERED/INVALID_ARGUMENT) -> caller 가 deactivate 처리하도록 invalid 반환
+            // 2. 삭제 대상 토큰(UNREGISTERED/INVALID_ARGUMENT) -> caller 가 deactivate 처리하도록 invalid 반환
             if (fcmErrorClassifier.isDeletableToken(code)) {
                 log.warn(">>>> [FCM] deletable token. token={}, errorCode={}", fcmErrorClassifier.maskToken(token), code);
                 return SingleSendResult.invalid(token);
             }
-            // 4. 일시 오류(UNAVAILABLE/INTERNAL/QUOTA_EXCEEDED) -> 재시도 대상 (multicast 와 분류 일치)
+            // 3. 일시 오류(UNAVAILABLE/INTERNAL/QUOTA_EXCEEDED) -> 재시도 대상 (multicast 와 분류 일치)
             if (fcmErrorClassifier.isRetryableToken(code)) {
                 log.warn(">>>> [FCM] send 일시 실패(재시도 대상). token={}, errorCode={}, msg={}",
                         fcmErrorClassifier.maskToken(token), code, e.getMessage());
                 throw new FcmTransientException(code, e);
             }
-            // 5. 영구·설정 오류 -> 재시도 무의미
+            // 4. 영구·설정 오류 -> 재시도 무의미
             log.error(">>>> [FCM] send 영구 실패. token={}, errorCode={}, msg={}",
                     fcmErrorClassifier.maskToken(token), code, e.getMessage());
             throw FcmSendFailedException.EXCEPTION;
@@ -78,6 +72,11 @@ public class FcmSender {
 
     // 멀티캐스트 발송 (한 유저의 여러 디바이스 동시 발송)
     public MulticastResult sendMulticast(List<String> tokens, Map<String, String> data) {
+        return sendMulticast(tokens, data, null);
+    }
+
+    // collapseKey 를 주면 같은 키의 이전 알림을 덮어써 트레이에 하나만 남는다
+    public MulticastResult sendMulticast(List<String> tokens, Map<String, String> data, String collapseKey) {
         // 1. 빈 토큰 short-circuit
         if (tokens == null || tokens.isEmpty()) {
             return MulticastResult.empty();
@@ -87,8 +86,8 @@ public class FcmSender {
         MulticastMessage.Builder builder = MulticastMessage.builder()
                 .addAllTokens(tokens)
                 .setNotification(displayNotification(data))
-                .setAndroidConfig(highPriorityAndroid())
-                .setApnsConfig(apnsConfig(data));
+                .setAndroidConfig(highPriorityAndroid(collapseKey, data))
+                .setApnsConfig(apnsConfig(data, collapseKey));
         putData(builder::putData, data);
 
         try {
@@ -121,6 +120,58 @@ public class FcmSender {
         }
     }
 
+    // 수신자마다 payload 가 다를 때. SDK 가 한 배치를 병렬로 던진다
+    public MulticastResult sendEach(List<PushMessage> messages, String collapseKey) {
+        if (messages == null || messages.isEmpty()) {
+            return MulticastResult.empty();
+        }
+
+        // 1. 응답이 입력 순서와 1:1 이라 토큰 목록을 같은 순서로 들고 간다
+        List<String> tokens = messages.stream().map(PushMessage::token).toList();
+        List<Message> payloads = messages.stream()
+                .map(m -> buildMessage(m.token(), m.data(), collapseKey))
+                .toList();
+
+        try {
+            // 2. 발송 + 응답을 invalid / success 로 분류
+            BatchResponse response = firebaseMessaging.sendEach(payloads);
+            TokenClassification classified = fcmErrorClassifier.classifyTokens(tokens, response);
+            classified.failureCodes().forEach(this::recordFailureMetric);
+            log.info(">>>> [FCM] sendEach 결과 success={}, failure={}, invalid={}, transient={}, codes={}",
+                    response.getSuccessCount(), response.getFailureCount(),
+                    classified.invalidTokens().size(), classified.hasTransientFailure(), classified.failureCodes());
+            return new MulticastResult(
+                    response.getSuccessCount(),
+                    response.getFailureCount(),
+                    classified.invalidTokens(),
+                    classified.successTokens(),
+                    classified.hasTransientFailure()
+            );
+        } catch (FirebaseMessagingException e) {
+            // 3. batch 자체 실패 -> 에러코드로 일시/영구 분류
+            MessagingErrorCode code = e.getMessagingErrorCode();
+            recordFailureMetric(code);
+            if (fcmErrorClassifier.isRetryableToken(code)) {
+                log.warn(">>>> [FCM] sendEach 일시 실패(재시도 대상). messageCount={}, errorCode={}, msg={}",
+                        messages.size(), code, e.getMessage());
+                throw new FcmTransientException(code, e);
+            }
+            log.error(">>>> [FCM] sendEach 영구 실패. messageCount={}, errorCode={}, msg={}",
+                    messages.size(), code, e.getMessage());
+            throw FcmSendFailedException.EXCEPTION;
+        }
+    }
+
+    private Message buildMessage(String token, Map<String, String> data, String collapseKey) {
+        Message.Builder builder = Message.builder()
+                .setToken(token)
+                .setNotification(displayNotification(data))
+                .setAndroidConfig(highPriorityAndroid(collapseKey, data))
+                .setApnsConfig(apnsConfig(data, collapseKey));
+        putData(builder::putData, data);
+        return builder.build();
+    }
+
     // 실패 코드별 카운터 누적 (code=null 은 UNSPECIFIED 로 표기)
     private void recordFailureMetric(MessagingErrorCode code) {
         meterRegistry.counter(METRIC_FAILURE, TAG_CODE, code != null ? code.name() : "UNSPECIFIED").increment();
@@ -142,29 +193,64 @@ public class FcmSender {
     }
 
     // Android HIGH 전송 우선순위 + 알림 표시 우선순위 MAX(헤드업 유도) + 기본 사운드
-    private AndroidConfig highPriorityAndroid() {
-        return AndroidConfig.builder()
+    private AndroidConfig highPriorityAndroid(String collapseKey, Map<String, String> data) {
+        AndroidNotification.Builder notification = AndroidNotification.builder()
+                .setChannelId(STORIXStatic.Notification.ANDROID_CHANNEL_ID)
+                .setDefaultSound(true)
+                .setPriority(AndroidNotification.Priority.MAX);
+
+        // 런처 배지 숫자 — 지원하는 런처에서만 표시된다
+        Integer badge = parseBadge(data);
+        if (badge != null) {
+            notification.setNotificationCount(badge);
+        }
+
+        AndroidConfig.Builder builder = AndroidConfig.builder()
                 .setPriority(AndroidConfig.Priority.HIGH)
-                .setNotification(AndroidNotification.builder()
-                        .setChannelId(STORIXStatic.Notification.ANDROID_CHANNEL_ID)
-                        .setDefaultSound(true)
-                        .setPriority(AndroidNotification.Priority.MAX)
-                        .build())
-                .build();
+                .setNotification(notification.build());
+        if (collapseKey != null) {
+            builder.setCollapseKey(collapseKey);
+        }
+        return builder.build();
     }
 
     // iOS APNs 고우선순위 즉시 표시(alert) + 기본 사운드 + 뱃지(미읽음 총합)
     private ApnsConfig apnsConfig(Map<String, String> data) {
+        return apnsConfig(data, null);
+    }
+
+    private ApnsConfig apnsConfig(Map<String, String> data, String collapseKey) {
         Aps.Builder aps = Aps.builder().setSound("default");
         Integer badge = parseBadge(data);
         if (badge != null) {
             aps.setBadge(badge);
         }
-        return ApnsConfig.builder()
+        // subtitle 이 있으면 제목 2줄 + 본문. Android 는 subtitle 자리가 없어 2줄까지만 된다
+        String subtitle = data != null ? data.get("subtitle") : null;
+        if (subtitle != null) {
+            aps.setAlert(ApsAlert.builder()
+                    .setTitle(data.get("title"))
+                    .setSubtitle(subtitle)
+                    .setBody(data.get("body"))
+                    .build());
+        }
+        // 앱의 Notification Service Extension 이 알림을 가로채 꾸미려면 필요
+        if (data != null && Boolean.parseBoolean(data.get("mutableContent"))) {
+            aps.setMutableContent(true);
+        }
+        // 알림센터에서 같은 스레드끼리 묶어서 쌓임
+        String threadId = data != null ? data.get("threadId") : null;
+        if (threadId != null) {
+            aps.setThreadId(threadId);
+        }
+        ApnsConfig.Builder builder = ApnsConfig.builder()
                 .putHeader("apns-priority", "10")
                 .putHeader("apns-push-type", "alert")
-                .setAps(aps.build())
-                .build();
+                .setAps(aps.build());
+        if (collapseKey != null) {
+            builder.putHeader("apns-collapse-id", collapseKey);
+        }
+        return builder.build();
     }
 
     // data.unreadCount -> iOS 뱃지 숫자 (없거나 파싱 실패 시 뱃지 미설정)

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/listener/NotificationEventListener.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/listener/NotificationEventListener.java
@@ -3,8 +3,6 @@ package com.storix.infrastructure.external.notification.listener;
 import com.storix.domain.domains.notification.dto.DispatchResult;
 import com.storix.domain.domains.notification.event.NotificationEvent;
 import com.storix.domain.domains.notification.service.NotificationDispatchService;
-import com.storix.infrastructure.external.notification.dto.MulticastResult;
-import com.storix.infrastructure.external.notification.exception.FcmTransientException;
 import com.storix.infrastructure.external.notification.fcm.FcmPushExecutor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,9 +19,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class NotificationEventListener {
 
-    private static final int MAX_SEND_ATTEMPTS = 3;
-    private static final long BASE_BACKOFF_MS = 500L;
-
     private final FcmPushExecutor fcmPushExecutor;
     private final NotificationDispatchService notificationDispatchService;
 
@@ -38,47 +33,13 @@ public class NotificationEventListener {
             if (!result.shouldSendPush()) return;
 
             // 3. FCM 멀티캐스트 발송 + 토큰 후처리 (일시오류 시 최대 3회 백오프 재시도)
-            sendWithRetry(event, result);
+            fcmPushExecutor.sendWithRetry(
+                    result.tokens(),
+                    buildData(event, result.notificationId(), result.unreadCount()),
+                    null,
+                    "notificationId=" + result.notificationId());
         } catch (Exception e) {
             log.error(">>> [Notification] dispatch failed event={}, cause={}", event, e.getMessage(), e);
-        }
-    }
-
-    // 일시 오류 재시도
-    private void sendWithRetry(NotificationEvent event, DispatchResult result) {
-        Map<String, String> data = buildData(event, result.notificationId(), result.unreadCount());
-        FcmTransientException lastTransient = null;
-        for (int attempt = 1; attempt <= MAX_SEND_ATTEMPTS; attempt++) {
-            try {
-                MulticastResult mc = fcmPushExecutor.sendAndApply(result.tokens(), data);
-                if (mc.hasTransientFailure()) {
-                    log.warn(">>> [Notification] 일부 토큰 일시오류 - 재시도 생략(중복발송 방지) notificationId={}, failure={}",
-                            result.notificationId(), mc.failureCount());
-                }
-                return;
-            } catch (FcmTransientException e) {
-                lastTransient = e;
-                if (attempt < MAX_SEND_ATTEMPTS) {
-                    log.warn(">>> [Notification] FCM 일시오류 재시도 {}/{} notificationId={}, code={}",
-                            attempt, MAX_SEND_ATTEMPTS, result.notificationId(), e.getMessagingErrorCode());
-                    sleep(BASE_BACKOFF_MS << (attempt - 1)); // 0.5s, 1s
-                }
-            } catch (Exception e) {
-                log.error(">>> [Notification] FCM 영구 실패(재시도 안 함) notificationId={}, cause={}",
-                        result.notificationId(), e.getMessage());
-                return;
-            }
-        }
-
-        log.error(">>> [Notification] FCM 일시오류 최종 실패 - 재시도 {}회 소진 notificationId={}, code={}",
-                MAX_SEND_ATTEMPTS, result.notificationId(), lastTransient.getMessagingErrorCode());
-    }
-
-    private void sleep(long ms) {
-        try {
-            Thread.sleep(ms);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
         }
     }
 

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/RedisTopicRoomPresenceAdapter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/RedisTopicRoomPresenceAdapter.java
@@ -1,0 +1,93 @@
+package com.storix.infrastructure.external.topicroom;
+
+import com.storix.common.utils.RedisKeyStatic;
+import com.storix.domain.domains.topicroom.application.port.TopicRoomPresencePort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class RedisTopicRoomPresenceAdapter implements TopicRoomPresencePort {
+
+    // STOMP heartbeat 가 10초라 여러 번 놓쳐도 견디도록 잡은 값
+    private static final Duration STALE_AFTER = Duration.ofSeconds(60);
+    private static final Duration TTL = Duration.ofHours(12);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RedisTopicRoomPresenceAdapter(
+            @Qualifier("redisTemplate") RedisTemplate<String, Object> redisTemplate
+    ) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void enter(Long roomId, Long userId, String sessionId) {
+        try {
+            String key = key(roomId);
+            redisTemplate.opsForZSet().add(key, member(userId, sessionId), System.currentTimeMillis());
+            redisTemplate.expire(key, TTL);
+        } catch (Exception e) {
+            log.warn(">>>> [TopicRoomPresence] 접속 기록 실패 roomId={}, userId={}, cause={}", roomId, userId, e.getMessage());
+        }
+    }
+
+    @Override
+    public void leave(Long roomId, Long userId, String sessionId) {
+        try {
+            redisTemplate.opsForZSet().remove(key(roomId), member(userId, sessionId));
+        } catch (Exception e) {
+            log.warn(">>>> [TopicRoomPresence] 접속 해제 실패 roomId={}, userId={}, cause={}", roomId, userId, e.getMessage());
+        }
+    }
+
+    // 인스턴스가 죽으면 DISCONNECT 를 못 받으므로 갱신이 끊긴 멤버는 접속자에서 제외
+    @Override
+    public Set<Long> findOnlineUserIds(Long roomId) {
+        try {
+            String key = key(roomId);
+            long threshold = System.currentTimeMillis() - STALE_AFTER.toMillis();
+            redisTemplate.opsForZSet().removeRangeByScore(key, 0, threshold);
+
+            Set<Object> members = redisTemplate.opsForZSet().rangeByScore(key, threshold, Double.MAX_VALUE);
+            if (members == null || members.isEmpty()) {
+                return Collections.emptySet();
+            }
+            return members.stream()
+                    .map(String::valueOf)
+                    .map(this::parseUserId)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
+        } catch (Exception e) {
+            // 조회 실패 시 아무도 접속 안 한 것으로 간주해 푸시를 보내는 쪽으로
+            log.warn(">>>> [TopicRoomPresence] 접속자 조회 실패 roomId={}, cause={}", roomId, e.getMessage());
+            return Collections.emptySet();
+        }
+    }
+
+    private Long parseUserId(String member) {
+        int separator = member.indexOf(':');
+        if (separator <= 0) return null;
+        try {
+            return Long.parseLong(member.substring(0, separator));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private String key(Long roomId) {
+        return RedisKeyStatic.TopicRoom.ONLINE_PREFIX + roomId;
+    }
+
+    private String member(Long userId, String sessionId) {
+        return userId + ":" + sessionId;
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/RedisTopicRoomPushBatchAdapter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/RedisTopicRoomPushBatchAdapter.java
@@ -6,9 +6,12 @@ import com.storix.domain.domains.topicroom.dto.PendingChatPush;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,6 +29,13 @@ public class RedisTopicRoomPushBatchAdapter implements TopicRoomPushBatchPort {
     private static final String FIELD_SENDER_ID = "senderId";
     private static final String FIELD_NICKNAME = "nickname";
     private static final String FIELD_MESSAGE = "message";
+
+    private static final RedisScript<List> DRAIN_SCRIPT = new DefaultRedisScript<>("""
+            local pending = redis.call('HGETALL', KEYS[1])
+            redis.call('DEL', KEYS[1])
+            redis.call('ZREM', KEYS[2], ARGV[1])
+            return pending
+            """, List.class);
 
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -98,19 +108,24 @@ public class RedisTopicRoomPushBatchAdapter implements TopicRoomPushBatchPort {
     @Override
     public PendingChatPush drain(Long roomId) {
         try {
-            String pendingKey = pendingKey(roomId);
-            Map<Object, Object> pending = redisTemplate.opsForHash().entries(pendingKey);
-            redisTemplate.delete(pendingKey);
-            redisTemplate.opsForZSet().remove(RedisKeyStatic.TopicRoom.PUSH_QUEUE, String.valueOf(roomId));
+            List<?> flat = redisTemplate.execute(
+                    DRAIN_SCRIPT,
+                    List.of(pendingKey(roomId), RedisKeyStatic.TopicRoom.PUSH_QUEUE),
+                    String.valueOf(roomId));
 
-            if (pending.isEmpty()) {
+            if (flat == null || flat.isEmpty()) {
                 return null;
             }
+
+            Map<String, String> pending = new HashMap<>();
+            for (int i = 0; i + 1 < flat.size(); i += 2) {
+                pending.put(String.valueOf(flat.get(i)), String.valueOf(flat.get(i + 1)));
+            }
             return new PendingChatPush(
-                    Long.valueOf(String.valueOf(pending.get(FIELD_MESSAGE_ID))),
-                    Long.valueOf(String.valueOf(pending.get(FIELD_SENDER_ID))),
-                    String.valueOf(pending.get(FIELD_NICKNAME)),
-                    String.valueOf(pending.get(FIELD_MESSAGE)));
+                    Long.valueOf(pending.get(FIELD_MESSAGE_ID)),
+                    Long.valueOf(pending.get(FIELD_SENDER_ID)),
+                    pending.get(FIELD_NICKNAME),
+                    pending.get(FIELD_MESSAGE));
         } catch (Exception e) {
             log.warn(">>>> [TopicRoomPush] 누적분 조회 실패 roomId={}, cause={}", roomId, e.getMessage());
             return null;

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/RedisTopicRoomPushBatchAdapter.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/RedisTopicRoomPushBatchAdapter.java
@@ -1,0 +1,157 @@
+package com.storix.infrastructure.external.topicroom;
+
+import com.storix.common.utils.RedisKeyStatic;
+import com.storix.domain.domains.topicroom.application.port.TopicRoomPushBatchPort;
+import com.storix.domain.domains.topicroom.dto.PendingChatPush;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+public class RedisTopicRoomPushBatchAdapter implements TopicRoomPushBatchPort {
+
+    private static final Duration SEND_INTERVAL = Duration.ofSeconds(30);
+    private static final Duration PENDING_TTL = Duration.ofMinutes(5);
+    private static final Duration ANCHOR_TTL = Duration.ofHours(1);
+
+    private static final String FIELD_MESSAGE_ID = "messageId";
+    private static final String FIELD_SENDER_ID = "senderId";
+    private static final String FIELD_NICKNAME = "nickname";
+    private static final String FIELD_MESSAGE = "message";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RedisTopicRoomPushBatchAdapter(
+            @Qualifier("redisTemplate") RedisTemplate<String, Object> redisTemplate
+    ) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // SETNX + TTL 이라 서버가 여러 대여도 한 곳만 발송을 가져간다
+    @Override
+    public boolean tryAcquireSendSlot(Long roomId) {
+        try {
+            return Boolean.TRUE.equals(
+                    redisTemplate.opsForValue().setIfAbsent(gateKey(roomId), "1", SEND_INTERVAL));
+        } catch (Exception e) {
+            // Redis 장애 시 묶음을 포기하고 발송을 허용
+            log.warn(">>>> [TopicRoomPush] 게이트 선점 실패 roomId={}, cause={}", roomId, e.getMessage());
+            return true;
+        }
+    }
+
+    @Override
+    public void accumulate(Long roomId, Long messageId, Long senderId, String senderNickname, String message) {
+        try {
+            String pendingKey = pendingKey(roomId);
+            redisTemplate.opsForHash().putAll(pendingKey, Map.of(
+                    FIELD_MESSAGE_ID, String.valueOf(messageId),
+                    FIELD_SENDER_ID, String.valueOf(senderId),
+                    FIELD_NICKNAME, senderNickname,
+                    FIELD_MESSAGE, message));
+            redisTemplate.expire(pendingKey, PENDING_TTL);
+
+            // 이미 예약돼 있으면 앞선 예약 시각을 유지
+            redisTemplate.opsForZSet().addIfAbsent(
+                    RedisKeyStatic.TopicRoom.PUSH_QUEUE,
+                    String.valueOf(roomId),
+                    dueAt(roomId));
+        } catch (Exception e) {
+            log.warn(">>>> [TopicRoomPush] 누적 실패 roomId={}, cause={}", roomId, e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean enqueue(Long roomId) {
+        try {
+            return Boolean.TRUE.equals(redisTemplate.opsForZSet().addIfAbsent(
+                    RedisKeyStatic.TopicRoom.PUSH_QUEUE, String.valueOf(roomId), dueAt(roomId)));
+        } catch (Exception e) {
+            log.warn(">>>> [TopicRoomPush] 대기열 등록 실패 roomId={}, cause={}", roomId, e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public List<Long> pollDueRoomIds(int limit) {
+        try {
+            Set<Object> due = redisTemplate.opsForZSet().rangeByScore(
+                    RedisKeyStatic.TopicRoom.PUSH_QUEUE, 0, System.currentTimeMillis(), 0, limit);
+            if (due == null || due.isEmpty()) {
+                return List.of();
+            }
+            return due.stream().map(String::valueOf).map(Long::valueOf).toList();
+        } catch (Exception e) {
+            log.warn(">>>> [TopicRoomPush] 대기열 조회 실패 cause={}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    @Override
+    public PendingChatPush drain(Long roomId) {
+        try {
+            String pendingKey = pendingKey(roomId);
+            Map<Object, Object> pending = redisTemplate.opsForHash().entries(pendingKey);
+            redisTemplate.delete(pendingKey);
+            redisTemplate.opsForZSet().remove(RedisKeyStatic.TopicRoom.PUSH_QUEUE, String.valueOf(roomId));
+
+            if (pending.isEmpty()) {
+                return null;
+            }
+            return new PendingChatPush(
+                    Long.valueOf(String.valueOf(pending.get(FIELD_MESSAGE_ID))),
+                    Long.valueOf(String.valueOf(pending.get(FIELD_SENDER_ID))),
+                    String.valueOf(pending.get(FIELD_NICKNAME)),
+                    String.valueOf(pending.get(FIELD_MESSAGE)));
+        } catch (Exception e) {
+            log.warn(">>>> [TopicRoomPush] 누적분 조회 실패 roomId={}, cause={}", roomId, e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public Long findLastPushedMessageId(Long roomId) {
+        try {
+            Object anchor = redisTemplate.opsForValue().get(anchorKey(roomId));
+            return anchor == null ? null : Long.valueOf(String.valueOf(anchor));
+        } catch (Exception e) {
+            log.warn(">>>> [TopicRoomPush] 앵커 조회 실패 roomId={}, cause={}", roomId, e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public void markPushed(Long roomId, Long messageId) {
+        try {
+            redisTemplate.opsForValue().set(anchorKey(roomId), String.valueOf(messageId), ANCHOR_TTL);
+        } catch (Exception e) {
+            log.warn(">>>> [TopicRoomPush] 앵커 갱신 실패 roomId={}, cause={}", roomId, e.getMessage());
+        }
+    }
+
+    private long dueAt(Long roomId) {
+        Long remaining = redisTemplate.getExpire(gateKey(roomId), TimeUnit.MILLISECONDS);
+        long wait = (remaining == null || remaining < 0) ? 0 : remaining;
+        return System.currentTimeMillis() + wait;
+    }
+
+    private String gateKey(Long roomId) {
+        return RedisKeyStatic.TopicRoom.PUSH_GATE_PREFIX + roomId;
+    }
+
+    private String pendingKey(Long roomId) {
+        return RedisKeyStatic.TopicRoom.PUSH_PENDING_PREFIX + roomId;
+    }
+
+    private String anchorKey(Long roomId) {
+        return RedisKeyStatic.TopicRoom.PUSH_ANCHOR_PREFIX + roomId;
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomChatPushListener.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomChatPushListener.java
@@ -1,0 +1,43 @@
+package com.storix.infrastructure.external.topicroom;
+
+import com.storix.domain.domains.topicroom.application.port.TopicRoomPushBatchPort;
+import com.storix.domain.domains.topicroom.event.TopicRoomChatPushEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TopicRoomChatPushListener {
+
+    private final TopicRoomPushBatchPort topicRoomPushBatchPort;
+    private final TopicRoomChatPushSender topicRoomChatPushSender;
+
+    @Async("notificationConsumerExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onEvent(TopicRoomChatPushEvent event) {
+        try {
+            if (topicRoomPushBatchPort.tryAcquireSendSlot(event.roomId())) {
+                Long anchor = topicRoomPushBatchPort.findLastPushedMessageId(event.roomId());
+                log.info(">>>> [TopicRoomPush] 게이트 선점, 즉시 발송 roomId={}, messageId={}, anchor={}",
+                        event.roomId(), event.messageId(), anchor);
+                topicRoomChatPushSender.send(
+                        event.roomId(), anchor, event.messageId(),
+                        event.senderId(), event.senderNickname(), event.message());
+                topicRoomPushBatchPort.markPushed(event.roomId(), event.messageId());
+                return;
+            }
+            log.debug(">>>> [TopicRoomPush] 게이트 대기, 묶음 누적 roomId={}, messageId={}",
+                    event.roomId(), event.messageId());
+            topicRoomPushBatchPort.accumulate(
+                    event.roomId(), event.messageId(), event.senderId(), event.senderNickname(), event.message());
+        } catch (Exception e) {
+            log.error(">>>> [TopicRoomPush] 처리 실패 roomId={}, senderId={}, cause={}",
+                    event.roomId(), event.senderId(), e.getMessage(), e);
+        }
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomChatPushSender.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomChatPushSender.java
@@ -96,8 +96,10 @@ public class TopicRoomChatPushSender {
     private String preview(String text) {
         if (text == null) return "";
         int max = STORIXStatic.Notification.CONTENT_PREVIEW_MAX;
-        return text.length() > max
-                ? text.substring(0, max) + STORIXStatic.Notification.CONTENT_PREVIEW_SUFFIX
-                : text;
+        if (text.codePointCount(0, text.length()) <= max) return text;
+
+        // 이모지 검증
+        return text.substring(0, text.offsetByCodePoints(0, max))
+                + STORIXStatic.Notification.CONTENT_PREVIEW_SUFFIX;
     }
 }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomChatPushSender.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomChatPushSender.java
@@ -1,0 +1,103 @@
+package com.storix.infrastructure.external.topicroom;
+
+import com.storix.domain.domains.topicroom.dto.TopicRoomChatPushTarget;
+import com.storix.domain.domains.topicroom.service.TopicRoomChatPushService;
+import com.storix.common.utils.STORIXStatic;
+import com.storix.domain.domains.notification.domain.NotificationCategory;
+import com.storix.domain.domains.notification.domain.TargetType;
+import com.storix.infrastructure.external.notification.dto.PushMessage;
+import com.storix.infrastructure.external.notification.fcm.FcmPushExecutor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TopicRoomChatPushSender {
+
+    private static final String PUSH_TYPE = "TOPIC_ROOM_CHAT";
+    private static final String THREAD_ID_PREFIX = "topic-room-";
+
+    private final TopicRoomChatPushService topicRoomChatPushService;
+    private final FcmPushExecutor fcmPushExecutor;
+
+    public void send(Long roomId, Long afterMessageId, Long upToMessageId,
+                     Long senderId, String senderNickname, String lastMessage) {
+        List<TopicRoomChatPushTarget> targets =
+                topicRoomChatPushService.resolveTargets(roomId, senderId, afterMessageId, upToMessageId);
+        if (targets.isEmpty()) {
+            log.debug(">>>> [TopicRoomPush] 발송 대상 없음 roomId={}", roomId);
+            return;
+        }
+
+        String roomName = topicRoomChatPushService.findRoomName(roomId);
+        if (roomName == null) {
+            log.warn(">>>> [TopicRoomPush] 방 정보 없음 roomId={}", roomId);
+            return;
+        }
+
+        String senderProfileImageUrl = topicRoomChatPushService.findSenderProfileImageUrl(senderId);
+
+        int maxBatchCount = targets.stream()
+                .mapToInt(TopicRoomChatPushTarget::batchMessageCount)
+                .max()
+                .orElse(0);
+        log.info(">>>> [TopicRoomPush] 발송 시작 roomId={}, targets={}, maxBatchCount={}",
+                roomId, targets.size(), maxBatchCount);
+
+        // 뱃지와 묶음 개수가 유저마다 달라 payload 는 유저 단위로 만들되, 발송은 한 배치로 묶는다
+        List<PushMessage> messages = new ArrayList<>();
+        for (TopicRoomChatPushTarget target : targets) {
+            Map<String, String> data =
+                    buildData(roomId, roomName, senderNickname, senderProfileImageUrl, lastMessage, target);
+            target.tokens().forEach(token -> messages.add(new PushMessage(token, data)));
+        }
+
+        // collapse 하지 않는다 — 최초 개별 알림과 묶음 알림이 각각 남아야 함
+        fcmPushExecutor.sendEachWithRetry(messages, null, "roomId=" + roomId + ", tokens=" + messages.size());
+    }
+
+    private Map<String, String> buildData(Long roomId,
+                                          String roomName,
+                                          String senderNickname,
+                                          String senderProfileImageUrl,
+                                          String lastMessage,
+                                          TopicRoomChatPushTarget target) {
+        int messageCount = target.batchMessageCount();
+        boolean single = messageCount <= 1;
+
+        Map<String, String> data = new HashMap<>();
+        data.put("type", PUSH_TYPE);
+        data.put("category", NotificationCategory.TOPIC_ROOM.name());
+        data.put("targetType", TargetType.TOPIC_ROOM.name());
+        data.put("targetId", String.valueOf(roomId));
+        data.put("roomName", roomName);
+        data.put("senderNickname", senderNickname);
+        data.put("senderProfileImageUrl", senderProfileImageUrl);
+        data.put("messageCount", String.valueOf(messageCount));
+        data.put("unreadCount", String.valueOf(target.badgeCount()));
+        data.put("title", single ? senderNickname : "새 메시지 " + messageCount + "건");
+        data.put("subtitle", roomName);
+        data.put("body", preview(lastMessage));
+
+        // 앱이 알림을 직접 꾸미도록 열어두고, 알림센터에서는 방 단위로 쌓이게
+        data.put("mutableContent", "true");
+        data.put("threadId", THREAD_ID_PREFIX + roomId);
+        return data;
+    }
+
+    // 본문 미리보기 — 10자 초과 시 잘라서 '…' 부가
+    private String preview(String text) {
+        if (text == null) return "";
+        int max = STORIXStatic.Notification.CONTENT_PREVIEW_MAX;
+        return text.length() > max
+                ? text.substring(0, max) + STORIXStatic.Notification.CONTENT_PREVIEW_SUFFIX
+                : text;
+    }
+}

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomReadMarker.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomReadMarker.java
@@ -18,7 +18,7 @@ public class TopicRoomReadMarker {
         try {
             topicRoomUnreadService.markRoomRead(userId, roomId);
         } catch (Exception e) {
-            log.debug(">>>> [TopicRoomRead] 읽음 처리 건너뜀 userId={}, roomId={}, cause={}",
+            log.warn(">>>> [TopicRoomRead] 읽음 처리 실패 userId={}, roomId={}, cause={}",
                     userId, roomId, e.getMessage());
         }
     }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomReadMarker.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomReadMarker.java
@@ -1,0 +1,25 @@
+package com.storix.infrastructure.external.topicroom;
+
+import com.storix.domain.domains.topicroom.service.TopicRoomUnreadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TopicRoomReadMarker {
+
+    private final TopicRoomUnreadService topicRoomUnreadService;
+
+    @Async("chatAsyncExecutor")
+    public void markRead(Long userId, Long roomId) {
+        try {
+            topicRoomUnreadService.markRoomRead(userId, roomId);
+        } catch (Exception e) {
+            log.debug(">>>> [TopicRoomRead] 읽음 처리 건너뜀 userId={}, roomId={}, cause={}",
+                    userId, roomId, e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] 토픽룸 채팅 푸시 — 3단계 게이트, 30초 묶음 발송, 접속자 제외
> - [x] 방별 미읽음 개수 · Red Dot · 앱 아이콘 배지
> - [x] 토픽룸별 알림 설정 조회·변경, 읽음 처리
> - [x] FCM 발송을 `sendEach` 한 배치로 전환
> - [x] 배치 스케줄러 · 비동기 풀 설정

### 알림함과 분리
토픽룸 채팅 푸시는 `notification` 테이블에 적재하지 않습니다. 기획 요구사항이라 `NotificationDispatchService` 파이프라인을 타지 않고 전용 이벤트·리스너로 처리합니다. 미읽음은 `chat_message` + 읽음 커서로 계산합니다.

### 3단계 게이트
푸시는 **기기 OS 권한 > 콘텐츠·커뮤니티 알림 설정 > 토픽룸별 알림 설정** 이 모두 ON일 때만 나갑니다. 어느 단계가 막든 미읽음 뱃지와 Red Dot 은 정상적으로 쌓입니다.

방을 보고 있는 사용자, 발신자 본인, 발신자를 차단한 사용자는 제외됩니다. 차단은 미읽음 집계에서도 빠집니다.

### 30초 묶음
첫 메시지는 즉시 개별 포맷으로 나가고, 30초 안에 쌓인 나머지는 `새 메시지 n건` 으로 묶여 한 번 더 나갑니다. Redis 게이트(SETNX+TTL)로 서버가 여러 대여도 한 곳만 발송합니다. 이벤트나 누적분이 유실되면 DB 의 마지막 메시지 ID 와 Redis 앵커를 1분마다 대조해 복구합니다.

### 저장 위치
방별 알림 설정과 읽음 커서는 별도 테이블 없이 `topic_room_user` 컬럼으로 넣었습니다. 방을 나가면 참여 행과 함께 사라져 재입장 시 기본값 ON 이 되고, 푸시 대상 조회가 조인 없이 끝납니다.

### 커밋 분리
`sendEach` 전환은 관리자 알림 경로도 함께 쓰는 공용 FCM 인프라라 되돌리기 쉽도록 커밋을 나눴습니다.

## 📸 작업 화면 (스크린샷)
로컬에서 iOS 2대 · Android 1대로 검증했습니다.

```
룰루 / 알림 테스트방 / 테스트 1          ← 즉시, 개별 포맷
새 메시지 4건 / 알림 테스트방 / 테스트 5   ← 30초 뒤, 묶음 포맷
```

즉시 발송 · 30초 게이트 · 묶음 flush · 방 보는 중 제외 · 이탈 시 읽음 처리 · 알림 OFF · 차단 · 창 도중 진입/이탈 · 배지 API 를 확인했습니다.

## 💬 리뷰 요구사항(선택)
- 읽음 커서는 `@Async` 로 갱신돼 동시 실행될 수 있어, 조건을 `WHERE` 로 내려 원자적으로 처리했습니다 (`advanceReadCursor`).
- 푸시 payload 의 라우팅 키를 `HOT_TOPIC_ROOM` 과 동일하게 맞춰(`targetType` / `targetId`) FE 수정 없이 기존 분기를 타도록 했습니다.

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호
- #204

## 🖇️ 기타

### 배포 시 정비 순서

**1. 배포 후 스키마 확인**

```sql
SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT
FROM information_schema.COLUMNS
WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'topic_room_user'
  AND COLUMN_NAME IN ('last_read_message_id','notification_enabled');

SHOW INDEX FROM chat_message WHERE Key_name = 'idx_room_id_sender';
```

`notification_enabled` 는 `not null default 1` 이라 기존 행이 자동으로 ON 이 됩니다. 백필이 필요한 건 `last_read_message_id` 뿐입니다.

**2. 고아 토픽룸 확인 — 백필보다 먼저**

```sql
SELECT tr.topic_room_id, tr.topic_room_name, tr.works_id
FROM topic_room tr
LEFT JOIN works w ON w.works_id = tr.works_id
WHERE w.works_id IS NULL;
```

`topic_room.works_id` 에 FK 가 없어 작품이 사라지면 방이 남습니다. 이런 방은 목록 응답에서 제외되는데 미읽음 집계에는 포함돼, **Red Dot 은 켜져 있는데 목록은 비는** 상태가 됩니다. 나오면 정리하고 넘어가는 게 좋습니다.

**3. 읽음 커서 백필**

```sql
UPDATE topic_room_user tu
SET tu.last_read_message_id = (
    SELECT MAX(cm.id) FROM chat_message cm WHERE cm.room_id = tu.topic_room_id
)
WHERE tu.last_read_message_id IS NULL;
```

기존 참여자를 전부 읽음 상태로 만듭니다. 하지 않으면 오래전 참여한 방의 누적 대화가 통째로 미읽음으로 잡혀 배포 직후 뱃지가 크게 뜹니다.

**4. 콘텐츠·커뮤니티 알림 그룹 백필**

```sql
SELECT COUNT(*) FROM notification_settings
WHERE topic_room_chat_enabled <> today_feed_enabled;

UPDATE notification_settings
SET topic_room_chat_enabled = today_feed_enabled;
```

새로 추가한 `notification_settings.topic_room_chat_enabled` 는 독립 토글이 아니라 `today_feed_enabled` · `hot_topic_room_enabled` 와 묶여 **콘텐츠·커뮤니티 알림 한 토글**로 움직입니다 (`UpdateNotificationSettingRequest.toCommand`). 그런데 ALTER 로 추가되는 컬럼은 그룹의 기존 상태를 알 방법이 없어 기존 행이 전부 같은 값으로 깔립니다. 그래서 백필이 필요합니다.

빠뜨리면 이렇게 어긋납니다. 조회 응답은 세 값의 AND 라 화면에는 OFF 로 보이는데, 푸시 조건은 `ns.topicRoomChatEnabled = true` 만 봅니다.

- 기존 행이 0 으로 깔린 경우 → 그룹을 켜둔 유저인데 채팅 푸시가 안 나감
- 기존 행이 1 로 깔린 경우 → 그룹을 꺼둔 유저인데 채팅 푸시가 나감 (설정 화면은 OFF 표시)

어느 쪽이든 유저가 토글을 다시 만지기 전까지 계속됩니다. 위 UPDATE 는 멱등이라 여러 번 돌려도 안전합니다.

컬럼 선언은 형제 플래그들과 동일하게 `@Column(nullable = false)` 만 둡니다. `columnDefinition` 의 default 는 "신규 행 기본값"이 아니라 사실상 **기존 행 백필 지시**로 동작하는데(신규 행 값은 `defaultFor()` 가 정합니다), 그룹에 속한 플래그는 그 값이 유저마다 달라 DDL 로 표현할 수 없습니다. 그룹 플래그를 새로 추가할 때는 DDL default 대신 이 UPDATE 로 그룹의 기존 값을 따라가게 하세요.

### 후속으로 남긴 것
- **Android 3줄 표시** — `AndroidNotification` 에 subtitle 이 없어 현재 2줄입니다. 3줄과 원형 프로필을 그리려면 앱이 `MessagingStyle` 로 직접 그려야 하고, 그러려면 서버가 data-only 로 보내야 합니다. **FE 렌더링이 먼저 배포된 뒤** 서버를 전환해야 하며, 순서가 바뀌면 Android 알림이 뜨지 않습니다.
- **iOS 원형 프로필** — Communication Notification 스타일은 NSE 가 필요합니다. 서버는 `mutable-content`, `senderProfileImageUrl`, `senderNickname`, `roomName` 을 이미 보내고 있어 앱 작업만 남았습니다. prod 프로필 이미지 162개 중 5개가 1MB 를 넘고 최대 3.2MB 라, NSE 메모리 한도를 감안해 다운샘플링이 필요합니다.
- **관리자 알림 `sendEach` 이관** — 수신자별 발송 결과를 장부에 남기는 구조라 응답 인덱스를 유저로 되돌리는 매핑이 필요해 이번에는 제외했습니다.

