### PR TITLE
Fix: [관리자 알림] 수신 동의 확인 및 뱃지 기준 정합

### DIFF
--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/NotificationSettingAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/notification/adaptor/NotificationSettingAdaptor.java
@@ -6,6 +6,8 @@ import com.storix.domain.domains.notification.repository.NotificationSettingRepo
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class NotificationSettingAdaptor {
@@ -17,6 +19,12 @@ public class NotificationSettingAdaptor {
     public NotificationSetting getByUserId(Long userId) {
         return notificationSettingRepository.findById(userId)
                 .orElseThrow(() -> UnknownNotificationSettingException.EXCEPTION);
+    }
+
+    // 여러 유저 알림 설정 일괄 조회
+    public List<NotificationSetting> findAllByUserIds(List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) return List.of();
+        return notificationSettingRepository.findAllById(userIds);
     }
 
 

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/adaptor/PushDeviceAdaptor.java
@@ -32,11 +32,6 @@ public class PushDeviceAdaptor {
         return pushDeviceRepository.findActiveFcmTokensByUserId(userId);
     }
 
-    public List<ActivePushToken> findMarketingEnabledActiveTokensByUserIds(List<Long> userIds) {
-        if (userIds == null || userIds.isEmpty()) return List.of();
-        return pushDeviceRepository.findMarketingEnabledActiveTokensByUserIds(userIds);
-    }
-
     public List<ActivePushToken> findActiveTokensByUserIds(List<Long> userIds) {
         if (userIds == null || userIds.isEmpty()) return List.of();
         return pushDeviceRepository.findActiveTokensByUserIds(userIds);

--- a/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
+++ b/STORIX-Domain/src/main/java/com/storix/domain/domains/pushdevice/repository/PushDeviceRepository.java
@@ -23,16 +23,6 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     @Query("""
         SELECT DISTINCT new com.storix.domain.domains.pushdevice.dto.ActivePushToken(d.userId, d.fcmToken)
         FROM PushDevice d
-        JOIN NotificationSetting s ON s.userId = d.userId
-        WHERE d.userId IN :userIds
-          AND d.isActive = true
-          AND s.marketingEnabled = true
-    """)
-    List<ActivePushToken> findMarketingEnabledActiveTokensByUserIds(@Param("userIds") List<Long> userIds);
-
-    @Query("""
-        SELECT DISTINCT new com.storix.domain.domains.pushdevice.dto.ActivePushToken(d.userId, d.fcmToken)
-        FROM PushDevice d
         WHERE d.userId IN :userIds
           AND d.isActive = true
     """)

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dispatcher/AdminNotificationDispatcher.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dispatcher/AdminNotificationDispatcher.java
@@ -9,6 +9,8 @@ import com.storix.domain.domains.notification.service.AdminNotificationDeliveryR
 import com.storix.common.utils.NightWindow;
 import com.storix.common.utils.STORIXStatic;
 import com.storix.domain.domains.notification.adaptor.NotificationAdaptor;
+import com.storix.domain.domains.notification.adaptor.NotificationSettingAdaptor;
+import com.storix.domain.domains.notification.domain.NotificationSetting;
 import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
 import com.storix.domain.domains.pushdevice.dto.ActivePushToken;
 import com.storix.infrastructure.external.notification.dto.MulticastResult;
@@ -37,6 +39,7 @@ public class AdminNotificationDispatcher {
     private final FcmPushExecutor fcmPushExecutor;
     private final AdminNotificationDeliveryResultService deliveryResultService;
     private final NotificationAdaptor notificationAdaptor;
+    private final NotificationSettingAdaptor notificationSettingAdaptor;
 
     // 대상 유저에게 발송하고 결과를 로그에 반영
     public AdminNotificationDispatchCounts dispatch(AdminNotificationChunkEvent event, LocalDateTime now) {
@@ -63,13 +66,14 @@ public class AdminNotificationDispatcher {
                 event.title(), event.content());
         if (notificationIdByUser.isEmpty()) return AdminNotificationDispatchCounts.empty();
 
-        // 2. 발송 대상 활성 토큰 조회
+        // 2. 발송 대상 활성 토큰 조회 — 타입별 수신 동의한 유저만 (인앱 저장은 동의와 무관)
         List<Long> targets = List.copyOf(notificationIdByUser.keySet());
         Map<Long, Integer> unreadByUser = notificationAdaptor.countUnreadByUserIds(targets); // 뱃지용 미읽음 총합
-        List<ActivePushToken> activeTokens = event.isMarketing()
-                ? pushDeviceAdaptor.findMarketingEnabledActiveTokensByUserIds(targets)
-                : pushDeviceAdaptor.findActiveTokensByUserIds(targets);
-        Map<Long, List<String>> tokensByUserId = activeTokens.stream()
+        List<Long> consented = notificationSettingAdaptor.findAllByUserIds(targets).stream()
+                .filter(setting -> setting.acceptsType(notificationType))
+                .map(NotificationSetting::getUserId)
+                .toList();
+        Map<Long, List<String>> tokensByUserId = pushDeviceAdaptor.findActiveTokensByUserIds(consented).stream()
                 .collect(Collectors.groupingBy(
                         ActivePushToken::userId,
                         LinkedHashMap::new,

--- a/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dispatcher/AdminNotificationDispatcher.java
+++ b/STORIX-Infrastructure/src/main/java/com/storix/infrastructure/external/notification/dispatcher/AdminNotificationDispatcher.java
@@ -8,11 +8,13 @@ import com.storix.domain.domains.notification.event.AdminNotificationChunkEvent;
 import com.storix.domain.domains.notification.service.AdminNotificationDeliveryResultService;
 import com.storix.common.utils.NightWindow;
 import com.storix.common.utils.STORIXStatic;
+import com.storix.domain.domains.chat.adaptor.ChatAdaptor;
 import com.storix.domain.domains.notification.adaptor.NotificationAdaptor;
 import com.storix.domain.domains.notification.adaptor.NotificationSettingAdaptor;
 import com.storix.domain.domains.notification.domain.NotificationSetting;
 import com.storix.domain.domains.pushdevice.adaptor.PushDeviceAdaptor;
 import com.storix.domain.domains.pushdevice.dto.ActivePushToken;
+import com.storix.domain.domains.topicroom.dto.UserUnreadCount;
 import com.storix.infrastructure.external.notification.dto.MulticastResult;
 import com.storix.infrastructure.external.notification.exception.FcmTransientException;
 import com.storix.infrastructure.external.notification.fcm.FcmPushExecutor;
@@ -40,6 +42,7 @@ public class AdminNotificationDispatcher {
     private final AdminNotificationDeliveryResultService deliveryResultService;
     private final NotificationAdaptor notificationAdaptor;
     private final NotificationSettingAdaptor notificationSettingAdaptor;
+    private final ChatAdaptor chatAdaptor;
 
     // 대상 유저에게 발송하고 결과를 로그에 반영
     public AdminNotificationDispatchCounts dispatch(AdminNotificationChunkEvent event, LocalDateTime now) {
@@ -68,7 +71,10 @@ public class AdminNotificationDispatcher {
 
         // 2. 발송 대상 활성 토큰 조회 — 타입별 수신 동의한 유저만 (인앱 저장은 동의와 무관)
         List<Long> targets = List.copyOf(notificationIdByUser.keySet());
-        Map<Long, Integer> unreadByUser = notificationAdaptor.countUnreadByUserIds(targets); // 뱃지용 미읽음 총합
+        // 뱃지는 알림함 + 토픽룸 채팅 미읽음 총합 — 다른 발송 경로와 같은 기준
+        Map<Long, Integer> inboxUnread = notificationAdaptor.countUnreadByUserIds(targets);
+        Map<Long, Long> chatUnread = chatAdaptor.countTotalUnreadByUserIds(targets).stream()
+                .collect(Collectors.toMap(UserUnreadCount::userId, UserUnreadCount::unreadCount));
         List<Long> consented = notificationSettingAdaptor.findAllByUserIds(targets).stream()
                 .filter(setting -> setting.acceptsType(notificationType))
                 .map(NotificationSetting::getUserId)
@@ -94,7 +100,8 @@ public class AdminNotificationDispatcher {
                     MulticastResult result = fcmPushExecutor.sendAndApply(
                             tokens, buildData(notificationType, targetType, eventTargetId, targetLink,
                                     event.title(), event.content(), notificationIdByUser.get(userId),
-                                    unreadByUser.getOrDefault(userId, 0)));
+                                    inboxUnread.getOrDefault(userId, 0)
+                                            + chatUnread.getOrDefault(userId, 0L).intValue()));
                     if (!result.successTokens().isEmpty()) {
                         outcomes.put(userId, AdminNotificationDeliveryOutcome.SENT);
                     } else if (result.hasTransientFailure()) {


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
> - [x] 관리자 알림 발송 시 타입별 수신 동의 확인
> - [x] 관리자 알림 뱃지에 토픽룸 미읽음 합산

관리자 브로드캐스트 경로가 다른 발송 경로와 어긋나 있던 두 가지를 맞춘다.

### 수신 동의 확인
`AdminNotificationDispatcher` 가 마케팅만 동의를 확인하고 나머지는 무조건 발송하고 있었다.

`AdminNotificationType` 은 네 가지뿐이고 마케팅을 뺀 셋(`FEATURE_UPDATE` · `TOS_UPDATE` · `PRIVACY_UPDATE`)은 `acceptsType()` 에서 전부 `operationPolicyEnabled` 로 매핑되는데, 관리자 경로는 이 토글을 조회조차 하지 않았다. 같은 `TOS_UPDATE` 라도 일반 경로로 나가면 막히고 관리자 경로로 나가면 무시되는 상태였다.

`acceptsType()` 을 그대로 재사용하도록 바꿨다. `notificationType` 은 원래부터 `event.notificationType().getNotificationType()` 로 꺼내 쓰고 있어서 그대로 넘기면 됐다.

```java
List<Long> consented = notificationSettingAdaptor.findAllByUserIds(targets).stream()
        .filter(setting -> setting.acceptsType(notificationType))
        .map(NotificationSetting::getUserId)
        .toList();
```

`acceptsType(MARKETING)` 이 `marketingEnabled` 라 마케팅도 같은 경로로 처리되고, `isMarketing()` 분기 자체가 사라진다. 그래서 `findMarketingEnabledActiveTokensByUserIds` 가 죽은 코드가 돼 어댑터·JPQL 양쪽에서 제거했다. 타입→토글 매핑이 `acceptsType()` 한 곳에만 남아, 앞으로 타입이 추가돼도 두 경로가 같이 따라간다.

인앱 알림함 적재는 그대로라 **푸시만 막히고 알림함에는 쌓인다.** 동의는 푸시에만 적용된다.

### 뱃지 기준
`notificationAdaptor.countUnreadByUserIds` 로 **알림함 미읽음만** 세고 있었다. 나머지 세 경로는 토픽룸 채팅 미읽음까지 합산한다.

iOS `aps.badge` 는 절대값이라 공지 푸시 한 번에 배지가 토픽룸 미읽음만큼 줄어들고, 공지는 전체 발송이라 전 유저 배지가 동시에 어긋난다. 다음 정상 푸시나 앱의 `/badge-count` 호출 전까지 유지된다.

토픽룸 푸시 경로가 쓰던 `ChatAdaptor.countTotalUnreadByUserIds` 를 같이 조회해 합산한다. 둘 다 청크 단위 group-by 라 쿼리 하나만 늘었다.

이제 네 경로가 같은 기준이다 — 일반 알림 / 토픽룸 채팅 / `/badge-count` API / 관리자 알림.

## 📸 작업 화면 (스크린샷)
로컬 서버 + iOS 실기기 2대로 `FEATURE_UPDATE` 전체 발송을 두 번 돌렸다.

```
1차 — 두 계정 모두 운영·정책 OFF
     룰루  푸시 X, 알림함 O
     유후  푸시 X, 알림함 O

2차 — 유후만 운영·정책 ON
     룰루  푸시 X, 알림함 O,  배지 19
     유후  푸시 O, 알림함 O,  배지 31
```

동의를 끈 유저는 푸시만 걸러지고 알림함에는 그대로 적재된다. 배지도 알림함 + 토픽룸 합산값으로 나간다(룰루 19 = 알림함 10 + 토픽룸 9). 수정 전이었다면 토픽룸 미읽음이 빠진 값이 실렸다.

## 💬 리뷰 요구사항(선택)
- 자바 쪽 필터로 내린 근거는 `NotificationSettingAdaptor.getByUserId` 주석의 *"모든 유저는 회원가입 시 row 가 생성되어 있다"* invariant 다. 기존 마케팅 쿼리의 INNER JOIN 도 같은 전제였다.
- `isMarketing()` 은 야간 마케팅 발송 연기에서 계속 쓰여 남아 있다.

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #216

## 🖇️ 기타
스키마 변경이나 백필은 없다. 배포 순서 제약도 없다.
