### PR TITLE
Chore: [토픽룸] 채팅 알림 후속 작업

### DIFF
--- a/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
+++ b/STORIX-Common/src/main/java/com/storix/common/utils/STORIXStatic.java
@@ -135,8 +135,10 @@ public class STORIXStatic {
         // 본문 템플릿 — 마케팅/광고 (운영자 입력 + 고정 suffix '(수신거부 : 설정)')
         public static final String TPL_MARKETING = "%s (수신거부 : 설정)";
 
-        // 댓글·채팅 본문 미리보기 — 10자 노출 후 ...
+        // 댓글 본문 미리보기 — 10자 노출 후 ...
         public static final int CONTENT_PREVIEW_MAX = 10;
+        // 채팅 본문 미리보기 — 공백 포함 30자 노출 후 ...
+        public static final int CHAT_PREVIEW_MAX = 30;
         public static final String CONTENT_PREVIEW_SUFFIX = "...";
 
     }

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/adaptor/ChatAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/adaptor/ChatAdaptor.java
@@ -104,13 +104,6 @@ public class ChatAdaptor {
                 .orElse(null);
     }
 
-    public List<UserUnreadCount> countUnreadByRoomForUsers(Long roomId, List<Long> userIds) {
-        if (userIds.isEmpty()) {
-            return List.of();
-        }
-        return chatRepository.countUnreadByRoomForUsers(roomId, userIds, MessageType.TALK);
-    }
-
     public List<UserUnreadCount> countMessagesAfterForUsers(
             Long roomId, List<Long> userIds, Long afterMessageId, Long upToMessageId) {
         if (userIds.isEmpty()) {

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/repository/ChatRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/chat/repository/ChatRepository.java
@@ -230,29 +230,6 @@ public interface ChatRepository extends JpaRepository<ChatMessage, Long> {
             JOIN TopicRoomUser tu ON tu.topicRoom.id = m.roomId
             WHERE m.roomId = :roomId
               AND tu.userId IN :userIds
-              AND m.deleted = false
-              AND m.messageType = :messageType
-              AND m.senderId <> tu.userId
-              AND NOT EXISTS (
-                  SELECT 1 FROM UserBlock b
-                  WHERE b.blockerId = tu.userId AND b.blockedUserId = m.senderId
-              )
-              AND ((tu.lastReadMessageId IS NOT NULL AND m.id > tu.lastReadMessageId)
-                OR (tu.lastReadMessageId IS NULL AND m.createdAt > tu.createdAt))
-            GROUP BY tu.userId
-            """)
-    List<UserUnreadCount> countUnreadByRoomForUsers(
-            @Param("roomId") Long roomId,
-            @Param("userIds") List<Long> userIds,
-            @Param("messageType") MessageType messageType
-    );
-
-    @Query("""
-            SELECT new com.storix.domain.domains.topicroom.dto.UserUnreadCount(tu.userId, COUNT(m.id))
-            FROM ChatMessage m
-            JOIN TopicRoomUser tu ON tu.topicRoom.id = m.roomId
-            WHERE m.roomId = :roomId
-              AND tu.userId IN :userIds
               AND m.id > :afterMessageId
               AND m.id <= :upToMessageId
               AND m.deleted = false

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationSetting.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/domain/NotificationSetting.java
@@ -42,7 +42,7 @@ public class NotificationSetting extends BaseTimeEntity {
     private boolean hotTopicRoomEnabled;
 
     // 알림함에 적재되지 않아 NotificationType 없이 단독 판정
-    @Column(name = "topic_room_chat_enabled", nullable = false, columnDefinition = "tinyint(1) not null default 1")
+    @Column(name = "topic_room_chat_enabled", nullable = false)
     private boolean topicRoomChatEnabled;
 
     // 마케팅/광고 수신 여부

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomChatPushService.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/topicroom/service/TopicRoomChatPushService.java
@@ -43,9 +43,8 @@ public class TopicRoomChatPushService {
         List<Long> offline = candidates.stream().filter(id -> !online.contains(id)).toList();
         if (offline.isEmpty()) return List.of();
 
-        Map<Long, Long> batchCount = toCountMap(afterMessageId == null
-                ? chatAdaptor.countUnreadByRoomForUsers(roomId, offline)
-                : chatAdaptor.countMessagesAfterForUsers(roomId, offline, afterMessageId, upToMessageId));
+        Map<Long, Long> batchCount = toCountMap(chatAdaptor.countMessagesAfterForUsers(
+                roomId, offline, afterMessageId != null ? afterMessageId : upToMessageId - 1, upToMessageId));
         List<Long> receiverIds = offline.stream()
                 .filter(id -> batchCount.getOrDefault(id, 0L) > 0)
                 .toList();

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dto/PushMessage.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dto/PushMessage.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 public record PushMessage(
         String token,
-        Map<String, String> data
+        Map<String, String> data,
+        boolean androidDataOnly
 ) {
 }

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/fcm/FcmSender.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/fcm/FcmSender.java
@@ -46,7 +46,7 @@ public class FcmSender {
     public SingleSendResult sendToToken(String token, Map<String, String> data) {
         try {
             // 1. 전송 성공
-            String messageId = firebaseMessaging.send(buildMessage(token, data, null));
+            String messageId = firebaseMessaging.send(buildMessage(token, data, null, false));
             log.debug(">>>> [FCM] send 성공. messageId={}, token={}", messageId, fcmErrorClassifier.maskToken(token));
             return SingleSendResult.success(messageId);
         } catch (FirebaseMessagingException e) {
@@ -86,7 +86,7 @@ public class FcmSender {
         MulticastMessage.Builder builder = MulticastMessage.builder()
                 .addAllTokens(tokens)
                 .setNotification(displayNotification(data))
-                .setAndroidConfig(highPriorityAndroid(collapseKey, data))
+                .setAndroidConfig(highPriorityAndroid(collapseKey, data, false))
                 .setApnsConfig(apnsConfig(data, collapseKey));
         putData(builder::putData, data);
 
@@ -129,7 +129,7 @@ public class FcmSender {
         // 1. 응답이 입력 순서와 1:1 이라 토큰 목록을 같은 순서로 들고 간다
         List<String> tokens = messages.stream().map(PushMessage::token).toList();
         List<Message> payloads = messages.stream()
-                .map(m -> buildMessage(m.token(), m.data(), collapseKey))
+                .map(m -> buildMessage(m.token(), m.data(), collapseKey, m.androidDataOnly()))
                 .toList();
 
         try {
@@ -162,12 +162,14 @@ public class FcmSender {
         }
     }
 
-    private Message buildMessage(String token, Map<String, String> data, String collapseKey) {
+    private Message buildMessage(String token, Map<String, String> data, String collapseKey, boolean androidDataOnly) {
         Message.Builder builder = Message.builder()
                 .setToken(token)
-                .setNotification(displayNotification(data))
-                .setAndroidConfig(highPriorityAndroid(collapseKey, data))
+                .setAndroidConfig(highPriorityAndroid(collapseKey, data, androidDataOnly))
                 .setApnsConfig(apnsConfig(data, collapseKey));
+        if (!androidDataOnly) {
+            builder.setNotification(displayNotification(data));
+        }
         putData(builder::putData, data);
         return builder.build();
     }
@@ -193,7 +195,16 @@ public class FcmSender {
     }
 
     // Android HIGH 전송 우선순위 + 알림 표시 우선순위 MAX(헤드업 유도) + 기본 사운드
-    private AndroidConfig highPriorityAndroid(String collapseKey, Map<String, String> data) {
+    private AndroidConfig highPriorityAndroid(String collapseKey, Map<String, String> data, boolean dataOnly) {
+        AndroidConfig.Builder builder = AndroidConfig.builder()
+                .setPriority(AndroidConfig.Priority.HIGH);
+        if (collapseKey != null) {
+            builder.setCollapseKey(collapseKey);
+        }
+        if (dataOnly) {
+            return builder.build();
+        }
+
         AndroidNotification.Builder notification = AndroidNotification.builder()
                 .setChannelId(STORIXStatic.Notification.ANDROID_CHANNEL_ID)
                 .setDefaultSound(true)
@@ -205,13 +216,7 @@ public class FcmSender {
             notification.setNotificationCount(badge);
         }
 
-        AndroidConfig.Builder builder = AndroidConfig.builder()
-                .setPriority(AndroidConfig.Priority.HIGH)
-                .setNotification(notification.build());
-        if (collapseKey != null) {
-            builder.setCollapseKey(collapseKey);
-        }
-        return builder.build();
+        return builder.setNotification(notification.build()).build();
     }
 
     // iOS APNs 고우선순위 즉시 표시(alert) + 기본 사운드 + 뱃지(미읽음 총합)
@@ -226,13 +231,15 @@ public class FcmSender {
             aps.setBadge(badge);
         }
         // subtitle 이 있으면 제목 2줄 + 본문. Android 는 subtitle 자리가 없어 2줄까지만 된다
-        String subtitle = data != null ? data.get("subtitle") : null;
-        if (subtitle != null) {
-            aps.setAlert(ApsAlert.builder()
+        if (data != null) {
+            ApsAlert.Builder alert = ApsAlert.builder()
                     .setTitle(data.get("title"))
-                    .setSubtitle(subtitle)
-                    .setBody(data.get("body"))
-                    .build());
+                    .setBody(data.get("body"));
+            String subtitle = data.get("subtitle");
+            if (subtitle != null) {
+                alert.setSubtitle(subtitle);
+            }
+            aps.setAlert(alert.build());
         }
         // 앱의 Notification Service Extension 이 알림을 가로채 꾸미려면 필요
         if (data != null && Boolean.parseBoolean(data.get("mutableContent"))) {

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomChatPushSender.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomChatPushSender.java
@@ -56,7 +56,7 @@ public class TopicRoomChatPushSender {
         for (TopicRoomChatPushTarget target : targets) {
             Map<String, String> data =
                     buildData(roomId, roomName, senderNickname, senderProfileImageUrl, lastMessage, target);
-            target.tokens().forEach(token -> messages.add(new PushMessage(token, data)));
+            target.tokens().forEach(token -> messages.add(new PushMessage(token, data, true)));
         }
 
         // collapse 하지 않는다 — 최초 개별 알림과 묶음 알림이 각각 남아야 함

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomChatPushSender.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/topicroom/TopicRoomChatPushSender.java
@@ -92,10 +92,10 @@ public class TopicRoomChatPushSender {
         return data;
     }
 
-    // 본문 미리보기 — 10자 초과 시 잘라서 '…' 부가
+    // 본문 미리보기 — 30자 초과 시 잘라서 '…' 부가
     private String preview(String text) {
         if (text == null) return "";
-        int max = STORIXStatic.Notification.CONTENT_PREVIEW_MAX;
+        int max = STORIXStatic.Notification.CHAT_PREVIEW_MAX;
         if (text.codePointCount(0, text.length()) <= max) return text;
 
         // 이모지 검증


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] `topic_room_chat_enabled` 컬럼 선언을 형제 플래그와 맞춤 (`columnDefinition` 제거)
> - [x] Android 채팅 알림을 data-only 로 전환
> - [x] 앵커 만료 시 발송 창 대신 방 전체 미읽음을 세던 문제 수정
> - [x] 채팅 알림 본문 미리보기를 공백 포함 30자로 확대

#214 의 1·2번과, 테스트 중 발견한 카운트 문제까지 담았다. 트레이 알림 정책(#214 3번)은 기획 답변 대기라 이 PR 범위 밖이다.

### 컬럼 default 제거
`notification_settings` 의 플래그 9개 중 `topic_room_chat_enabled` 만 `columnDefinition = "tinyint(1) not null default 1"` 이 붙어 있었다.

`ddl-auto=update` 에서 이 default 는 신규 행 기본값이 아니라 **ALTER 시점의 기존 행 백필**로 동작한다(신규 행 값은 `defaultFor()` 가 정한다). 그런데 이 컬럼은 `today_feed_enabled` · `hot_topic_room_enabled` 와 묶여 **콘텐츠·커뮤니티 알림 한 토글**로 움직여서(`UpdateNotificationSettingRequest.toCommand`), 그룹 상태가 유저마다 달라 DDL 로 표현할 수 없다.

그 결과 그룹을 꺼둔 유저도 이 컬럼만 1 로 깔렸다. 조회는 세 값의 AND(`NotificationSettingResponse:16`)라 화면엔 OFF 인데 푸시 조건은 `ns.topicRoomChatEnabled = true` 만 본다(`TopicRoomUserRepository:69`). **설정은 꺼져 있는데 채팅 푸시는 나가는** 상태가 된다. 선언을 형제와 맞추고, 기존 행은 백필로 정리한다(아래 기타 참고).

### Android data-only
FCM 최상위 `notification` 은 플랫폼 공통이라 "iOS 에만" 붙일 수 없다. 붙어 있으면 Android 는 시스템이 알림을 자동 표시해버려 앱이 `MessagingStyle` 로 3줄·원형 프로필을 그릴 수 없다.

그래서 data-only 여부를 배치가 아닌 **메시지 단위 속성**(`PushMessage.androidDataOnly`)으로 두고, 채팅 경로만 `true` 로 보낸다. `FcmSender` 는 관리자·일반 알림도 함께 쓰는 공용이라 배치 단위 플래그로 두면 다른 경로까지 딸려간다.

- `true` 면 공통 `notification` 과 `AndroidNotification`(채널·사운드·배지)을 싣지 않는다
- iOS 표시는 `aps.alert` 가 맡는다. 공통 `notification` 이 빠져도 표시되도록 **alert 를 항상 명시**하도록 바꿨다
- `collapseKey` 와 `AndroidConfig.Priority.HIGH` 는 유지

### 미리보기 길이
채팅 본문 미리보기를 10자에서 30자로 늘렸다. 기존 `CONTENT_PREVIEW_MAX` 는 댓글 알림과 공유하고 있어 채팅용 상수(`CHAT_PREVIEW_MAX`)를 따로 뒀고, 댓글은 10자 그대로다. 자르는 기준은 원래부터 코드포인트라 공백도 한 글자로 세고 이모지는 깨지지 않는다.

### 앵커 카운트
앵커(`topic-room:push:anchor:{roomId}`)는 TTL 이 1시간이라(`RedisTopicRoomPushBatchAdapter:26`) 1시간 넘게 조용한 방에서는 사라진다. 그때 `resolveTargets` 가 발송 창 대신 **방 전체 미읽음**을 세고 있었다.

앵커가 없을 때의 처리가 세 곳에서 제각각이었다. 중복 방지(`Flusher:29`)는 발송을 허용하고, 복구 판정(`FlushScheduler:59`)은 명시적으로 건너뛰는데, 카운트만 다른 값으로 갈아탔다. 앵커가 없으면 이번 발송분만 세도록 맞췄고, 폴백 전용이던 `countUnreadByRoomForUsers` 는 어댑터·JPQL 양쪽에서 제거했다.

## 📸 작업 화면 (스크린샷)
로컬 서버 + iOS 실기기 2대로 확인했다.

```
앵커 만료 + 미읽음 5건  →  유후 / 알림 테스트방 / 앵커 만료 재현 테스트   (개별 포맷)
앵커 있음, 창 내 1건    →  유후 / 알림 테스트방 / 묶음테스트 A          (개별 포맷)
30초 묶음 (69, 72]     →  새 메시지 3건 / 알림 테스트방 / 묶음테스트 D  (묶음 포맷)
```

수정 전이었다면 첫 케이스가 `새 메시지 5건` 으로 떴다. 발송 후 Redis 도 함께 확인했다 — 앵커가 68 → 72 로 전진하고 `push:gate` · `push:pending` · `push:queue` 가 모두 회수돼 잔여 키가 없다.

iOS 는 이번 data-only 변경의 영향을 받지 않는 것도 같이 확인했다.

## 💬 리뷰 요구사항(선택)
- `aps.alert` 를 항상 명시하도록 바꿔서 **채팅이 아닌 일반·관리자 알림의 iOS 경로도** 서버가 직접 alert 를 싣는다. 내용은 `title`/`body` 로 동일하고 FCM 이 하던 변환을 명시로 옮긴 것뿐이지만, 일반 알림 iOS 회귀는 한 번 봐주면 좋겠다.
- 앵커가 없을 때 `upToMessageId - 1` 을 창 시작으로 쓴다. 쿼리 조건이 `m.id > start AND m.id <= upTo` 라 이번에 보내는 1건만 잡힌다. 복구 sweep 에서도 앵커가 없으면 보수적으로 1건이 된다.

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #214

## 🖇️ 기타

### ⚠️ 배포 게이트 — FE Android 렌더링이 먼저다

**FE 의 Android 렌더링이 배포되기 전에 이 변경이 prod 로 나가면 Android 채팅 알림이 아예 뜨지 않는다.** data-only 는 앱이 직접 그리지 않으면 아무것도 표시되지 않는다.

develop 머지와 prod 배포는 별개이니, **릴리스 PR 에 담기 전에 FE Android 배포 여부를 반드시 확인**해야 한다. iOS 는 영향이 없다.

### 배포 시 백필 (필수)

```sql
SELECT COUNT(*) FROM notification_settings
WHERE topic_room_chat_enabled <> today_feed_enabled;

UPDATE notification_settings
SET topic_room_chat_enabled = today_feed_enabled;
```

멱등이라 여러 번 돌려도 안전하다.

- **dev** — 이미 `default 1` 로 ALTER 된 상태라 어긋나 있다. 위 UPDATE 로 정리한다. 컬럼 타입도 형제 컬럼과 다르면 `ALTER TABLE ... MODIFY` 로 맞춘다
- **prod** — `064dd62` 가 main 미포함이라 컬럼이 아직 없다. 이 PR 이후 ALTER 되면서 기존 행이 전부 같은 값으로 깔리니, **릴리스 PR 에 이 UPDATE 를 반드시 포함**해야 한다. Flyway 가 없어 문서에 없으면 누락된다

그룹에 속한 플래그를 새로 추가할 때는 DDL default 가 아니라 그룹의 기존 값으로 백필하는 게 원칙이다. 배경은 #213 본문 기타 4번에 정리해뒀다.
